### PR TITLE
fix(sync): seq fence strict — an equal-seq row can carry a server merge the device never saw

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -190,7 +190,9 @@ export class OAuthAuth implements AuthProvider {
 		// replaying it: the server may have already committed that rotation,
 		// and a replay of a consumed token 401s definitively (forced re-link).
 		const raw =
-			this.lateRefresh?.token === sentToken ? this.lateRefresh.raw : this.refreshFn(sentToken);
+			this.lateRefresh?.token === sentToken
+				? this.lateRefresh.raw
+				: this.refreshFn(sentToken);
 		try {
 			const result = await withTimeout(raw, OAuthAuth.REFRESH_DEADLINE_MS);
 			this.lateRefresh = null;

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import { RequestTimeoutError, withTimeout } from "./api";
 import { rlog } from "./remote-log";
 /**
  * Auth providers for Engram plugin — abstracts API key vs OAuth token management.
@@ -101,6 +102,21 @@ export class OAuthAuth implements AuthProvider {
 	private onTokenRotated?: (tokens: PersistedTokens) => void | Promise<void>;
 	private authenticated = true;
 	private inflightRefresh: Promise<string> | null = null;
+	/** A deadline-abandoned refresh whose underlying request is still pending.
+	 *  Under REFRESH-TOKEN ROTATION an abandoned-but-server-committed refresh
+	 *  consumes the old token: replaying it "transiently" later guarantees a
+	 *  definitive 401 → forced re-link (review MAJOR-1). While this is set,
+	 *  doRefresh REUSES the pending request instead of replaying the token,
+	 *  and a late success is adopted as a normal rotation. */
+	private lateRefresh: {
+		token: string;
+		raw: ReturnType<RefreshFn>;
+	} | null = null;
+
+	/** Deadline for one refresh round-trip. Static + mutable like
+	 *  EXPIRY_BUFFER_MS so tests can shrink it. Lives HERE (not in the host's
+	 *  refreshFn) so the abandoned promise stays reachable for late adoption. */
+	private static REFRESH_DEADLINE_MS = 15_000;
 	// Invoked once when the refresh token is DEFINITIVELY rejected by the server
 	// (revoked / rotated-away / expired → 400/401/403/404), as opposed to a
 	// transient error (network / 5xx / 429). The host clears persisted auth and
@@ -154,6 +170,14 @@ export class OAuthAuth implements AuthProvider {
 		}
 	}
 
+	/** Adopt a successful rotation into memory (in-time or late). */
+	private adoptRotation(result: Awaited<ReturnType<RefreshFn>>): void {
+		this.accessToken = result.access_token;
+		this.refreshToken = result.refresh_token;
+		this.expiresAt = Date.now() + result.expires_in * 1000;
+		this.authenticated = true;
+	}
+
 	private async doRefresh(): Promise<string> {
 		// A cleared token (after a definitive rejection) can never succeed — fail
 		// fast instead of replaying an empty/dead token against the server.
@@ -161,12 +185,16 @@ export class OAuthAuth implements AuthProvider {
 			this.authenticated = false;
 			throw new Error("Not authenticated: refresh token cleared");
 		}
+		const sentToken = this.refreshToken;
+		// Reuse a deadline-abandoned request for the SAME token instead of
+		// replaying it: the server may have already committed that rotation,
+		// and a replay of a consumed token 401s definitively (forced re-link).
+		const raw =
+			this.lateRefresh?.token === sentToken ? this.lateRefresh.raw : this.refreshFn(sentToken);
 		try {
-			const result = await this.refreshFn(this.refreshToken);
-			this.accessToken = result.access_token;
-			this.refreshToken = result.refresh_token;
-			this.expiresAt = Date.now() + result.expires_in * 1000;
-			this.authenticated = true;
+			const result = await withTimeout(raw, OAuthAuth.REFRESH_DEADLINE_MS);
+			this.lateRefresh = null;
+			this.adoptRotation(result);
 			// Await persistence so callers can't act on the new access token
 			// before the rotated refresh token reaches disk.
 			await this.onTokenRotated?.({
@@ -178,8 +206,33 @@ export class OAuthAuth implements AuthProvider {
 				"auth",
 				`OAuth refresh ok — accessTokenLen=${result.access_token.length} expiresInS=${result.expires_in}`,
 			);
-			return this.accessToken;
+			return result.access_token;
 		} catch (err) {
+			if (err instanceof RequestTimeoutError) {
+				// Deadline lost the race but the request is only ABANDONED, not
+				// cancelled. Keep it reachable: retries reuse it (above), and a
+				// late success is adopted iff no newer rotation superseded it.
+				this.lateRefresh = { token: sentToken, raw };
+				raw.then(
+					async (late) => {
+						if (this.refreshToken !== sentToken) return; // superseded
+						this.lateRefresh = null;
+						this.adoptRotation(late);
+						await this.onTokenRotated?.({
+							refreshToken: late.refresh_token,
+							accessToken: late.access_token,
+							expiresAt: this.expiresAt,
+						});
+						rlog().info(
+							"auth",
+							`OAuth refresh adopted LATE rotation (response arrived after the ${OAuthAuth.REFRESH_DEADLINE_MS}ms deadline)`,
+						);
+					},
+					() => {
+						if (this.lateRefresh?.raw === raw) this.lateRefresh = null;
+					},
+				);
+			}
 			this.authenticated = false;
 			this.accessToken = null;
 			this.expiresAt = 0;

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ import {
 	normalizePath,
 	requestUrl,
 } from "obsidian";
-import { EngramApi, withTimeout } from "./api";
+import { EngramApi } from "./api";
 import {
 	ApiKeyAuth,
 	type AuthProvider,
@@ -1352,21 +1352,20 @@ export default class EngramSyncPlugin extends Plugin {
 			const refreshFn: RefreshFn = async (token) => {
 				const base = this.settings.apiUrl.replace(/\/+$/, "");
 				const apiUrl = base.endsWith("/api") ? base : `${base}/api`;
-				// Bounded: getToken() serializes EVERY api call behind this refresh,
-				// so a wedged half-open refresh silences the whole plugin (no HTTP
-				// at all — the test_57 300s fullSync stall signature). A timeout
-				// rejects with no `status`, which OAuthAuth already classifies as
-				// transient (keep token, retry later).
-				const resp = await withTimeout(
-					requestUrl({
-						url: `${apiUrl}/auth/token/refresh`,
-						method: "POST",
-						headers: { "Content-Type": "application/json" },
-						body: JSON.stringify({ refresh_token: token }),
-						throw: false,
-					}),
-					15_000,
-				);
+				// Deliberately UNbounded here: OAuthAuth.doRefresh owns the deadline
+				// (REFRESH_DEADLINE_MS) and needs THIS raw promise to stay alive
+				// past it — a deadline-abandoned refresh may still have rotated the
+				// token server-side, and doRefresh adopts that late success / reuses
+				// the pending request instead of replaying the consumed token
+				// (review MAJOR-1: an inner wrapper here would permanently reject
+				// the promise and force a re-link on every slow rotation).
+				const resp = await requestUrl({
+					url: `${apiUrl}/auth/token/refresh`,
+					method: "POST",
+					headers: { "Content-Type": "application/json" },
+					body: JSON.stringify({ refresh_token: token }),
+					throw: false,
+				});
 				if (resp.status < 200 || resp.status >= 300) {
 					// Carry the HTTP status so OAuthAuth can distinguish a definitive
 					// rejection (revoked/expired token → 4xx, clear + re-link) from a

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1680,7 +1680,10 @@ export class SyncEngine {
 		const since = now - this.seqHealLastAt;
 		if (since >= SyncEngine.SEQ_HEAL_COOLDOWN_MS) {
 			this.seqHealLastAt = now;
-			rlog().info("crdt", `gap-heal fired: note=${noteId} seq=${seq} cursor=${this.catchupSeq}`);
+			rlog().info(
+				"crdt",
+				`gap-heal fired: note=${noteId} seq=${seq} cursor=${this.catchupSeq}`,
+			);
 			void this.catchupViaSeqReplay();
 			return;
 		}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4960,17 +4960,30 @@ export class SyncEngine {
 				// a row converged earlier) also mismatches, and treating that as
 				// "we are behind" backfills a checkpoint-lagged projection over
 				// newer live content (the ModifyTest 40B/23B revert ping-pong; 1805
-				// backfills in one suite run). A row at or below the path's
+				// backfills in one suite run). A row STRICTLY below the path's
 				// high-water seq (or recorded version) is history: skip the whole
 				// diverged block — nothing is recorded, so a genuinely newer row
 				// still converges on a later pass.
+				//
+				// STRICT `<`, never `<=` (main run 29881173619, test_85): an
+				// EQUAL-seq row can carry the server-side MERGE of this device's
+				// own push with an edit it never received — the device's
+				// high-water came from its own push echo, so `<=` fenced the very
+				// row it needed and the missed edit was lost until the next write.
+				// The truly-stale equal-seq row (checkpoint-lagged projection of
+				// the op we just applied) is already skipped by the upstream
+				// serverHash equality gate below; seq only needs to fence rows
+				// PROVABLY behind the high-water. This snapshot-vs-causality
+				// ambiguity is inherent — the proper fix is routing CRDT rows
+				// through the Yjs delta converge (Phase E; see
+				// docs/context/d2-seq-replay-stale-snapshot-stomp.md direction 1).
 				const staleRow =
 					(stored?.seq !== undefined &&
 						change.seq !== undefined &&
-						change.seq <= stored.seq) ||
+						change.seq < stored.seq) ||
 					(stored?.version !== undefined &&
 						change.version !== undefined &&
-						change.version <= stored.version);
+						change.version < stored.version);
 				if (staleRow) {
 					rlog().info(
 						"pull",

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1655,11 +1655,23 @@ export class SyncEngine {
 		return "healing";
 	}
 
+	/** Re-reads the live map at WRITE time and never lowers the per-path
+	 *  high-water: applyChange reads `stored` before its awaits, and a live op
+	 *  (applyLiveOpWithSeq) can bump the map during them — a bare
+	 *  `seq: change.seq` would clobber that bump back down and re-open the
+	 *  fenced revert window (review MAJOR-2). */
+	private pathSeqHighWater(normalized: string, rowSeq: number | undefined): number | undefined {
+		const hw = Math.max(rowSeq ?? 0, this.syncState.get(normalized)?.seq ?? 0);
+		return hw > 0 ? hw : undefined;
+	}
+
 	/** Trailing-edge throttle for heal-triggered seq replays: the first
 	 *  trigger fires immediately; triggers inside the cooldown coalesce into
 	 *  ONE trailing replay at window end (never dropped — a dropped trailing
-	 *  run could strand a real miss until the next op). */
+	 *  run could strand a real miss until the next op). Guarded against a late
+	 *  channel callback re-arming the timer after destroy() (review MINOR-5). */
 	private scheduleSeqHeal(): void {
+		if (this.engineDestroyed) return;
 		const now = Date.now();
 		const since = now - this.seqHealLastAt;
 		if (since >= SyncEngine.SEQ_HEAL_COOLDOWN_MS) {
@@ -1701,6 +1713,14 @@ export class SyncEngine {
 		// id in the new vault. Living here (not just resetForVaultChange) keeps
 		// BOTH vault-change paths in lockstep, per this method's contract.
 		this.lastRelocationTs.clear();
+		// The heal throttle is per-vault too (review MINOR-3): a trailing
+		// replay armed under the OLD vault must not fire into the new one, and
+		// a stale cooldown stamp must not delay the new vault's first heal.
+		if (this.seqHealTimer !== null) {
+			window.clearTimeout(this.seqHealTimer);
+			this.seqHealTimer = null;
+		}
+		this.seqHealLastAt = 0;
 		await this.saveData({ lastSync: "" });
 	}
 
@@ -3262,6 +3282,7 @@ export class SyncEngine {
 	private seqReplayAgain = false;
 	private seqHealLastAt = 0;
 	private seqHealTimer: number | null = null;
+	private engineDestroyed = false;
 	private static readonly SEQ_HEAL_COOLDOWN_MS = 4_000;
 
 	/** Returns the number of ops applied across this replay (incl. any coalesced
@@ -4981,6 +5002,9 @@ export class SyncEngine {
 					(stored?.seq !== undefined &&
 						change.seq !== undefined &&
 						change.seq < stored.seq) ||
+					// Strict here as well; the equal-version decision is owned by the
+					// earlier anti-stale guard (`known >= change.version` skip above),
+					// which short-circuits before this block for on-disk files.
 					(stored?.version !== undefined &&
 						change.version !== undefined &&
 						change.version < stored.version);
@@ -5040,7 +5064,7 @@ export class SyncEngine {
 								hash: localHash,
 								serverHash: change.content_hash,
 								version: change.version,
-								seq: change.seq,
+								seq: this.pathSeqHighWater(normalized, change.seq),
 							});
 						} else {
 							// Keep serverHash UNrecorded so the next poll retries — never
@@ -5080,11 +5104,14 @@ export class SyncEngine {
 								`CRDT catch-up: pull backfilling diverged note ${change.path}`,
 							);
 							await this.flushFromCrdt(normalized, content);
+							// Spread the current entry (preserves crdtHead, mirrors the
+							// converged branch above) and never lower the seq high-water.
 							this.syncState.set(normalized, {
+								...(this.syncState.get(normalized) ?? {}),
 								hash: fnv1a(content),
 								version: change.version,
 								serverHash: change.content_hash,
-								seq: change.seq,
+								seq: this.pathSeqHighWater(normalized, change.seq),
 							});
 						}
 					}
@@ -7033,6 +7060,7 @@ export class SyncEngine {
 
 	/** Cancel all pending debounce, cooldown, and health check timers. */
 	destroy(): void {
+		this.engineDestroyed = true;
 		for (const timer of this.debounceTimers.values()) {
 			window.clearTimeout(timer);
 		}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1650,8 +1650,12 @@ export class SyncEngine {
 		if (!Number.isInteger(seq) || (seq as number) <= this.catchupSeq) {
 			return "applied";
 		}
-		rlog().info("crdt", `gap-heal fired: note=${noteId} seq=${seq} cursor=${this.catchupSeq}`);
-		this.scheduleSeqHeal();
+		// Detection is NOT logged per-op: the cursor only advances via replay,
+		// so under active editing every fresh-seq op detects "behind" — 1200+
+		// rlog POSTs per CI run, pure load on the delivery path being timed.
+		// The FIRE sites in scheduleSeqHeal log (with this op's note id), which
+		// is what the e2e log-oracle asserts.
+		this.scheduleSeqHeal(noteId, seq as number);
 		return "healing";
 	}
 
@@ -1670,12 +1674,13 @@ export class SyncEngine {
 	 *  ONE trailing replay at window end (never dropped — a dropped trailing
 	 *  run could strand a real miss until the next op). Guarded against a late
 	 *  channel callback re-arming the timer after destroy() (review MINOR-5). */
-	private scheduleSeqHeal(): void {
+	private scheduleSeqHeal(noteId: string, seq: number): void {
 		if (this.engineDestroyed) return;
 		const now = Date.now();
 		const since = now - this.seqHealLastAt;
 		if (since >= SyncEngine.SEQ_HEAL_COOLDOWN_MS) {
 			this.seqHealLastAt = now;
+			rlog().info("crdt", `gap-heal fired: note=${noteId} seq=${seq} cursor=${this.catchupSeq}`);
 			void this.catchupViaSeqReplay();
 			return;
 		}
@@ -1683,7 +1688,10 @@ export class SyncEngine {
 		this.seqHealTimer = window.setTimeout(() => {
 			this.seqHealTimer = null;
 			this.seqHealLastAt = Date.now();
-			rlog().info("crdt", "gap-heal replay (trailing, throttled)");
+			rlog().info(
+				"crdt",
+				`gap-heal fired: note=${noteId} seq=${seq} cursor=${this.catchupSeq} (trailing)`,
+			);
 			void this.catchupViaSeqReplay();
 		}, SyncEngine.SEQ_HEAL_COOLDOWN_MS - since);
 	}
@@ -3283,7 +3291,14 @@ export class SyncEngine {
 	private seqHealLastAt = 0;
 	private seqHealTimer: number | null = null;
 	private engineDestroyed = false;
-	private static readonly SEQ_HEAL_COOLDOWN_MS = 4_000;
+	/** 20s, raised from 4s (post-merge CI evidence): the cursor only advances
+	 *  via replay, so under ACTIVE editing every fresh-seq op is a "behind"
+	 *  detection and the window bounds replay rate — at 4s the replays' REST
+	 *  paging measurably loaded the delivery path the e2e suite times (main
+	 *  stayed ~50-67% red post-merge). A true missed broadcast still heals
+	 *  within one window; before gap-heal existed it waited for the next
+	 *  checkpoint/reconnect or forever. */
+	private static readonly SEQ_HEAL_COOLDOWN_MS = 20_000;
 
 	/** Returns the number of ops applied across this replay (incl. any coalesced
 	 *  re-run) plus the sets of server note-ids and attachment paths seen

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -448,3 +448,69 @@ describe("OAuthAuth self-heal on definitive rejection", () => {
 		expect(auth.getRefreshToken()).toBe("engram_rt_live");
 	});
 });
+
+describe("OAuthAuth late-rotation adoption (deadline-abandoned refresh)", () => {
+	// review MAJOR-1: a deadline-abandoned refresh may still have rotated the
+	// token server-side. The old token is then consumed; replaying it later
+	// 401s definitively and force-re-links a healthy install. doRefresh must
+	// (a) adopt a late success and (b) reuse the pending request on retry
+	// instead of replaying the sent token.
+	const DEADLINE = (OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS;
+
+	it("adopts a rotation that resolves after the deadline", async () => {
+		(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS = 20;
+		try {
+			let resolveLate: (v: {
+				access_token: string;
+				refresh_token: string;
+				expires_in: number;
+			}) => void = () => {};
+			const refreshFn = mock(
+				() =>
+					new Promise<{ access_token: string; refresh_token: string; expires_in: number }>(
+						(res) => {
+							resolveLate = res;
+						},
+					),
+			);
+			const rotated = mock(async () => {});
+			const auth = new OAuthAuth("engram_rt_old", "vault-1", "u@test.com", refreshFn, rotated);
+
+			await expect(auth.getToken()).rejects.toThrow(/timed out/);
+			// The server committed the rotation; the response arrives late.
+			resolveLate({ access_token: "jwt_late", refresh_token: "engram_rt_late", expires_in: 3600 });
+			await new Promise((r) => setTimeout(r, 5));
+
+			expect(auth.getRefreshToken()).toBe("engram_rt_late");
+			expect(rotated).toHaveBeenCalledTimes(1);
+			// The adopted access token serves the next getToken without a new refresh.
+			refreshFn.mockClear();
+			expect(await auth.getToken()).toBe("jwt_late");
+			expect(refreshFn).not.toHaveBeenCalled();
+		} finally {
+			(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS = DEADLINE;
+		}
+	});
+
+	it("retry reuses the pending request instead of replaying the sent token", async () => {
+		(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS = 20;
+		try {
+			const refreshFn = mock(
+				() =>
+					new Promise<{ access_token: string; refresh_token: string; expires_in: number }>(
+						() => {},
+					),
+			);
+			const auth = new OAuthAuth("engram_rt_old", "vault-1", "u@test.com", refreshFn);
+
+			await expect(auth.getToken()).rejects.toThrow(/timed out/);
+			await expect(auth.getToken()).rejects.toThrow(/timed out/);
+
+			// One network attempt total: the second getToken reused the pending raw.
+			expect(refreshFn).toHaveBeenCalledTimes(1);
+			expect(auth.getRefreshToken()).toBe("engram_rt_old");
+		} finally {
+			(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS = DEADLINE;
+		}
+	});
+});

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -467,18 +467,30 @@ describe("OAuthAuth late-rotation adoption (deadline-abandoned refresh)", () => 
 			}) => void = () => {};
 			const refreshFn = mock(
 				() =>
-					new Promise<{ access_token: string; refresh_token: string; expires_in: number }>(
-						(res) => {
-							resolveLate = res;
-						},
-					),
+					new Promise<{
+						access_token: string;
+						refresh_token: string;
+						expires_in: number;
+					}>((res) => {
+						resolveLate = res;
+					}),
 			);
 			const rotated = mock(async () => {});
-			const auth = new OAuthAuth("engram_rt_old", "vault-1", "u@test.com", refreshFn, rotated);
+			const auth = new OAuthAuth(
+				"engram_rt_old",
+				"vault-1",
+				"u@test.com",
+				refreshFn,
+				rotated,
+			);
 
 			await expect(auth.getToken()).rejects.toThrow(/timed out/);
 			// The server committed the rotation; the response arrives late.
-			resolveLate({ access_token: "jwt_late", refresh_token: "engram_rt_late", expires_in: 3600 });
+			resolveLate({
+				access_token: "jwt_late",
+				refresh_token: "engram_rt_late",
+				expires_in: 3600,
+			});
 			await new Promise((r) => setTimeout(r, 5));
 
 			expect(auth.getRefreshToken()).toBe("engram_rt_late");
@@ -488,7 +500,8 @@ describe("OAuthAuth late-rotation adoption (deadline-abandoned refresh)", () => 
 			expect(await auth.getToken()).toBe("jwt_late");
 			expect(refreshFn).not.toHaveBeenCalled();
 		} finally {
-			(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS = DEADLINE;
+			(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS =
+				DEADLINE;
 		}
 	});
 
@@ -497,9 +510,11 @@ describe("OAuthAuth late-rotation adoption (deadline-abandoned refresh)", () => 
 		try {
 			const refreshFn = mock(
 				() =>
-					new Promise<{ access_token: string; refresh_token: string; expires_in: number }>(
-						() => {},
-					),
+					new Promise<{
+						access_token: string;
+						refresh_token: string;
+						expires_in: number;
+					}>(() => {}),
 			);
 			const auth = new OAuthAuth("engram_rt_old", "vault-1", "u@test.com", refreshFn);
 
@@ -510,7 +525,8 @@ describe("OAuthAuth late-rotation adoption (deadline-abandoned refresh)", () => 
 			expect(refreshFn).toHaveBeenCalledTimes(1);
 			expect(auth.getRefreshToken()).toBe("engram_rt_old");
 		} finally {
-			(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS = DEADLINE;
+			(OAuthAuth as unknown as { REFRESH_DEADLINE_MS: number }).REFRESH_DEADLINE_MS =
+				DEADLINE;
 		}
 	});
 });


### PR DESCRIPTION
Correction to #278's per-path seq fence, caught by main run 29881173619 (`test_85_missed_delivery_no_deletion`).

**Failure:** device B pushed a local edit while a server edit sat undelivered. The server merged both into the row under the same seq B had just observed via its own push echo, so the `<=` fence classified the row as history (`stale row (seq 89/89) — history, skip`) and B never converged to the merged content.

**Fix:** strict `<`. Only rows provably *behind* the per-path high-water are history. The truly-stale equal-seq case (checkpoint-lagged projection of the op just applied) is already covered by the upstream `serverHash` equality gate, so the revert-ping-pong protection from #278 is preserved (pre-merge storm rows sit strictly below the high-water).

This ambiguity (seq equality cannot distinguish "lagged projection" from "merge containing unseen edits") is inherent to snapshot backfill — the proper fix is Phase E's routing of CRDT rows through the Yjs delta converge (`docs/context/d2-seq-replay-stale-snapshot-stomp.md`, direction 1).

Gate: tsc + biome + 2169 tests green. No version bump (release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJksd3C2xLkXyucHRRnuVC