### PR TITLE
fix(ci): enforce the no-bump rule and repo-qualify gh in the release job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,17 @@ jobs:
     # permanently false and the Discord announce has never once fired.
     env:
       WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK_URL }}
+      # Without this, every `gh` call in this job dies with "none of the git
+      # remotes configured for this repository point to a known GitHub host".
+      # `gh` infers the repo from `git remote -v`, and our self-hosted runners
+      # set a system-wide
+      #   url.<lan-git-cache>/engram-app/.insteadOf https://github.com/engram-app/
+      # to spare the GitHub rate limit. `git remote -v` DISPLAYS the rewritten
+      # URL, so what checkout wrote as github.com reads back as a LAN host that
+      # `gh` cannot map to a repo. GH_REPO makes resolution explicit and
+      # remote-independent. This broke the 1.13.1 release: assets never
+      # uploaded, and the release published stable, "Latest", and unusable.
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Mint App token
         id: app-token

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,18 +15,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check version consistency (only when bumped)
+      # Under the release-please channel model, release-please owns the version:
+      # feature PRs must NOT bump manifest.json/package.json, only the Release
+      # PR does. That rule was documented (CLAUDE.md, lefthook.yml) and
+      # unenforced, so it held only as long as everyone read a current copy of
+      # the repo. Two feature PRs bumped 1.13.0 -> 1.13.1 -> 1.13.2 anyway,
+      # which puts main ahead of .release-please-manifest.json: release-please
+      # still plans the version AFTER what it last released, so the Release PR
+      # opens with a version main already claims, fails the manifest-compliance
+      # tests, and stays stuck until someone hand-aligns it.
+      - name: Version bumps belong to the Release PR
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
           PR_MANIFEST=$(jq -r '.version' manifest.json)
           MAIN_MANIFEST=$(git show origin/main:manifest.json | jq -r '.version')
 
           if [[ "$PR_MANIFEST" == "$MAIN_MANIFEST" ]]; then
-            echo "manifest.json unchanged ($PR_MANIFEST) — no bump required under the channel model. OK."
+            echo "manifest.json unchanged ($PR_MANIFEST) — correct for a feature PR under the channel model. OK."
             exit 0
           fi
 
-          echo "Version bumped $MAIN_MANIFEST -> $PR_MANIFEST; enforcing consistency."
+          # The release-please branch is the one place a bump is legitimate.
+          if [[ "$HEAD_REF" != release-please--* ]]; then
+            echo "::error::manifest.json bumped $MAIN_MANIFEST -> $PR_MANIFEST on a feature branch. release-please owns versions; only the Release PR may bump them. Restore main's values: git checkout origin/main -- manifest.json package.json versions.json"
+            exit 1
+          fi
+
+          echo "Release PR ($HEAD_REF) bumped $MAIN_MANIFEST -> $PR_MANIFEST; enforcing consistency."
           ERRORS=()
           PR_PKG=$(jq -r '.version' package.json)
           [[ "$PR_PKG" == "$PR_MANIFEST" ]] || ERRORS+=("package.json ($PR_PKG) != manifest.json ($PR_MANIFEST)")


### PR DESCRIPTION
Two release-process guardrails, both learned the hard way from today's 1.13.x releases.

## 1. Enforce the no-bump rule (`version-check.yml`)

Under the release-please channel model, release-please owns the version: feature PRs must NOT bump `manifest.json`/`package.json`, only the Release PR does. That rule was documented (CLAUDE.md, `lefthook.yml`) and **unenforced**, so it held only as long as everyone read a current copy of the repo.

Today two feature PRs bumped `1.13.0 -> 1.13.1 -> 1.13.2` anyway. That puts `main` ahead of `.release-please-manifest.json`: release-please still plans the version *after* what it last released, so the Release PR opens claiming a version main already has, fails the manifest-compliance tests, and stays stuck until someone hand-aligns it. That hand-alignment is what desynced the release tag from the committed version (see below).

`version-check.yml` already computed exactly the values needed; it just treated "unchanged" as the only OK state and never rejected the bad one. Now a bump on a non-`release-please--*` branch fails with a message and the exact recovery command.

## 2. Repo-qualify `gh` in the release job (`release-please.yml`)

Every `gh` call in the release job died with:

```
none of the git remotes configured for this repository point to a known GitHub host
```

`gh` infers the repo from `git remote -v`. Our self-hosted runners set a system-wide

```
url.<lan-git-cache>/engram-app/.insteadOf https://github.com/engram-app/
```

to spare the GitHub rate limit, and **`git remote -v` displays the rewritten URL** — so what `actions/checkout` wrote as `github.com` reads back as a LAN host `gh` cannot map to a repo. Job-level `GH_REPO` makes resolution explicit and remote-independent, covering every `gh` call in the job including future ones.

This is a *second, independent* bug that was hidden behind the `fromJson` one fixed in #268: fixing that let the job run far enough to hit this. It skipped the asset upload, publishing `1.13.1` stable, "Latest", and completely unusable.

### Blast radius (checked, no change needed)

- `release-audit.yml` — talks to the API via `curl`, immune.
- `dependabot-auto-merge.yml` — passes a full PR URL, which `gh` resolves without remotes.

The backend repo has the same class of exposure (`deploy-prod.yml`'s `gh release create`, gated behind `has_impact` so it hasn't bitten yet); that is a separate PR in that repo.

## Release repair

`1.13.2` has been published by hand with all three assets, built from `e9c9932` and verified byte-identical to the committed `main.js`. The bogus assetless `1.13.1` is still present and will keep `release-audit.yml` red until it is removed.

## Note

Per the rule this PR enforces, this PR does **not** bump any version.