### PR TITLE
ci(version-check): carve out workflow-only changes from the version-bump gate

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -30,6 +30,21 @@ jobs:
           echo "PR in versions:   $PR_IN_VERSIONS"
           echo "Main manifest:    $MAIN_MANIFEST"
 
+          # Workflow-only carve-out. The shipped plugin is built from these paths;
+          # everything else (.github/, docs/, tests/, *.md, lint configs, scripts)
+          # produces no new artifact, so a version bump isn't required. Positive
+          # allowlist (like backend verify.yml's version-check): an unknown path
+          # defaults to "shippable -> bump required". Consistency checks below
+          # still run regardless.
+          SHIPPABLE=$(git diff --name-only origin/main...HEAD -- \
+            src manifest.json styles.css esbuild.config.mjs main.js assets \
+            tsconfig.json package.json bun.lock version-bump.mjs)
+          REQUIRE_BUMP=true
+          if [[ -z "$SHIPPABLE" ]]; then
+            REQUIRE_BUMP=false
+            echo "No shippable paths changed vs main (CI/docs/test/config only) — version bump not required."
+          fi
+
           ERRORS=()
 
           if [[ "$PR_PKG" != "$PR_MANIFEST" ]]; then
@@ -40,7 +55,7 @@ jobs:
             ERRORS+=("versions.json has no entry for $PR_MANIFEST")
           fi
 
-          if [[ "$PR_MANIFEST" == "$MAIN_MANIFEST" ]]; then
+          if [[ "$REQUIRE_BUMP" == "true" && "$PR_MANIFEST" == "$MAIN_MANIFEST" ]]; then
             ERRORS+=("Version $PR_MANIFEST has not been bumped (main is also $MAIN_MANIFEST)")
           fi
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -75,6 +75,17 @@ pre-push:
           exit 0
         fi
 
+        # Workflow-only carve-out (mirrors .github/workflows/version-check.yml):
+        # require a version bump only when a shippable path changed vs main.
+        # CI/docs/test/config-only branches push without bumping.
+        SHIPPABLE="$(git diff --name-only origin/main...HEAD -- \
+          src manifest.json styles.css esbuild.config.mjs main.js assets \
+          tsconfig.json package.json bun.lock version-bump.mjs 2>/dev/null || true)"
+        if [ -z "$SHIPPABLE" ]; then
+          echo "✓ pre-push: no shippable paths changed vs main — version bump not required"
+          exit 0
+        fi
+
         for file in package.json manifest.json; do
           branch_v=$(node -p "require('./$file').version" 2>/dev/null || true)
           main_v=$(git show "origin/main:$file" 2>/dev/null \


### PR DESCRIPTION
## What

Require a plugin version bump only when a **shippable** path changed vs `main`. CI/docs/test/lint-config-only PRs (including Dependabot `gha-all` action bumps) no longer need a manual version bump to pass `version-check`.

Shippable allowlist (positive, mirrors backend `verify.yml` version-check — an unknown path defaults to "shippable → bump required"):
`src manifest.json styles.css esbuild.config.mjs main.js assets tsconfig.json package.json bun.lock version-bump.mjs`

## Why

Dependabot's `pull_request` context can't bump the app version, and pure workflow bumps produce no new plugin artifact — yet `version-check` failed on them, forcing a manual signed version-bump commit on every monthly `gha-all` PR (e.g. #252 just needed a throwaway 1.12.27→1.12.28 bump). The backend already has this carve-out; this brings the plugin to parity.

## Scope

- `.github/workflows/version-check.yml` — gate the bump check on a shippable-path diff. Consistency checks (`package.json` == `manifest.json`, `versions.json` has the entry) still run unconditionally.
- `lefthook.yml` — same carve-out in the local `pre-push` hook, so a workflow-only branch can be pushed without `--no-verify` (this PR's own push is the proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)