### PR TITLE
feat: use inline WebSocket content for faster sync

### DIFF
--- a/main.js
+++ b/main.js
@@ -2024,7 +2024,14 @@ var NoteChannel = class {
         event_type: p.event_type,
         path: p.path,
         timestamp: Date.now(),
-        kind: (_b = p.kind) != null ? _b : "note"
+        kind: (_b = p.kind) != null ? _b : "note",
+        content: p.content,
+        title: p.title,
+        folder: p.folder,
+        tags: p.tags,
+        mtime: p.mtime,
+        updated_at: p.updated_at,
+        version: p.version
       };
       rlog().info("channel", `Event: ${streamEvent.event_type} ${streamEvent.path}`);
       (_c = this.onEvent) == null ? void 0 : _c.call(this, streamEvent);
@@ -4214,7 +4221,7 @@ var SyncEngine = class {
   }
   /** Handle a WebSocket stream event (upsert or delete). */
   async handleStreamEvent(event) {
-    var _a, _b;
+    var _a, _b, _c, _d, _e, _f, _g;
     if (this.shouldIgnore(event.path)) return;
     devLog().log("ws", `${event.event_type} ${(_a = event.kind) != null ? _a : "note"}: ${event.path}`);
     rlog().info("ws", `Event: ${event.event_type} ${(_b = event.kind) != null ? _b : "note"}: ${event.path}`);
@@ -4251,6 +4258,18 @@ var SyncEngine = class {
             },
             attachment.content_base64
           );
+        } else if (event.content !== void 0) {
+          await this.applyChange({
+            path: event.path,
+            title: (_c = event.title) != null ? _c : "",
+            content: event.content,
+            folder: (_d = event.folder) != null ? _d : "",
+            tags: (_e = event.tags) != null ? _e : [],
+            mtime: (_f = event.mtime) != null ? _f : Date.now(),
+            updated_at: (_g = event.updated_at) != null ? _g : (/* @__PURE__ */ new Date()).toISOString(),
+            deleted: false,
+            version: event.version
+          });
         } else {
           const note = await this.api.getNote(event.path);
           await this.applyChange({
@@ -4266,7 +4285,7 @@ var SyncEngine = class {
         }
       } catch (e) {
         console.error(
-          `Engram Sync: failed to fetch content for WebSocket event ${event.path}`,
+          `Engram Sync: failed to apply WebSocket event ${event.path}`,
           e
         );
       }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -172,12 +172,19 @@ export class NoteChannel {
 		}
 
 		if (event === "note_changed" && payload) {
-			const p = payload as { event_type: string; path: string; kind?: string };
+			const p = payload as Record<string, unknown>;
 			const streamEvent: NoteStreamEvent = {
 				event_type: p.event_type as "upsert" | "delete",
-				path: p.path,
+				path: p.path as string,
 				timestamp: Date.now(),
 				kind: (p.kind as "note" | "attachment") ?? "note",
+				content: p.content as string | undefined,
+				title: p.title as string | undefined,
+				folder: p.folder as string | undefined,
+				tags: p.tags as string[] | undefined,
+				mtime: p.mtime as number | undefined,
+				updated_at: p.updated_at as string | undefined,
+				version: p.version as number | undefined,
 			};
 			rlog().info("channel", `Event: ${streamEvent.event_type} ${streamEvent.path}`);
 			this.onEvent?.(streamEvent);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -944,7 +944,21 @@ export class SyncEngine {
 						},
 						attachment.content_base64,
 					);
+				} else if (event.content !== undefined) {
+					// Use inline content from the broadcast — no extra HTTP roundtrip
+					await this.applyChange({
+						path: event.path,
+						title: event.title ?? "",
+						content: event.content,
+						folder: event.folder ?? "",
+						tags: event.tags ?? [],
+						mtime: event.mtime ?? Date.now(),
+						updated_at: event.updated_at ?? new Date().toISOString(),
+						deleted: false,
+						version: event.version,
+					});
 				} else {
+					// Fallback: fetch content via GET (e.g., folder rename broadcasts)
 					const note = await this.api.getNote(event.path);
 					await this.applyChange({
 						path: note.path,
@@ -960,7 +974,7 @@ export class SyncEngine {
 			} catch (e) {
 				// biome-ignore lint/suspicious/noConsole: error boundary
 				console.error(
-					`Engram Sync: failed to fetch content for WebSocket event ${event.path}`,
+					`Engram Sync: failed to apply WebSocket event ${event.path}`,
 					e,
 				);
 			}

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,14 @@ export interface NoteStreamEvent {
 	path: string;
 	timestamp: number;
 	kind?: "note" | "attachment";
+	/** Inline note data — present when the server includes content in the broadcast. */
+	content?: string;
+	title?: string;
+	folder?: string;
+	tags?: string[];
+	mtime?: number;
+	updated_at?: string;
+	version?: number;
 }
 
 /** A queued change waiting to be pushed when connectivity returns. */


### PR DESCRIPTION
## Summary
- When the server includes note content in the WebSocket broadcast payload, apply it directly — no extra `GET /notes/{path}` roundtrip needed
- Falls back to GET when content is absent (e.g., folder rename broadcasts, or older backend versions)
- Backward compatible: works with both old and new backend payloads

### Changes
- `types.ts`: Added optional content fields to `NoteStreamEvent` (content, title, folder, tags, mtime, updated_at, version)
- `channel.ts`: Pass through all payload fields into the stream event
- `sync.ts`: `handleStreamEvent()` checks for inline content before fetching via API

## Companion PR
- Backend: Rasbandit/Engram#22 — adds content to upsert broadcast payloads

## Test plan
- [x] 252 plugin unit tests pass
- [x] TypeScript compiles clean
- [ ] Cross-repo E2E triggered from backend CI with this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)