### PR TITLE
test: prove the no-bump gate fails (do not merge)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,17 @@ jobs:
     # permanently false and the Discord announce has never once fired.
     env:
       WEBHOOK: ${{ secrets.DISCORD_RELEASES_WEBHOOK_URL }}
+      # Without this, every `gh` call in this job dies with "none of the git
+      # remotes configured for this repository point to a known GitHub host".
+      # `gh` infers the repo from `git remote -v`, and our self-hosted runners
+      # set a system-wide
+      #   url.<lan-git-cache>/engram-app/.insteadOf https://github.com/engram-app/
+      # to spare the GitHub rate limit. `git remote -v` DISPLAYS the rewritten
+      # URL, so what checkout wrote as github.com reads back as a LAN host that
+      # `gh` cannot map to a repo. GH_REPO makes resolution explicit and
+      # remote-independent. This broke the 1.13.1 release: assets never
+      # uploaded, and the release published stable, "Latest", and unusable.
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Mint App token
         id: app-token

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -15,18 +15,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check version consistency (only when bumped)
+      # Under the release-please channel model, release-please owns the version:
+      # feature PRs must NOT bump manifest.json/package.json, only the Release
+      # PR does. That rule was documented (CLAUDE.md, lefthook.yml) and
+      # unenforced, so it held only as long as everyone read a current copy of
+      # the repo. Two feature PRs bumped 1.13.0 -> 1.13.1 -> 1.13.2 anyway,
+      # which puts main ahead of .release-please-manifest.json: release-please
+      # still plans the version AFTER what it last released, so the Release PR
+      # opens with a version main already claims, fails the manifest-compliance
+      # tests, and stays stuck until someone hand-aligns it.
+      - name: Version bumps belong to the Release PR
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
           PR_MANIFEST=$(jq -r '.version' manifest.json)
           MAIN_MANIFEST=$(git show origin/main:manifest.json | jq -r '.version')
 
           if [[ "$PR_MANIFEST" == "$MAIN_MANIFEST" ]]; then
-            echo "manifest.json unchanged ($PR_MANIFEST) — no bump required under the channel model. OK."
+            echo "manifest.json unchanged ($PR_MANIFEST) — correct for a feature PR under the channel model. OK."
             exit 0
           fi
 
-          echo "Version bumped $MAIN_MANIFEST -> $PR_MANIFEST; enforcing consistency."
+          # The release-please branch is the one place a bump is legitimate.
+          if [[ "$HEAD_REF" != release-please--* ]]; then
+            echo "::error::manifest.json bumped $MAIN_MANIFEST -> $PR_MANIFEST on a feature branch. release-please owns versions; only the Release PR may bump them. Restore main's values: git checkout origin/main -- manifest.json package.json versions.json"
+            exit 1
+          fi
+
+          echo "Release PR ($HEAD_REF) bumped $MAIN_MANIFEST -> $PR_MANIFEST; enforcing consistency."
           ERRORS=()
           PR_PKG=$(jq -r '.version' package.json)
           [[ "$PR_PKG" == "$PR_MANIFEST" ]] || ERRORS+=("package.json ($PR_PKG) != manifest.json ($PR_MANIFEST)")

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,14 @@
 {
-	"id": "engram-vault-sync",
-	"name": "Engram Vault Sync",
-	"minAppVersion": "1.7.2",
-	"description": "Your notes are your AI's memory. Sync your vault everywhere, search by meaning, and let Claude, Cursor, and other AI apps read and write your notes. Hosted or self-host, free to start.",
-	"author": "Rasbandit",
-	"authorUrl": "https://github.com/Rasbandit",
-	"isDesktopOnly": false,
-	"fundingUrl": {
-		"GitHub Sponsors": "https://github.com/sponsors/engram-app",
-		"Ko-fi": "https://ko-fi.com/engrams_sync"
-	},
-	"version": "1.13.2"
+  "id": "engram-vault-sync",
+  "name": "Engram Vault Sync",
+  "minAppVersion": "1.7.2",
+  "description": "Your notes are your AI's memory. Sync your vault everywhere, search by meaning, and let Claude, Cursor, and other AI apps read and write your notes. Hosted or self-host, free to start.",
+  "author": "Rasbandit",
+  "authorUrl": "https://github.com/Rasbandit",
+  "isDesktopOnly": false,
+  "fundingUrl": {
+    "GitHub Sponsors": "https://github.com/sponsors/engram-app",
+    "Ko-fi": "https://ko-fi.com/engrams_sync"
+  },
+  "version": "1.99.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engram-obsidian",
-  "version": "1.13.2",
+  "version": "1.99.0",
   "description": "Your notes are your AI's memory. Sync your vault everywhere, search by meaning, and let Claude, Cursor, and other AI apps read and write your notes. Hosted or self-host, free to start.",
   "main": "main.js",
   "type": "module",


### PR DESCRIPTION
Throwaway PR verifying that the guardrail added in #273 actually fails when a feature branch bumps the version. Bumps manifest.json + package.json to 1.99.0 on a non-release-please branch.

Expected: `version-check` FAILS. This PR will be closed and the branch deleted once observed.