### PR TITLE
fix: prevent false conflicts when sync hash is missing

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -23,6 +23,13 @@ const HEALTH_CHECK_INTERVAL_MS = 30_000;
 /** Paths that are always ignored regardless of user settings. */
 const ALWAYS_IGNORED = [".obsidian/", ".trash/", ".git/"];
 
+/** If we have no sync hash and the local file's mtime is older than the remote
+ *  mtime by at least this many seconds, treat the file as stale (not locally
+ *  modified) and skip conflict detection. 1 hour is conservative — if a user
+ *  edited a file, its mtime will be within seconds/minutes of the remote push,
+ *  not hours behind. */
+const STALE_THRESHOLD_S = 3600;
+
 /** Fast string hash (FNV-1a 32-bit). Not cryptographic — just for content change detection. */
 function fnv1a(s: string): number {
 	let h = 0x811c9dc5;
@@ -739,9 +746,18 @@ export class SyncEngine {
 
 			// Local was modified by the user if its content hash differs from
 			// what we last wrote during sync (or if we never wrote it).
-			const localModified = lastSyncedHash === undefined
-				? localContent !== change.content  // first sync: compare directly
-				: localHash !== lastSyncedHash;
+			let localModified: boolean;
+			if (lastSyncedHash !== undefined) {
+				localModified = localHash !== lastSyncedHash;
+			} else {
+				// No sync hash — first sync for this file. Use a staleness
+				// heuristic: if the local mtime is well before the remote mtime,
+				// the user almost certainly didn't edit locally — the file is
+				// just stale and the remote is newer.
+				const localMtimeS = existing.stat.mtime / 1000;
+				const stale = change.mtime - localMtimeS > STALE_THRESHOLD_S;
+				localModified = stale ? false : localContent !== change.content;
+			}
 
 			if (!forceOverwrite && localModified && localContent !== change.content) {
 				// Both sides differ — real conflict

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -978,6 +978,60 @@ describe("SyncEngine conflict resolution", () => {
 		expect(mockApp.vault.trash).toHaveBeenCalled();
 	});
 
+	test("no conflict when firstSync and local file is stale (mtime older than remote)", async () => {
+		const engine = createEngine();
+		engine.setLastSync(LAST_SYNC);
+
+		// Local file has old mtime (2 weeks ago) — user hasn't touched it
+		const TWO_WEEKS_AGO_MS = (REMOTE_MTIME - 14 * 86400) * 1000;
+		const localFile = new TFile("Notes/Conflict.md", TWO_WEEKS_AGO_MS);
+		(mockApp.vault.getAbstractFileByPath as jest.Mock).mockReturnValueOnce(localFile);
+		(mockApp.vault.read as jest.Mock).mockResolvedValueOnce("# Old local version");
+
+		// No syncedHash exists (firstSync=true scenario)
+		// Remote has newer content with recent mtime
+		let conflictCalled = false;
+		engine.onConflict = async () => {
+			conflictCalled = true;
+			return { choice: "keep-remote" };
+		};
+
+		await engine.applyChange(makeChange({
+			content: "# Updated remote version",
+			mtime: REMOTE_MTIME,
+		}));
+
+		// Should NOT trigger conflict — local is stale, remote is newer
+		expect(conflictCalled).toBe(false);
+		expect(mockApp.vault.modify).toHaveBeenCalledWith(localFile, "# Updated remote version");
+	});
+
+	test("still conflicts when firstSync but local file was recently modified", async () => {
+		const engine = createEngine();
+		engine.setLastSync(LAST_SYNC);
+
+		// Local file has mtime within the stale threshold (30 min ago)
+		// — user plausibly edited it, so conflict should still trigger
+		const THIRTY_MIN_AGO_MS = (REMOTE_MTIME - 1800) * 1000;
+		const localFile = new TFile("Notes/Conflict.md", THIRTY_MIN_AGO_MS);
+		(mockApp.vault.getAbstractFileByPath as jest.Mock).mockReturnValueOnce(localFile);
+		(mockApp.vault.read as jest.Mock).mockResolvedValueOnce("# User just edited this");
+
+		let conflictCalled = false;
+		engine.onConflict = async () => {
+			conflictCalled = true;
+			return { choice: "keep-remote" };
+		};
+
+		await engine.applyChange(makeChange({
+			content: "# Remote version",
+			mtime: REMOTE_MTIME,
+		}));
+
+		// SHOULD trigger conflict — local was recently edited
+		expect(conflictCalled).toBe(true);
+	});
+
 	test("no false conflict when remote appends to previously synced file", async () => {
 		const engine = createEngine();
 		engine.setLastSync(LAST_SYNC);


### PR DESCRIPTION
## Summary

- Adds a staleness heuristic to conflict detection in `applyChange()` — when `syncedHash` is undefined (firstSync=true) and the local file's mtime is >1 hour older than the remote mtime, treat it as stale and skip conflict detection
- Fixes false conflicts triggered by remote-only edits (e.g. via MCP/API) on files that haven't been touched locally in days/weeks
- Root cause: all 10 recent conflicts (5 files × 2 devices) had `firstSync=true | syncedHash=none` — the plugin couldn't distinguish "user edited locally" from "I just don't have a hash record"

## Changes

- `src/sync.ts`: Added `STALE_THRESHOLD_S = 3600` constant and staleness check in the `lastSyncedHash === undefined` branch
- `tests/sync.test.ts`: 2 new tests — stale file skips conflict, recent file still triggers conflict

## Test plan

- [x] New test: stale file (mtime 2 weeks old) + no sync hash → no conflict, remote overwrites
- [x] New test: recent file (mtime 30 min ago) + no sync hash → conflict still triggers
- [x] All 203 existing tests pass
- [x] Clean build (`tsc -noEmit` + esbuild)
- [ ] Manual: clear plugin data, restart Obsidian, edit a note via MCP, verify no conflict modal
- [ ] Manual: edit a note locally, then edit same note via MCP within 1 hour, verify conflict modal appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)