### PR TITLE
docs: replace em dash in user-guide beta note

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -17,7 +17,7 @@ The AI never reaches into Obsidian directly. It goes through Engram, which holds
 - **Stable** (default): install from Obsidian Community Plugins. Auto-updates.
 - **Testing a specific PR**: install [BRAT](https://github.com/TfTHacker/obsidian42-brat), then "Add beta plugin" with a **frozen version** = the PR build tag (`X.Y.Z-pr.<num>.g<sha>`, shown on the PR's prerelease).
 
-> A `main`-tracking **Beta** channel is planned; until its release workflow ships, only Stable and per-PR frozen builds are published — don't enable BRAT "beta versions" on the repo yet, as it would install an arbitrary open-PR build.
+> A `main`-tracking **Beta** channel is planned; until its release workflow ships, only Stable and per-PR frozen builds are published. Don't enable BRAT "beta versions" on the repo yet, as it would install an arbitrary open-PR build.
 
 ## Other ways to install
 


### PR DESCRIPTION
#250 landed with an em dash on `docs/user-guide.md:20`, which fails the `TODO drift` em/en-dash gate on main (the gate is not a required check, so #250 auto-merged over it). Swap the em dash for a period.

Follows up #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)