### PR TITLE
fix(api): bound the five direct requestUrl call sites (token refresh can wedge the whole plugin)

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -39,7 +39,11 @@ export class RequestTimeoutError extends Error {
 	}
 }
 
-async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+/** Deadline-bound a promise. Exported for the direct `requestUrl` call sites
+ *  outside EngramApi (token refresh, device flow, waitlist, update check,
+ *  probeHealth) — anything unbounded there can wedge its caller forever;
+ *  the token-refresh case stalls EVERY request behind getToken(). */
+export async function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
 	let timer: number | undefined;
 	const deadline = new Promise<never>((_, reject) => {
 		timer = window.setTimeout(() => reject(new RequestTimeoutError(ms)), ms);
@@ -153,7 +157,10 @@ export class EngramApi {
 	static async probeHealth(rawUrl: string): Promise<PreflightResult> {
 		const base = EngramApi.normalizeBaseUrl(rawUrl);
 		try {
-			const resp = await requestUrl({ url: `${base}/health`, method: "GET", throw: false });
+			const resp = await withTimeout(
+				requestUrl({ url: `${base}/health`, method: "GET", throw: false }),
+				10_000,
+			);
 			let body: unknown = null;
 			try {
 				body = resp.json;

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -1,4 +1,5 @@
 import { type App, Modal, Notice, requestUrl } from "obsidian";
+import { withTimeout } from "./api";
 import type EngramSyncPlugin from "./main";
 
 export interface DeviceFlowResult {
@@ -73,13 +74,16 @@ export class DeviceFlowModal extends Modal {
 			client_id: this.plugin.settings.clientId,
 		};
 		if (vaultName) body.vault_name = vaultName;
-		const resp = await requestUrl({
-			url: `${apiUrl}/auth/device`,
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(body),
-			throw: false,
-		});
+		const resp = await withTimeout(
+			requestUrl({
+				url: `${apiUrl}/auth/device`,
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(body),
+				throw: false,
+			}),
+			15_000,
+		);
 		if (resp.status < 200 || resp.status >= 300) {
 			throw new Error(`HTTP ${resp.status}`);
 		}
@@ -142,13 +146,16 @@ export class DeviceFlowModal extends Modal {
 			}
 
 			try {
-				const resp = await requestUrl({
-					url: `${apiUrl}/auth/device/token`,
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ device_code: deviceCode }),
-					throw: false,
-				});
+				const resp = await withTimeout(
+					requestUrl({
+						url: `${apiUrl}/auth/device/token`,
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ device_code: deviceCode }),
+						throw: false,
+					}),
+					15_000,
+				);
 
 				if (resp.status === 428) return;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import {
 	normalizePath,
 	requestUrl,
 } from "obsidian";
-import { EngramApi } from "./api";
+import { EngramApi, withTimeout } from "./api";
 import {
 	ApiKeyAuth,
 	type AuthProvider,
@@ -1352,13 +1352,21 @@ export default class EngramSyncPlugin extends Plugin {
 			const refreshFn: RefreshFn = async (token) => {
 				const base = this.settings.apiUrl.replace(/\/+$/, "");
 				const apiUrl = base.endsWith("/api") ? base : `${base}/api`;
-				const resp = await requestUrl({
-					url: `${apiUrl}/auth/token/refresh`,
-					method: "POST",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify({ refresh_token: token }),
-					throw: false,
-				});
+				// Bounded: getToken() serializes EVERY api call behind this refresh,
+				// so a wedged half-open refresh silences the whole plugin (no HTTP
+				// at all — the test_57 300s fullSync stall signature). A timeout
+				// rejects with no `status`, which OAuthAuth already classifies as
+				// transient (keep token, retry later).
+				const resp = await withTimeout(
+					requestUrl({
+						url: `${apiUrl}/auth/token/refresh`,
+						method: "POST",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({ refresh_token: token }),
+						throw: false,
+					}),
+					15_000,
+				);
 				if (resp.status < 200 || resp.status >= 300) {
 					// Carry the HTTP status so OAuthAuth can distinguish a definitive
 					// rejection (revoked/expired token → 4xx, clear + re-link) from a

--- a/src/update-check.ts
+++ b/src/update-check.ts
@@ -1,4 +1,5 @@
 import { requestUrl } from "obsidian";
+import { withTimeout } from "./api";
 
 /** Raw manifest on the default branch — the same file Obsidian's own community
  *  updater reads to detect the latest version. No auth, works on mobile. */
@@ -23,7 +24,10 @@ export function isNewerVersion(latest: string, current: string): boolean {
  *  to disrupt plugin load. */
 export async function checkForPluginUpdate(currentVersion: string): Promise<string | null> {
 	try {
-		const resp = await requestUrl({ url: MANIFEST_URL, method: "GET", throw: false });
+		const resp = await withTimeout(
+			requestUrl({ url: MANIFEST_URL, method: "GET", throw: false }),
+			10_000,
+		);
 		if (resp.status !== 200) return null;
 		const latest = (resp.json as { version?: unknown } | undefined)?.version;
 		return typeof latest === "string" && isNewerVersion(latest, currentVersion) ? latest : null;

--- a/src/waitlist.ts
+++ b/src/waitlist.ts
@@ -1,4 +1,5 @@
 import { requestUrl } from "obsidian";
+import { withTimeout } from "./api";
 
 /** The MARKETING site endpoint (engram.page), not the sync backend
  *  (api.engram.page). Hardcoded: it's a fixed public URL, independent of the
@@ -9,13 +10,16 @@ export const WAITLIST_ENDPOINT = "https://engram.page/api/waitlist";
  *  authenticated. Throws on non-2xx or transport error so the modal can show
  *  an inline message; dismissal is independent of this succeeding. */
 export async function submitWaitlistEmail(email: string): Promise<void> {
-	const resp = await requestUrl({
-		url: WAITLIST_ENDPOINT,
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({ email, source: "obsidian-plugin" }),
-		throw: false,
-	});
+	const resp = await withTimeout(
+		requestUrl({
+			url: WAITLIST_ENDPOINT,
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ email, source: "obsidian-plugin" }),
+			throw: false,
+		}),
+		15_000,
+	);
 	if (resp.status < 200 || resp.status >= 300) {
 		throw new Error(`waitlist signup failed: ${resp.status}`);
 	}


### PR DESCRIPTION
Follow-up to the reliability wave (#278 / backend #1058) and the test_57 hang diagnosis.

`sendRequest` + `health()` have had deadlines since the issue-#244 wedge fix, but five direct `requestUrl` sites bypass them and hang forever on a half-open connection:

- **`main.ts` OAuth token refresh — the important one.** `getToken()` serializes every API call behind an in-flight refresh, so one wedged refresh silences the entire plugin with zero HTTP traffic. That matches the test_57 300s fullSync stall evidence (ping/manifest OK, then ~4 min of total silence, then recovery) better than any bounded path. 15s bound; a timeout rejects without `status`, which `OAuthAuth` already treats as transient (keep token, retry later).
- Device-flow start + token poll (15s) — a hang here freezes the login modal.
- Waitlist submit (15s), update check (10s), `probeHealth` (10s).

Reuses the existing `withTimeout`/`RequestTimeoutError` from `api.ts` (now exported). No version bump (release-please owns versions). Full gate green: tsc + biome + 2169 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJksd3C2xLkXyucHRRnuVC