### PR TITLE
fix: persist push hashes, break attachment loop, save on close

### DIFF
--- a/main.js
+++ b/main.js
@@ -1158,6 +1158,13 @@ var SyncEngine = class {
     const buffer = base64ToArrayBuffer(contentBase64);
     const existing = this.app.vault.getAbstractFileByPath(normalized);
     if (existing && existing instanceof import_obsidian2.TFile) {
+      if (existing.stat.size === buffer.byteLength) {
+        const localBuffer = await this.app.vault.readBinary(existing);
+        if (this.arrayBuffersEqual(localBuffer, buffer)) {
+          rlog().info("pull", `Attachment unchanged: ${change.path} | bytes=${buffer.byteLength}`);
+          return false;
+        }
+      }
       await this.app.vault.modifyBinary(existing, buffer);
       rlog().info("pull", `Attachment applied: ${change.path} | bytes=${buffer.byteLength}`);
       return true;
@@ -1229,6 +1236,9 @@ var SyncEngine = class {
     const prePullSync = this.lastSync;
     const pulled = await this.pull();
     const pushed = await this.pushModifiedFiles(prePullSync);
+    if (pushed > 0) {
+      await this.saveData({ lastSync: this.lastSync });
+    }
     devLog().log("lifecycle", `fullSync done \u2014 pulled=${pulled} pushed=${pushed}`);
     rlog().info("lifecycle", `FullSync done \u2014 pulled=${pulled} pushed=${pushed}`);
     return { pulled, pushed };
@@ -1308,6 +1318,7 @@ var SyncEngine = class {
         new import_obsidian2.Notice(`Engram Sync: reconciled ${toFix.length} files`);
       }
     }
+    await this.saveData({ lastSync: this.lastSync });
     return pushed;
   }
   /** Compute MD5 hex hash of a UTF-8 string using Web Crypto API. */
@@ -1466,6 +1477,16 @@ var SyncEngine = class {
     rlog().info("queue", `Queue flush done \u2014 ${flushed}/${entries.length} flushed, ${this.queue.size} remaining`);
     this.emitStatus();
     return flushed;
+  }
+  /** Fast byte-level comparison of two ArrayBuffers. */
+  arrayBuffersEqual(a, b) {
+    if (a.byteLength !== b.byteLength) return false;
+    const va = new Uint8Array(a);
+    const vb = new Uint8Array(b);
+    for (let i = 0; i < va.length; i++) {
+      if (va[i] !== vb[i]) return false;
+    }
+    return true;
   }
   /** Cancel all pending debounce, cooldown, and health check timers. */
   destroy() {
@@ -2611,6 +2632,7 @@ var EngramSyncPlugin = class extends import_obsidian8.Plugin {
     this.registerDomEvent(document, "visibilitychange", () => {
       if (document.visibilityState === "hidden") {
         rlog().flush();
+        this.savePluginData(this.syncEngine.getLastSync());
       }
     });
     this.addCommand({
@@ -2733,6 +2755,7 @@ var EngramSyncPlugin = class extends import_obsidian8.Plugin {
     var _a, _b;
     devLog().log("lifecycle", "plugin unloading");
     rlog().info("lifecycle", "Plugin unloading");
+    this.savePluginData(this.syncEngine.getLastSync());
     (_a = this.syncEngine) == null ? void 0 : _a.destroy();
     (_b = this.noteStream) == null ? void 0 : _b.disconnect();
     if (this.syncInterval) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,6 +119,7 @@ export default class EngramSyncPlugin extends Plugin {
 		this.registerDomEvent(document, "visibilitychange", () => {
 			if (document.visibilityState === "hidden") {
 				rlog().flush();
+				this.savePluginData(this.syncEngine.getLastSync());
 			}
 		});
 
@@ -260,6 +261,8 @@ export default class EngramSyncPlugin extends Plugin {
 	onunload(): void {
 		devLog().log("lifecycle", "plugin unloading");
 		rlog().info("lifecycle", "Plugin unloading");
+		// Best-effort save before teardown — hashes must be exported before destroy
+		this.savePluginData(this.syncEngine.getLastSync());
 		this.syncEngine?.destroy();
 		this.noteStream?.disconnect();
 		if (this.syncInterval) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -865,6 +865,14 @@ export class SyncEngine {
 		const existing = this.app.vault.getAbstractFileByPath(normalized);
 
 		if (existing && existing instanceof TFile) {
+			// Skip if content is identical — prevents modify event and push-back loop
+			if (existing.stat.size === buffer.byteLength) {
+				const localBuffer = await this.app.vault.readBinary(existing);
+				if (this.arrayBuffersEqual(localBuffer, buffer)) {
+					rlog().info("pull", `Attachment unchanged: ${change.path} | bytes=${buffer.byteLength}`);
+					return false;
+				}
+			}
 			await this.app.vault.modifyBinary(existing, buffer);
 			rlog().info("pull", `Attachment applied: ${change.path} | bytes=${buffer.byteLength}`);
 			return true;
@@ -968,6 +976,11 @@ export class SyncEngine {
 		const pulled = await this.pull();
 		const pushed = await this.pushModifiedFiles(prePullSync);
 
+		// Persist syncedHashes updated during push (pull already saved its own)
+		if (pushed > 0) {
+			await this.saveData({ lastSync: this.lastSync });
+		}
+
 		devLog().log("lifecycle", `fullSync done — pulled=${pulled} pushed=${pushed}`);
 		rlog().info("lifecycle", `FullSync done — pulled=${pulled} pushed=${pushed}`);
 		return { pulled, pushed };
@@ -1066,6 +1079,9 @@ export class SyncEngine {
 				new Notice(`Engram Sync: reconciled ${toFix.length} files`);
 			}
 		}
+
+		// Persist all hashes accumulated during pushAll + reconcile
+		await this.saveData({ lastSync: this.lastSync });
 
 		return pushed;
 	}
@@ -1249,6 +1265,17 @@ export class SyncEngine {
 		rlog().info("queue", `Queue flush done — ${flushed}/${entries.length} flushed, ${this.queue.size} remaining`);
 		this.emitStatus();
 		return flushed;
+	}
+
+	/** Fast byte-level comparison of two ArrayBuffers. */
+	private arrayBuffersEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
+		if (a.byteLength !== b.byteLength) return false;
+		const va = new Uint8Array(a);
+		const vb = new Uint8Array(b);
+		for (let i = 0; i < va.length; i++) {
+			if (va[i] !== vb[i]) return false;
+		}
+		return true;
 	}
 
 	/** Cancel all pending debounce, cooldown, and health check timers. */


### PR DESCRIPTION
## Summary
- **Push hash persistence**: `saveData()` added after `pushModifiedFiles()` in `fullSync()` and after reconcile in `pushAll()` — push-originated syncedHashes now survive across sessions, eliminating false `firstSync=true` conflicts on mobile
- **Attachment content comparison**: `applyAttachmentChange()` now compares binary content (size pre-check + byte comparison) before calling `vault.modifyBinary()` — breaks the pull→push→pull loop that was re-syncing ~22 attachments (~35MB) every cycle
- **Save on close/background**: `savePluginData()` added to both `visibilitychange` and `onunload()` handlers — conflict resolution hashes persist through app close

## Test plan
- [ ] Build and install plugin on desktop
- [ ] Verify attachment "applied" count drops to 0 after first cycle (`GET /logs?category=pull`)
- [ ] Verify no `firstSync=true` conflicts on mobile after restart (`GET /logs?category=conflict`)
- [ ] Resolve a conflict, close app immediately, reopen — conflict should not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)