### PR TITLE
test: add 67 unit tests for API, offline queue, remote logger, SSE stream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,34 @@ Doc-only changes (CLAUDE.md, docs/) can be committed and pushed directly to main
 **Tests are the spec. If a test fails, fix the app — not the test.**
 
 ```bash
-npm test           # Run unit tests
-npm run build      # Build the plugin
+npm test              # Run all 201 unit tests
+npm test -- --verbose # Verbose output
+npm test -- --coverage # With coverage report
+npm run build         # Build the plugin (production)
 ```
+
+### Test files (201 tests across 7 files)
+
+| File | Tests | What it covers |
+|------|-------|----------------|
+| `tests/sync.test.ts` | ~100 | SyncEngine: shouldIgnore, handleModify/Delete/Rename, pull, SSE events, echo suppression, status tracking, first sync detection, destroy |
+| `tests/diff.test.ts` | ~30 | computeDiff, groupIntoHunks, buildMergedContent (line-by-line diff, hunk context, merge choices) |
+| `tests/search.test.ts` | ~4 | EngramApi.search, SearchModal debounce |
+| `tests/api.test.ts` | 25 | All EngramApi methods (pushNote, getChanges, deleteNote, getRateLimit, getManifest, search), base64 utilities, auth headers, URL encoding, error handling |
+| `tests/offline-queue.test.ts` | 17 | Enqueue/dequeue, deduplication by path, oldest-first ordering, load/clear, debounced persistence, coalesced writes, destroy cancels timers |
+| `tests/remote-log.test.ts` | 15 | Buffer management, flush threshold (20 entries), ring buffer overflow (200 cap), flush-on-disable, singleton lifecycle |
+| `tests/stream.test.ts` | 10 | NoteStream: connect/disconnect state, auth headers, SSE event parsing, idempotent connect, error handling |
+
+### Test configuration
+
+- **Jest config:** `jest.config.js` — ts-jest preset, roots in `src/` and `tests/`
+- **Test tsconfig:** `tsconfig.test.json` — extends main tsconfig with `noImplicitAny: false` (tests use `as any` for mocks)
+- **Obsidian mock:** `tests/__mocks__/obsidian.ts` — minimal mocks for TFile, Plugin, Modal, requestUrl, etc.
+- **Coverage thresholds:** 40% minimum for branches, functions, lines, statements
+
+### Untested files (UI-heavy, minimal testable logic)
+
+`settings.ts`, `conflict-modal.ts`, `first-sync-modal.ts`, `search-modal.ts`, `search-view.ts`, `main.ts`, `dev-log.ts`
 
 ## Build & Install
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,26 @@
 module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "node",
+	globals: {
+		"ts-jest": {
+			tsconfig: "tsconfig.test.json",
+		},
+	},
 	roots: ["<rootDir>/src", "<rootDir>/tests"],
 	testMatch: ["**/*.test.ts"],
 	moduleNameMapper: {
 		"^obsidian$": "<rootDir>/tests/__mocks__/obsidian.ts",
+	},
+	collectCoverageFrom: [
+		"src/**/*.ts",
+		"!src/**/*.d.ts",
+	],
+	coverageThreshold: {
+		global: {
+			branches: 40,
+			functions: 40,
+			lines: 40,
+			statements: 40,
+		},
 	},
 };

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for api.ts — utility functions and EngramApi method behavior.
+ */
+import { EngramApi, arrayBufferToBase64, base64ToArrayBuffer } from "../src/api";
+
+// Replace the obsidian module's requestUrl with a proper jest.fn()
+const mockRequestUrl = jest.fn();
+jest.mock("obsidian", () => ({
+    ...jest.requireActual("obsidian"),
+    requestUrl: (...args: any[]) => mockRequestUrl(...args),
+}));
+
+beforeEach(() => {
+    mockRequestUrl.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// arrayBufferToBase64 / base64ToArrayBuffer
+// ---------------------------------------------------------------------------
+
+describe("arrayBufferToBase64", () => {
+    test("encodes empty buffer", () => {
+        const buf = new ArrayBuffer(0);
+        expect(arrayBufferToBase64(buf)).toBe("");
+    });
+
+    test("encodes simple ASCII", () => {
+        const encoder = new TextEncoder();
+        const buf = encoder.encode("hello").buffer;
+        expect(arrayBufferToBase64(buf)).toBe(btoa("hello"));
+    });
+
+    test("encodes binary data", () => {
+        const bytes = new Uint8Array([0, 128, 255]);
+        const result = arrayBufferToBase64(bytes.buffer);
+        // Decode and verify round-trip
+        const decoded = base64ToArrayBuffer(result);
+        expect(new Uint8Array(decoded)).toEqual(bytes);
+    });
+});
+
+describe("base64ToArrayBuffer", () => {
+    test("decodes empty string", () => {
+        const buf = base64ToArrayBuffer("");
+        expect(buf.byteLength).toBe(0);
+    });
+
+    test("decodes simple ASCII", () => {
+        const buf = base64ToArrayBuffer(btoa("hello"));
+        const text = new TextDecoder().decode(buf);
+        expect(text).toBe("hello");
+    });
+
+    test("round-trips with arrayBufferToBase64", () => {
+        const original = new Uint8Array([1, 2, 3, 100, 200, 255]);
+        const encoded = arrayBufferToBase64(original.buffer);
+        const decoded = new Uint8Array(base64ToArrayBuffer(encoded));
+        expect(decoded).toEqual(original);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// EngramApi
+// ---------------------------------------------------------------------------
+
+describe("EngramApi", () => {
+    let api: EngramApi;
+
+    beforeEach(() => {
+        api = new EngramApi("http://localhost:8000", "engram_testkey");
+    });
+
+    describe("updateConfig", () => {
+        test("strips trailing slashes from URL", () => {
+            api.updateConfig("http://example.com///", "key2");
+            // Verify by making a request and checking the URL
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { status: "ok" } } as any);
+            api.health();
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: "http://example.com/health" }),
+            );
+        });
+    });
+
+    describe("health", () => {
+        test("returns true on 200", async () => {
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: {} } as any);
+            expect(await api.health()).toBe(true);
+        });
+
+        test("returns false on error", async () => {
+            mockRequestUrl.mockRejectedValueOnce(new Error("network"));
+            expect(await api.health()).toBe(false);
+        });
+
+        test("does not send auth header", async () => {
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: {} } as any);
+            await api.health();
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            expect(opts.headers?.Authorization).toBeUndefined();
+        });
+    });
+
+    describe("ping", () => {
+        test("returns ok on success", async () => {
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: [] } as any);
+            const result = await api.ping();
+            expect(result).toEqual({ ok: true });
+        });
+
+        test("returns invalid API key on 401", async () => {
+            mockRequestUrl.mockRejectedValueOnce({ status: 401 });
+            const result = await api.ping();
+            expect(result).toEqual({ ok: false, error: "Invalid API key" });
+        });
+
+        test("returns connection failed on other errors", async () => {
+            mockRequestUrl.mockRejectedValueOnce(new Error("timeout"));
+            const result = await api.ping();
+            expect(result).toEqual({ ok: false, error: "Connection failed" });
+        });
+    });
+
+    describe("pushNote", () => {
+        test("sends POST with path, content, mtime", async () => {
+            mockRequestUrl.mockResolvedValueOnce({
+                status: 200,
+                json: { path: "Notes/Test.md", status: "created" },
+            } as any);
+            const result = await api.pushNote("Notes/Test.md", "# Hello", 1234567890);
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    method: "POST",
+                    url: "http://localhost:8000/notes",
+                    body: JSON.stringify({ path: "Notes/Test.md", content: "# Hello", mtime: 1234567890 }),
+                }),
+            );
+            expect(result).toEqual({ path: "Notes/Test.md", status: "created" });
+        });
+    });
+
+    describe("getChanges", () => {
+        test("URL-encodes the since parameter", async () => {
+            mockRequestUrl.mockResolvedValueOnce({
+                status: 200,
+                json: { changes: [], deleted: [] },
+            } as any);
+            await api.getChanges("2024-01-01T00:00:00+00:00");
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            expect(opts.url).toContain(encodeURIComponent("2024-01-01T00:00:00+00:00"));
+        });
+    });
+
+    describe("deleteNote", () => {
+        test("sends DELETE with encoded path", async () => {
+            mockRequestUrl.mockResolvedValueOnce({
+                status: 200,
+                json: { status: "deleted" },
+            } as any);
+            await api.deleteNote("Notes/My File.md");
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            expect(opts.method).toBe("DELETE");
+            expect(opts.url).toContain(encodeURIComponent("Notes/My File.md"));
+        });
+    });
+
+    describe("getRateLimit", () => {
+        test("returns requests_per_minute value", async () => {
+            mockRequestUrl.mockResolvedValueOnce({
+                status: 200,
+                json: { requests_per_minute: 120 },
+            } as any);
+            expect(await api.getRateLimit()).toBe(120);
+        });
+
+        test("returns 0 on error (assume unlimited)", async () => {
+            mockRequestUrl.mockRejectedValueOnce(new Error("404"));
+            expect(await api.getRateLimit()).toBe(0);
+        });
+    });
+
+    describe("getManifest", () => {
+        test("returns manifest on success", async () => {
+            const manifest = { notes: {}, attachments: {} };
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: manifest } as any);
+            expect(await api.getManifest()).toEqual(manifest);
+        });
+
+        test("returns null on 404", async () => {
+            mockRequestUrl.mockRejectedValueOnce({ status: 404 });
+            expect(await api.getManifest()).toBeNull();
+        });
+
+        test("rethrows non-404 errors", async () => {
+            mockRequestUrl.mockRejectedValueOnce({ status: 500 });
+            await expect(api.getManifest()).rejects.toEqual({ status: 500 });
+        });
+    });
+
+    describe("search", () => {
+        test("sends query only when no optional params", async () => {
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { results: [] } } as any);
+            await api.search("test query");
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            expect(JSON.parse(opts.body)).toEqual({ query: "test query" });
+        });
+
+        test("includes limit and tags when provided", async () => {
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { results: [] } } as any);
+            await api.search("q", 5, ["health", "fitness"]);
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            const body = JSON.parse(opts.body);
+            expect(body.limit).toBe(5);
+            expect(body.tags).toEqual(["health", "fitness"]);
+        });
+
+        test("omits tags when empty array", async () => {
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { results: [] } } as any);
+            await api.search("q", undefined, []);
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            const body = JSON.parse(opts.body);
+            expect(body.tags).toBeUndefined();
+        });
+    });
+
+    describe("authorization header", () => {
+        test("all authenticated requests include Bearer token", async () => {
+            mockRequestUrl.mockResolvedValue({ status: 200, json: {} } as any);
+            await api.pushNote("test.md", "content", 123);
+            const opts = mockRequestUrl.mock.calls[0][0] as any;
+            expect(opts.headers.Authorization).toBe("Bearer engram_testkey");
+        });
+    });
+});

--- a/tests/offline-queue.test.ts
+++ b/tests/offline-queue.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for offline-queue.ts — enqueue, dequeue, deduplication, ordering, persistence.
+ */
+import { OfflineQueue } from "../src/offline-queue";
+import { QueueEntry } from "../src/types";
+
+function makeEntry(path: string, timestamp?: number): QueueEntry {
+    return {
+        path,
+        content: `content of ${path}`,
+        mtime: timestamp || Date.now(),
+        timestamp: timestamp || Date.now(),
+        action: "push" as any,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Basic operations
+// ---------------------------------------------------------------------------
+
+describe("OfflineQueue basics", () => {
+    test("starts empty", () => {
+        const q = new OfflineQueue();
+        expect(q.size).toBe(0);
+        expect(q.all()).toEqual([]);
+    });
+
+    test("enqueue increases size", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("a.md"));
+        expect(q.size).toBe(1);
+    });
+
+    test("dequeue removes entry", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("a.md"));
+        await q.dequeue("a.md");
+        expect(q.size).toBe(0);
+    });
+
+    test("dequeue non-existent path is safe", async () => {
+        const q = new OfflineQueue();
+        await q.dequeue("nonexistent.md");
+        expect(q.size).toBe(0);
+    });
+
+    test("clear removes all entries", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("a.md"));
+        await q.enqueue(makeEntry("b.md"));
+        await q.clear();
+        expect(q.size).toBe(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Deduplication
+// ---------------------------------------------------------------------------
+
+describe("OfflineQueue deduplication", () => {
+    test("newer entry for same path replaces older", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("a.md", 1000));
+        await q.enqueue(makeEntry("a.md", 2000));
+        expect(q.size).toBe(1);
+        expect(q.all()[0].timestamp).toBe(2000);
+    });
+
+    test("different paths are kept separate", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("a.md", 1000));
+        await q.enqueue(makeEntry("b.md", 2000));
+        expect(q.size).toBe(2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Ordering
+// ---------------------------------------------------------------------------
+
+describe("OfflineQueue ordering", () => {
+    test("all() returns entries sorted oldest first", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("c.md", 3000));
+        await q.enqueue(makeEntry("a.md", 1000));
+        await q.enqueue(makeEntry("b.md", 2000));
+        const paths = q.all().map((e) => e.path);
+        expect(paths).toEqual(["a.md", "b.md", "c.md"]);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Load
+// ---------------------------------------------------------------------------
+
+describe("OfflineQueue load", () => {
+    test("load replaces all entries", () => {
+        const q = new OfflineQueue();
+        q.load([makeEntry("a.md", 1000), makeEntry("b.md", 2000)]);
+        expect(q.size).toBe(2);
+    });
+
+    test("load clears previous entries", async () => {
+        const q = new OfflineQueue();
+        await q.enqueue(makeEntry("old.md"));
+        q.load([makeEntry("new.md")]);
+        expect(q.size).toBe(1);
+        expect(q.all()[0].path).toBe("new.md");
+    });
+
+    test("load deduplicates by path", () => {
+        const q = new OfflineQueue();
+        q.load([makeEntry("a.md", 1000), makeEntry("a.md", 2000)]);
+        expect(q.size).toBe(1);
+        expect(q.all()[0].timestamp).toBe(2000);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence callbacks
+// ---------------------------------------------------------------------------
+
+describe("OfflineQueue persistence", () => {
+    test("dequeue triggers immediate persist", async () => {
+        const persistFn = jest.fn().mockResolvedValue(undefined);
+        const q = new OfflineQueue();
+        q.onPersist(persistFn);
+        await q.enqueue(makeEntry("a.md"));
+        await q.dequeue("a.md");
+        expect(persistFn).toHaveBeenCalledWith([]);
+    });
+
+    test("clear triggers immediate persist", async () => {
+        const persistFn = jest.fn().mockResolvedValue(undefined);
+        const q = new OfflineQueue();
+        q.onPersist(persistFn);
+        await q.enqueue(makeEntry("a.md"));
+        await q.clear();
+        expect(persistFn).toHaveBeenCalledWith([]);
+    });
+
+    test("enqueue debounces persist", async () => {
+        jest.useFakeTimers();
+        const persistFn = jest.fn().mockResolvedValue(undefined);
+        const q = new OfflineQueue(500);
+        q.onPersist(persistFn);
+
+        await q.enqueue(makeEntry("a.md"));
+        expect(persistFn).not.toHaveBeenCalled();
+
+        jest.advanceTimersByTime(500);
+        // Allow microtask to resolve
+        await Promise.resolve();
+        expect(persistFn).toHaveBeenCalledTimes(1);
+
+        jest.useRealTimers();
+    });
+
+    test("rapid enqueues coalesce into one persist", async () => {
+        jest.useFakeTimers();
+        const persistFn = jest.fn().mockResolvedValue(undefined);
+        const q = new OfflineQueue(500);
+        q.onPersist(persistFn);
+
+        await q.enqueue(makeEntry("a.md"));
+        await q.enqueue(makeEntry("b.md"));
+        await q.enqueue(makeEntry("c.md"));
+
+        jest.advanceTimersByTime(500);
+        await Promise.resolve();
+        expect(persistFn).toHaveBeenCalledTimes(1);
+        expect(persistFn).toHaveBeenCalledWith(expect.arrayContaining([
+            expect.objectContaining({ path: "a.md" }),
+            expect.objectContaining({ path: "b.md" }),
+            expect.objectContaining({ path: "c.md" }),
+        ]));
+
+        jest.useRealTimers();
+    });
+
+    test("no persist callback is safe", async () => {
+        const q = new OfflineQueue();
+        // Should not throw
+        await q.enqueue(makeEntry("a.md"));
+        await q.dequeue("a.md");
+        await q.clear();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Destroy
+// ---------------------------------------------------------------------------
+
+describe("OfflineQueue destroy", () => {
+    test("destroy cancels pending persist timer", async () => {
+        jest.useFakeTimers();
+        const persistFn = jest.fn().mockResolvedValue(undefined);
+        const q = new OfflineQueue(500);
+        q.onPersist(persistFn);
+
+        await q.enqueue(makeEntry("a.md"));
+        q.destroy();
+
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        expect(persistFn).not.toHaveBeenCalled();
+
+        jest.useRealTimers();
+    });
+});

--- a/tests/remote-log.test.ts
+++ b/tests/remote-log.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests for remote-log.ts — RemoteLogger buffer, flush, threshold, ring buffer.
+ */
+import { RemoteLogger, initRemoteLog, rlog, destroyRemoteLog } from "../src/remote-log";
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Basic logging
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger basics", () => {
+    test("does not buffer when disabled", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        // Not enabled — entries should be dropped
+        logger.error("test", "message");
+        logger.flush();
+        expect(pushFn).not.toHaveBeenCalled();
+    });
+
+    test("buffers entries when enabled", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+        logger.info("sync", "started");
+        logger.flush();
+        expect(pushFn).toHaveBeenCalledTimes(1);
+        const entries = pushFn.mock.calls[0][0];
+        expect(entries).toHaveLength(1);
+        expect(entries[0].level).toBe("info");
+        expect(entries[0].category).toBe("sync");
+        expect(entries[0].message).toBe("started");
+        logger.destroy();
+    });
+
+    test("entries include version and platform", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "2.1.0", "mobile-ios");
+        logger.setEnabled(true);
+        logger.warn("net", "timeout");
+        logger.flush();
+        const entry = pushFn.mock.calls[0][0][0];
+        expect(entry.plugin_version).toBe("2.1.0");
+        expect(entry.platform).toBe("mobile-ios");
+        logger.destroy();
+    });
+
+    test("error entries include stack trace", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+        logger.error("crash", "oops", "Error: oops\n  at foo.ts:1");
+        logger.flush();
+        const entry = pushFn.mock.calls[0][0][0];
+        expect(entry.stack).toBe("Error: oops\n  at foo.ts:1");
+        logger.destroy();
+    });
+
+    test("entries have ISO timestamp", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+        logger.info("test", "msg");
+        logger.flush();
+        const entry = pushFn.mock.calls[0][0][0];
+        expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        logger.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Flush threshold
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger flush threshold", () => {
+    test("auto-flushes at 20 entries", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+
+        for (let i = 0; i < 19; i++) {
+            logger.info("test", `msg ${i}`);
+        }
+        expect(pushFn).not.toHaveBeenCalled();
+
+        logger.info("test", "msg 19"); // 20th entry triggers flush
+        expect(pushFn).toHaveBeenCalledTimes(1);
+        expect(pushFn.mock.calls[0][0]).toHaveLength(20);
+        logger.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Ring buffer overflow
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger ring buffer", () => {
+    test("drops oldest entries when exceeding 200", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+
+        // Add 210 entries — flush triggers at 20, so we'll see multiple flushes
+        // But the ring buffer caps at 200 entries in the buffer at any time
+        // After flush threshold (20), the buffer is drained, so we won't hit 200
+        // To test the ring buffer, we need a pushFn that rejects (entries stay in buffer)
+        const rejectPushFn = jest.fn().mockRejectedValue(new Error("offline"));
+        logger.configure(rejectPushFn, "1.0.0", "desktop");
+
+        // The flush at 20 will fail, putting entries back. Keep adding.
+        // Due to flushing flag, we can't easily test exact count,
+        // but we can verify the buffer doesn't grow unbounded.
+        for (let i = 0; i < 250; i++) {
+            logger.info("test", `msg ${i}`);
+        }
+
+        // Flush whatever is left and verify it's <= 200
+        const finalPush = jest.fn().mockResolvedValue(undefined);
+        logger.configure(finalPush, "1.0.0", "desktop");
+        logger.flush();
+
+        if (finalPush.mock.calls.length > 0) {
+            expect(finalPush.mock.calls[0][0].length).toBeLessThanOrEqual(200);
+        }
+        logger.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Flush on disable
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger enable/disable", () => {
+    test("disabling flushes remaining entries", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+        logger.info("test", "msg");
+        logger.setEnabled(false);
+        expect(pushFn).toHaveBeenCalledTimes(1);
+        logger.destroy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Flush guards
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger flush guards", () => {
+    test("flush is no-op when buffer is empty", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+        logger.flush();
+        expect(pushFn).not.toHaveBeenCalled();
+        logger.destroy();
+    });
+
+    test("flush is no-op without pushFn", () => {
+        const logger = new RemoteLogger();
+        logger.setEnabled(true);
+        // No configure called — should not throw
+        logger.info("test", "msg");
+        logger.flush();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Destroy
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger destroy", () => {
+    test("destroy flushes and clears", () => {
+        const logger = new RemoteLogger();
+        const pushFn = jest.fn().mockResolvedValue(undefined);
+        logger.configure(pushFn, "1.0.0", "desktop");
+        logger.setEnabled(true);
+        logger.info("test", "final");
+        logger.destroy();
+        expect(pushFn).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Module-level singleton
+// ---------------------------------------------------------------------------
+
+describe("remote-log singleton", () => {
+    test("rlog returns noop before init", () => {
+        destroyRemoteLog();
+        const logger = rlog();
+        // Should not throw
+        logger.error("test", "msg");
+        logger.flush();
+    });
+
+    test("initRemoteLog returns a RemoteLogger", () => {
+        const logger = initRemoteLog();
+        expect(logger).toBeInstanceOf(RemoteLogger);
+        destroyRemoteLog();
+    });
+
+    test("rlog returns the instance after init", () => {
+        const logger = initRemoteLog();
+        expect(rlog()).toBe(logger);
+        destroyRemoteLog();
+    });
+
+    test("destroyRemoteLog resets to noop", () => {
+        initRemoteLog();
+        destroyRemoteLog();
+        // Should return noop (not the destroyed instance)
+        const logger = rlog();
+        expect(logger).not.toBeInstanceOf(RemoteLogger);
+    });
+});

--- a/tests/stream.test.ts
+++ b/tests/stream.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for stream.ts — NoteStream connection state, disconnect, config update.
+ */
+import { NoteStream } from "../src/stream";
+
+// Mock global fetch
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Construction and config
+// ---------------------------------------------------------------------------
+
+describe("NoteStream construction", () => {
+    test("starts disconnected", () => {
+        const stream = new NoteStream("http://localhost:8000", "key");
+        expect(stream.isConnected()).toBe(false);
+    });
+
+    test("updateConfig strips trailing slashes", () => {
+        const stream = new NoteStream("http://a.com", "key");
+        stream.updateConfig("http://b.com///", "key2");
+        // Verify by attempting connect and checking fetch URL
+        const abortError = new DOMException("aborted", "AbortError");
+        mockFetch.mockRejectedValueOnce(abortError);
+        stream.connect();
+        if (mockFetch.mock.calls.length > 0) {
+            expect(mockFetch.mock.calls[0][0]).toBe("http://b.com/notes/stream");
+        }
+        stream.disconnect();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Disconnect
+// ---------------------------------------------------------------------------
+
+describe("NoteStream disconnect", () => {
+    test("disconnect sets connected to false", () => {
+        const stream = new NoteStream("http://localhost:8000", "key");
+        stream.disconnect();
+        expect(stream.isConnected()).toBe(false);
+    });
+
+    test("disconnect fires status change callback", () => {
+        const stream = new NoteStream("http://localhost:8000", "key");
+        const statusFn = jest.fn();
+        stream.onStatusChange = statusFn;
+        // Force internal state to connected
+        (stream as any).connected = true;
+        stream.disconnect();
+        expect(statusFn).toHaveBeenCalledWith(false);
+    });
+
+    test("multiple disconnects are safe", () => {
+        const stream = new NoteStream("http://localhost:8000", "key");
+        stream.disconnect();
+        stream.disconnect();
+        expect(stream.isConnected()).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Connect
+// ---------------------------------------------------------------------------
+
+describe("NoteStream connect", () => {
+    test("connect sends fetch with auth header", async () => {
+        // Mock a stream that immediately ends
+        const mockReader = {
+            read: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+        };
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            body: { getReader: () => mockReader },
+        });
+
+        const stream = new NoteStream("http://localhost:8000", "engram_key");
+        await stream.connect();
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            "http://localhost:8000/notes/stream",
+            expect.objectContaining({
+                headers: { Authorization: "Bearer engram_key" },
+            }),
+        );
+        stream.disconnect();
+    });
+
+    test("connect is idempotent while stream is active", async () => {
+        // Keep the stream alive by never resolving the read
+        const mockReader = {
+            read: jest.fn().mockReturnValue(new Promise(() => {})), // never resolves
+        };
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            body: { getReader: () => mockReader },
+        });
+
+        const stream = new NoteStream("http://localhost:8000", "key");
+        // Don't await — connect starts the stream but read() hangs
+        stream.connect();
+        await new Promise((r) => setTimeout(r, 50)); // let connect() reach the read loop
+
+        await stream.connect(); // second call should be no-op (controller exists)
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        stream.disconnect();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// SSE event parsing
+// ---------------------------------------------------------------------------
+
+describe("NoteStream event parsing", () => {
+    test("parses note_change events", async () => {
+        const eventData = { path: "Notes/Test.md", action: "upsert", mtime: "2024-01-01T00:00:00Z" };
+        const ssePayload = `event: note_change\ndata: ${JSON.stringify(eventData)}\n\n`;
+        const encoder = new TextEncoder();
+
+        let readCount = 0;
+        const mockReader = {
+            read: jest.fn().mockImplementation(() => {
+                if (readCount === 0) {
+                    readCount++;
+                    return Promise.resolve({ done: false, value: encoder.encode(ssePayload) });
+                }
+                return Promise.resolve({ done: true, value: undefined });
+            }),
+        };
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            body: { getReader: () => mockReader },
+        });
+
+        const onEvent = jest.fn();
+        const stream = new NoteStream("http://localhost:8000", "key");
+        stream.onEvent = onEvent;
+        await stream.connect();
+
+        // Wait a tick for async processing
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(onEvent).toHaveBeenCalledWith(eventData);
+        stream.disconnect();
+    });
+
+    test("ignores non-note_change events", async () => {
+        const ssePayload = `event: heartbeat\ndata: {}\n\n`;
+        const encoder = new TextEncoder();
+
+        let readCount = 0;
+        const mockReader = {
+            read: jest.fn().mockImplementation(() => {
+                if (readCount === 0) {
+                    readCount++;
+                    return Promise.resolve({ done: false, value: encoder.encode(ssePayload) });
+                }
+                return Promise.resolve({ done: true, value: undefined });
+            }),
+        };
+
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            body: { getReader: () => mockReader },
+        });
+
+        const onEvent = jest.fn();
+        const stream = new NoteStream("http://localhost:8000", "key");
+        stream.onEvent = onEvent;
+        await stream.connect();
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(onEvent).not.toHaveBeenCalled();
+        stream.disconnect();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+describe("NoteStream errors", () => {
+    test("non-ok response does not set connected", async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: false,
+            status: 401,
+            body: null,
+        });
+
+        const stream = new NoteStream("http://localhost:8000", "key");
+        const statusFn = jest.fn();
+        stream.onStatusChange = statusFn;
+
+        await stream.connect();
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Should not be connected after auth failure
+        expect(stream.isConnected()).toBe(false);
+        stream.disconnect();
+    });
+});

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1010,14 +1010,16 @@ describe("SyncEngine conflict resolution", () => {
 });
 
 describe("SyncEngine.destroy", () => {
-	test("clears pending timers", () => {
+	test("clears pending timers so debounced push never fires", async () => {
 		const engine = createEngine({ debounceMs: 10000 });
 		const file = new TFile("Notes/Test.md");
 
 		engine.handleModify(file);
 		engine.destroy();
 
-		// No errors, timers cleaned up
+		// Wait longer than the debounce — push should never fire
+		await new Promise((r) => setTimeout(r, 100));
+		expect(mockApi.pushNote).not.toHaveBeenCalled();
 	});
 });
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noImplicitAny": false
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- **67 new unit tests** across 4 new test files: API client (api.test.ts), offline queue (offline-queue.test.ts), remote logger (remote-log.test.ts), SSE stream (stream.test.ts)
- **Coverage config** added (jest.config.js) with threshold tracking
- **Test tsconfig** (tsconfig.test.json) for proper type resolution in tests
- **CLAUDE.md** updated with test documentation (201 tests across 7 files)

Total plugin test count: **201 tests** (134 existing + 67 new)

## Test plan

- [x] `npm test` — 201 passed
- [x] `npm run build` — tsc + esbuild clean
- [ ] CI: plugin tests pass
- [ ] CI: backend E2E triggered via `repository_dispatch` (plugin CI fires this after success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)