### PR TITLE
refactor: auto-append /api prefix to base URL

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -21,10 +21,18 @@ export class EngramApi {
 	constructor(
 		private baseUrl: string,
 		private apiKey: string,
-	) {}
+	) {
+		this.baseUrl = EngramApi.normalizeBaseUrl(baseUrl);
+	}
+
+	/** Strip trailing slashes and append /api if not already present. */
+	private static normalizeBaseUrl(url: string): string {
+		const base = url.replace(/\/+$/, "");
+		return base.endsWith("/api") ? base : `${base}/api`;
+	}
 
 	updateConfig(baseUrl: string, apiKey: string): void {
-		this.baseUrl = baseUrl.replace(/\/+$/, "");
+		this.baseUrl = EngramApi.normalizeBaseUrl(baseUrl);
 		this.apiKey = apiKey;
 	}
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -63,21 +63,33 @@ describe("base64ToArrayBuffer", () => {
 // EngramApi
 // ---------------------------------------------------------------------------
 
+const TEST_SERVER = "http://localhost:8000";
+const TEST_API_BASE = `${TEST_SERVER}/api`;
+const TEST_KEY = "engram_testkey";
+
 describe("EngramApi", () => {
     let api: EngramApi;
 
     beforeEach(() => {
-        api = new EngramApi("http://localhost:8000", "engram_testkey");
+        api = new EngramApi(TEST_SERVER, TEST_KEY);
     });
 
     describe("updateConfig", () => {
-        test("strips trailing slashes from URL", () => {
+        test("strips trailing slashes and appends /api", () => {
             api.updateConfig("http://example.com///", "key2");
-            // Verify by making a request and checking the URL
             mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { status: "ok" } } as any);
             api.health();
             expect(mockRequestUrl).toHaveBeenCalledWith(
-                expect.objectContaining({ url: "http://example.com/health" }),
+                expect.objectContaining({ url: "http://example.com/api/health" }),
+            );
+        });
+
+        test("does not double-append /api if already present", () => {
+            api.updateConfig("http://example.com/api", "key2");
+            mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { status: "ok" } } as any);
+            api.health();
+            expect(mockRequestUrl).toHaveBeenCalledWith(
+                expect.objectContaining({ url: "http://example.com/api/health" }),
             );
         });
     });
@@ -131,7 +143,7 @@ describe("EngramApi", () => {
             expect(mockRequestUrl).toHaveBeenCalledWith(
                 expect.objectContaining({
                     method: "POST",
-                    url: "http://localhost:8000/notes",
+                    url: `${TEST_API_BASE}/notes`,
                     body: JSON.stringify({ path: "Notes/Test.md", content: "# Hello", mtime: 1234567890 }),
                 }),
             );

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -22,7 +22,7 @@ describe("EngramApi.search", () => {
 		const resp = await api.search("omega oils");
 
 		expect(mockRequestUrl).toHaveBeenCalledWith({
-			url: "http://localhost:8000/search",
+			url: "http://localhost:8000/api/search",
 			method: "POST",
 			headers: {
 				Authorization: "Bearer test-key",


### PR DESCRIPTION
## Summary
- `EngramApi.normalizeBaseUrl()` strips trailing slashes and appends `/api` to server URL
- Idempotent — won't double-append if user already includes `/api` in their settings
- WebSocket channel unaffected (connects to `/socket`, not `/api/socket`)
- Test constants extracted for URL configuration

## Context
Companion to Rasbandit/Engram — backend moved all routes under `/api` prefix. This ensures the plugin sends requests to the correct paths.

**No user action required** — existing users' `apiUrl` setting (e.g., `http://host:8000`) will automatically get `/api` appended.

## Test plan
- [x] `npm test` — 224/224 pass
- [x] New test: verifies `/api` is not double-appended
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)