### PR TITLE
feat(sync): socket-native live-bound converge — delete the REST backstop (single-path D3)

### DIFF
--- a/main.js
+++ b/main.js
@@ -12483,10 +12483,13 @@ var _CrdtManager = class _CrdtManager {
   /**
    * Mark `noteId` as having completed its server handshake (STEP2 received).
    * Called by `CrdtChannel.handleFrame` after any inbound sync frame is applied
-   * to the doc. Idempotent — safe to call on every inbound frame.
+   * to the doc. Idempotent — safe to call on every inbound frame. Also fires
+   * `opts.onSynced` (fix wave 1) — this is the op-level "real ops landed"
+   * signal SyncEngine commits a staged live-bound convergence on.
    */
   markSynced(noteId) {
-    this.synced.add(this.docId(noteId));
+    var _a, _b;
+    this.synced.add(this.docId(noteId)), (_b = (_a = this.opts).onSynced) == null || _b.call(_a, noteId);
   }
   /**
    * Returns true if `noteId`'s handshake has completed this session (i.e.
@@ -13235,7 +13238,10 @@ var EngramApi = class _EngramApi {
   static async probeHealth(rawUrl) {
     let base = _EngramApi.normalizeBaseUrl(rawUrl);
     try {
-      let resp = await (0, import_obsidian.requestUrl)({ url: `${base}/health`, method: "GET", throw: !1 }), body = null;
+      let resp = await withTimeout(
+        (0, import_obsidian.requestUrl)({ url: `${base}/health`, method: "GET", throw: !1 }),
+        1e4
+      ), body = null;
       try {
         body = resp.json;
       } catch (e) {
@@ -15389,7 +15395,8 @@ var SEARCH_VIEW_TYPE = "engram-search-view", SearchView = class extends import_o
 var import_obsidian20 = require("obsidian");
 
 // src/device-flow-modal.ts
-var import_obsidian10 = require("obsidian"), DeviceFlowModal = class extends import_obsidian10.Modal {
+var import_obsidian10 = require("obsidian");
+var DeviceFlowModal = class extends import_obsidian10.Modal {
   constructor(app, plugin) {
     super(app);
     this.resolve = () => {
@@ -15425,13 +15432,16 @@ var import_obsidian10 = require("obsidian"), DeviceFlowModal = class extends imp
       client_id: this.plugin.settings.clientId
     };
     vaultName && (body.vault_name = vaultName);
-    let resp = await (0, import_obsidian10.requestUrl)({
-      url: `${apiUrl}/auth/device`,
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-      throw: !1
-    });
+    let resp = await withTimeout(
+      (0, import_obsidian10.requestUrl)({
+        url: `${apiUrl}/auth/device`,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        throw: !1
+      }),
+      15e3
+    );
     if (resp.status < 200 || resp.status >= 300)
       throw new Error(`HTTP ${resp.status}`);
     return resp.json;
@@ -15459,13 +15469,16 @@ var import_obsidian10 = require("obsidian"), DeviceFlowModal = class extends imp
           return;
         }
         try {
-          let resp = await (0, import_obsidian10.requestUrl)({
-            url: `${apiUrl}/auth/device/token`,
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ device_code: deviceCode }),
-            throw: !1
-          });
+          let resp = await withTimeout(
+            (0, import_obsidian10.requestUrl)({
+              url: `${apiUrl}/auth/device/token`,
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ device_code: deviceCode }),
+              throw: !1
+            }),
+            15e3
+          );
           if (resp.status === 428) return;
           if (resp.status >= 200 && resp.status < 300) {
             this.pollInterval && window.clearInterval(this.pollInterval);
@@ -16861,15 +16874,19 @@ var import_obsidian16 = require("obsidian");
 var import_obsidian15 = require("obsidian");
 
 // src/waitlist.ts
-var import_obsidian14 = require("obsidian"), WAITLIST_ENDPOINT = "https://engram.page/api/waitlist";
+var import_obsidian14 = require("obsidian");
+var WAITLIST_ENDPOINT = "https://engram.page/api/waitlist";
 async function submitWaitlistEmail(email) {
-  let resp = await (0, import_obsidian14.requestUrl)({
-    url: WAITLIST_ENDPOINT,
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, source: "obsidian-plugin" }),
-    throw: !1
-  });
+  let resp = await withTimeout(
+    (0, import_obsidian14.requestUrl)({
+      url: WAITLIST_ENDPOINT,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, source: "obsidian-plugin" }),
+      throw: !1
+    }),
+    15e3
+  );
   if (resp.status < 200 || resp.status >= 300)
     throw new Error(`waitlist signup failed: ${resp.status}`);
 }
@@ -17982,9 +17999,35 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     /** Per-note re-handshake attempt tracking for the live-bound catch-up path,
      *  keyed by note_id. `hash` is the server content_hash being retried; a new
      *  hash starts a fresh episode. Purely diagnostic now (the logged attempt
-     *  number): convergence comes from the deterministic REST delta pull, and a
-     *  failed pull retries at the 5-min poll cadence — no give-up, no storm. */
+     *  number, and cleared on commit) — convergence recording lives entirely in
+     *  `commitCrdtConvergence`; this map never gates a retry. */
     this.crdtRehandshakeAttempts = /* @__PURE__ */ new Map();
+    /** Fix wave 1 (single-path D3 review): staged convergence for a diverged
+     *  LIVE-BOUND note, keyed by note_id. `socketConvergeLiveBound` no longer
+     *  verifies-and-records by text equality — text equality does not prove
+     *  the doc holds the server's actual Yjs ops (two independently-typed
+     *  identical bodies are a disjoint lineage; recording on that basis is the
+     *  duplication class this replaces). Instead a diverged pull entry STAGES
+     *  what it would record here, and `commitCrdtConvergence` (wired from
+     *  CrdtManager's onSynced, fired only when a real inbound frame leaves the
+     *  doc non-empty) commits it — actual op-level proof, not a text guess. A
+     *  fresh content_hash overwrites any prior stage (new episode); nothing
+     *  else prunes it — `commitCrdtConvergence` re-resolves the current path
+     *  via noteIdMap and no-ops if the id was deleted, so a stale stage can
+     *  never write syncState at a dead path. */
+    this.pendingConvergence = /* @__PURE__ */ new Map();
+    /** Fix wave 1: per-note_id cooldown for `socketConvergeLiveBound`'s STEP1
+     *  re-handshake — bounds how often a live-bound note can re-fire reset+
+     *  enroll (open, catch-up, and manifest heal can all independently detect
+     *  the same divergence in quick succession; unconditional firing drains
+     *  the handshake budget, the #193 starvation class). Value = last-fired
+     *  `Date.now()`. `healCooldownMs` is a public instance field so tests can
+     *  shrink it. */
+    this.crdtHealCooldown = /* @__PURE__ */ new Map();
+    /** See `crdtHealCooldown`. 30s: long enough that open+catch-up+heal racing
+     *  on the same note collapse to one handshake, short enough that a
+     *  genuinely-still-diverged note keeps retrying within a session. */
+    this.healCooldownMs = 3e4;
     /** Optional CRDT enrollment tracker. When set, a pull that surfaces a
      *  CRDT-managed markdown note we don't have locally enrolls it (sends a
      *  sync-step-1) so the body is pulled over the y-protocols handshake — the
@@ -19817,19 +19860,67 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       return rlog().warn("crdt", `REST converge failed for ${path}: ${errMsg(e)}`), null;
     }
   }
-  /** Deterministic catch-up for a diverged LIVE-BOUND note: pull the delta
-   *  since our real state vector over REST and apply it to the live Y.Doc —
-   *  the editor binding paints it, no disk write. Returns true only when the
-   *  doc verifiably reached server state (applied, no pending gap), so the
-   *  caller records convergence for delivered data ONLY. Best-effort:
-   *  isolates its own failure, never throws. */
-  async restConvergeLiveBound(path, noteId) {
-    let head = await this.restConvergeCore(path, noteId);
-    return head === null ? !1 : (this.setCrdtHead(path, head), rlog().info("crdt", `REST converge: live-bound ${path} caught up to head=${head}`), !0);
+  /** Socket-native re-handshake for a diverged LIVE-BOUND note (single-path
+   *  D3, fix wave 1). Supersedes the original verify-by-text design: text
+   *  equality between the doc's projection and a row snapshot does NOT prove
+   *  the doc holds the server's actual Yjs ops — two independently-typed
+   *  identical bodies are a disjoint lineage, and recording convergence on
+   *  that basis let the doubling class through. Also, that design recorded
+   *  on a match WITHOUT re-registering the room subscription, so a doc that
+   *  happened to already match a DEAD room's row stayed silently deaf.
+   *
+   *  Always fires STEP1 (`reset`+`enroll`) on a diverged row — restores
+   *  main's re-registration semantics unconditionally, no text compare.
+   *  Convergence is recorded separately and ONLY on op-level proof: see
+   *  `commitCrdtConvergence`, fired from CrdtManager's `onSynced` when a
+   *  real inbound frame actually applies non-empty. Cooldown-gated per
+   *  note_id (`crdtHealCooldown`/`healCooldownMs`) so open+catch-up+heal all
+   *  independently detecting the same divergence collapses to one handshake
+   *  instead of draining the handshake budget (#193 starvation class).
+   *  Never throws. */
+  socketConvergeLiveBound(path, noteId) {
+    let last2 = this.crdtHealCooldown.get(noteId);
+    if (last2 !== void 0 && Date.now() - last2 < this.healCooldownMs) {
+      devLog().log("crdt", `socket converge: cooldown skip for ${path}`);
+      return;
+    }
+    this.crdtEnrollment && (this.crdtHealCooldown.set(noteId, Date.now()), this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId), rlog().info("crdt", `socket converge: re-handshake fired for ${path}`));
+  }
+  /** Commit a staged live-bound convergence (see `pendingConvergence`) — the
+   *  ONLY place that leg's `serverHash`/`version`/`seq` get written. Wired
+   *  from CrdtManager's `onSynced` (crdt/wiring.ts), which fires from
+   *  `CrdtChannel.handleFrame` exactly when an inbound sync frame leaves the
+   *  doc's text non-empty — real ops landed, not a guess. Idempotent and
+   *  cheap when nothing is staged (steady-state live traffic fires this on
+   *  every frame). Re-resolves the CURRENT path via `noteIdMap` rather than
+   *  trusting the path captured at stage time, so a rename (path moved) or
+   *  delete (id unmapped) between staging and commit can't write syncState
+   *  at a stale/dead path — no separate teardown hook needed. Never throws
+   *  into the CRDT manager's synchronous callback. */
+  async commitCrdtConvergence(noteId) {
+    var _a, _b, _c;
+    let staged = this.pendingConvergence.get(noteId);
+    if (!staged) return;
+    this.pendingConvergence.delete(noteId), this.crdtRehandshakeAttempts.delete(noteId);
+    let path = (_a = this.noteIdMap) == null ? void 0 : _a.pathForId(noteId);
+    if (path)
+      try {
+        let boundFile = this.app.vault.getFileByPath(path), stored = this.syncState.get(path), localHash = (_b = stored == null ? void 0 : stored.hash) != null ? _b : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
+        this.syncState.set(path, {
+          ...(_c = this.syncState.get(path)) != null ? _c : {},
+          hash: localHash,
+          serverHash: staged.serverHash,
+          version: staged.version,
+          seq: staged.seq
+        }), rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
+      } catch (e) {
+        rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
+      }
   }
   /** Deterministic catch-up for a diverged NOT-live-bound (cold) CRDT note:
-   *  same Yjs-delta core as restConvergeLiveBound, but there is no editor
-   *  binding to paint the doc. Replaces the old content-snapshot
+   *  same Yjs-delta REST core the live-bound leg used before the D3 socket
+   *  migration (cold-leg REST stays — see restConvergeCore), but there is no
+   *  editor binding to paint the doc. Replaces the old content-snapshot
    *  `flushFromCrdt(path, content)` backfill, which reverted a fresher live
    *  merge when the seq gap-heal's behind-detector fires a catch-up replay
    *  DURING active editing on this note from another device — the feed's
@@ -19849,9 +19940,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  then clobber it (the exact revert family this fixes elsewhere).
    *  `projectedText` is read once, purely so the caller can hash what
    *  actually landed for syncState bookkeeping — never to write disk again.
-   *  Returns that text on success, or null on failure/pending-gap — mirrors
-   *  restConvergeLiveBound's retry contract (never record convergence for
-   *  data that hasn't arrived). */
+   *  Returns that text on success, or null on failure/pending-gap — never
+   *  record convergence for data that hasn't arrived (same principle the
+   *  live-bound leg's `commitCrdtConvergence` applies via op-level proof). */
   async restConvergeAndFlush(path, noteId) {
     let head = await this.restConvergeCore(path, noteId);
     if (head === null || !this.crdt) return null;
@@ -19870,9 +19961,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  that missed a live announce/STEP2 during a fan-out storm, WITHOUT its
    *  per-open synchronous manifest-hash check + forced re-handshake, the
    *  #203 false-fire that caused the open-path lag). Fire-and-forget from
-   *  file-open: a single note, one delta-since-our-real-state-vector via the
-   *  existing guarded `restConvergeLiveBound` — empty (near-no-op) when
-   *  already converged. Live-bound-only first cut (design decision iii): a
+   *  file-open: a single note, one STEP1 re-handshake via
+   *  `socketConvergeLiveBound` — cheap even when already converged, since
+   *  the per-note cooldown collapses a redundant fire into a no-op.
+   *  Live-bound-only first cut (design decision iii): a
    *  just-opened note is live-bound after CrdtLiveViews.refresh(), so this
    *  covers the real case without a vault-wide heads fetch on every open; an
    *  idle note is still covered by reconnect catch-up (#5). Never throws. */
@@ -19887,7 +19979,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           return;
         }
         if (!this.isLiveBound(normalized)) return;
-        await this.restConvergeLiveBound(normalized, noteId);
+        this.socketConvergeLiveBound(normalized, noteId);
       } catch (e) {
         rlog().warn("crdt", `healNoteOnOpen ${path}: ${errMsg(e)}`);
       }
@@ -20356,13 +20448,20 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  Before the REST purge, fullSync's pull had a SEPARATE cursor from the
    *  socket replay, so it re-delivered the diverged note and converged it; the
    *  cursor unification removed that. This restores it: a manifest snapshot
-   *  re-detects the divergence every catch-up and re-fires the same idempotent
-   *  `restConvergeLiveBound` (a converged note's serverHash already matches and
-   *  is skipped). Only live-bound notes (the editor owns the body, so disk
-   *  writes are unsafe) need it — idle divergences heal through the normal
-   *  op-log apply. Best-effort; never throws into catchUp. */
+   *  re-detects the divergence every catch-up and re-fires the STEP1
+   *  re-handshake (cooldown-gated, so a repeat detection is cheap). Only
+   *  live-bound notes (the editor owns the body, so disk writes are unsafe)
+   *  need it — idle divergences heal through the normal op-log apply.
+   *
+   *  Recording: this leg STAGES the manifest's `content_hash` into
+   *  `pendingConvergence` (fix wave 1) rather than recording it directly —
+   *  the manifest carries hashes only (keyed HMAC, uncomputable
+   *  client-side), so this leg can never itself prove the doc holds the
+   *  server's ops. `commitCrdtConvergence` commits the stage once a real
+   *  STEP2/update frame actually applies. Best-effort; never throws into
+   *  catchUp. */
   async healDivergedLiveBoundNotes(manifest) {
-    var _a, _b, _c, _d, _e;
+    var _a, _b, _c;
     if (!(!manifest || !this.crdt))
       for (let entry of manifest.notes) {
         let path = (0, import_obsidian21.normalizePath)(entry.path);
@@ -20372,14 +20471,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         let noteId = (_c = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(path)) != null ? _b : entry.id) != null ? _c : null;
         if (noteId)
           try {
-            if (await this.restConvergeLiveBound(path, noteId) && entry.content_hash) {
-              let boundFile = this.app.vault.getFileByPath(path), localHash = (_d = stored == null ? void 0 : stored.hash) != null ? _d : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
-              this.syncState.set(path, {
-                ...(_e = this.syncState.get(path)) != null ? _e : {},
-                hash: localHash,
-                serverHash: entry.content_hash
-              });
-            }
+            entry.content_hash && this.pendingConvergence.set(noteId, { path, serverHash: entry.content_hash }), this.socketConvergeLiveBound(path, noteId);
           } catch (e) {
             rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
           }
@@ -20389,7 +20481,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  Returns true when a file was actually created, modified, or trashed.
    *  When forceOverwrite is true, skip conflict detection and always apply. */
   async applyChange(change, forceOverwrite = !1) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y, _z, _A, _B;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y, _z;
     if (this.shouldIgnore(change.path))
       return devLog().log("pull", `applyChange SKIP (ignored): ${change.path}`), !1;
     let normalized = (0, import_obsidian21.normalizePath)(change.path);
@@ -20470,24 +20562,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         else if (change.content_hash && (stored == null ? void 0 : stored.serverHash) !== change.content_hash)
           if (this.isLiveBound(normalized)) {
             let key = noteId != null ? noteId : normalized, prevAttempt = this.crdtRehandshakeAttempts.get(key), attempts = (prevAttempt == null ? void 0 : prevAttempt.hash) === change.content_hash ? prevAttempt.attempts + 1 : 1;
-            if (rlog().warn(
+            rlog().warn(
               "pull",
-              `CRDT catch-up: diverged + live-bound, re-handshake + REST converge (attempt ${attempts}) ${change.path}`
-            ), noteId && this.crdtEnrollment && (this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId)), noteId ? await this.restConvergeLiveBound(normalized, noteId) : !1) {
-              this.crdtRehandshakeAttempts.delete(key);
-              let boundFile = this.app.vault.getFileByPath(normalized), localHash = (_s = stored == null ? void 0 : stored.hash) != null ? _s : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
-              this.syncState.set(normalized, {
-                ...(_t2 = this.syncState.get(normalized)) != null ? _t2 : {},
-                hash: localHash,
-                serverHash: change.content_hash,
-                version: change.version,
-                seq: change.seq
-              });
-            } else
-              this.crdtRehandshakeAttempts.set(key, {
-                hash: change.content_hash,
-                attempts
-              });
+              `CRDT catch-up: diverged + live-bound, socket re-handshake (attempt ${attempts}) ${change.path}`
+            ), this.crdtRehandshakeAttempts.set(key, { hash: change.content_hash, attempts }), noteId && (this.pendingConvergence.set(noteId, {
+              path: normalized,
+              serverHash: change.content_hash,
+              version: change.version,
+              seq: change.seq
+            }), this.socketConvergeLiveBound(normalized, noteId));
           } else {
             let localFile = this.app.vault.getFileByPath(normalized), localNow = localFile ? await this.app.vault.cachedRead(localFile) : null;
             if (localNow !== null && (stored == null ? void 0 : stored.hash) !== void 0 && fnv1a(localNow) !== stored.hash && localNow !== content)
@@ -20502,7 +20585,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               );
               let flushed = await this.restConvergeAndFlush(normalized, noteId);
               flushed !== null ? this.syncState.set(normalized, {
-                ...(_u = this.syncState.get(normalized)) != null ? _u : {},
+                ...(_s = this.syncState.get(normalized)) != null ? _s : {},
                 hash: fnv1a(flushed),
                 version: change.version,
                 serverHash: change.content_hash,
@@ -20547,14 +20630,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           "conflict",
           `Detected: ${change.path} | firstSync=${firstSync} | localHash=${localHash} | syncedHash=${lastSyncedHash != null ? lastSyncedHash : "none"} | localMtime=${new Date(localMtime * 1e3).toISOString()} | remoteMtime=${new Date(change.mtime * 1e3).toISOString()} | localLen=${localContent.length} | remoteLen=${content.length}`
         );
-        let pullBase = (_v = this.baseStore) == null ? void 0 : _v.get(normalized);
+        let pullBase = (_t2 = this.baseStore) == null ? void 0 : _t2.get(normalized);
         if (pullBase) {
           let merge2 = threeWayMerge(pullBase.content, localContent, content);
           if (merge2.clean) {
             await this.modifyFile(existing, merge2.merged), this.syncState.set(normalized, {
               hash: fnv1a(merge2.merged),
               version: change.version
-            }), change.version != null && ((_w = this.baseStore) == null || _w.set(normalized, merge2.merged, change.version));
+            }), change.version != null && ((_u = this.baseStore) == null || _u.set(normalized, merge2.merged, change.version));
             try {
               await this.pushFile(existing, !0);
             } catch (e) {
@@ -20605,7 +20688,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             await this.createFileWithFolders(conflictPath, content), this.syncState.set((0, import_obsidian21.normalizePath)(conflictPath), {
               hash: fnv1a(content),
               version: change.version
-            }), change.version != null && ((_x = this.baseStore) == null || _x.set(
+            }), change.version != null && ((_v = this.baseStore) == null || _v.set(
               (0, import_obsidian21.normalizePath)(conflictPath),
               content,
               change.version
@@ -20627,7 +20710,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             await this.modifyFile(existing, resolution.mergedContent), this.syncState.set(normalized, {
               hash: fnv1a(resolution.mergedContent),
               version: change.version
-            }), change.version != null && ((_y = this.baseStore) == null || _y.set(
+            }), change.version != null && ((_w = this.baseStore) == null || _w.set(
               normalized,
               resolution.mergedContent,
               change.version
@@ -20650,12 +20733,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           hash: localHash,
           version: change.version,
           serverHash: change.content_hash
-        }), change.version != null && ((_z = this.baseStore) == null || _z.set(normalized, content, change.version)), rlog().info("pull", `Unchanged: ${change.path}`), !1;
+        }), change.version != null && ((_x = this.baseStore) == null || _x.set(normalized, content, change.version)), rlog().info("pull", `Unchanged: ${change.path}`), !1;
       return devLog().log("pull", `applyChange OVERWRITE: ${change.path} (len=${content.length})`), await this.modifyFile(existing, content), this.syncState.set(normalized, {
         hash: fnv1a(content),
         version: change.version,
         serverHash: change.content_hash
-      }), change.version != null && ((_A = this.baseStore) == null || _A.set(normalized, content, change.version)), rlog().info(
+      }), change.version != null && ((_y = this.baseStore) == null || _y.set(normalized, content, change.version)), rlog().info(
         "pull",
         `Applied: ${change.path} | localLen=${localContent.length} | remoteLen=${content.length}`
       ), !0;
@@ -20674,7 +20757,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       hash: fnv1a(content),
       version: change.version,
       serverHash: change.content_hash
-    }), change.version != null && ((_B = this.baseStore) == null || _B.set(normalized, content, change.version)), rlog().info("pull", `Created: ${change.path} | len=${content.length}`), !0;
+    }), change.version != null && ((_z = this.baseStore) == null || _z.set(normalized, content, change.version)), rlog().info("pull", `Created: ${change.path} | len=${content.length}`), !0;
   }
   /** Apply a remote attachment change to the vault.
    *  If contentBase64 is provided (from WebSocket), use it directly. Otherwise fetch it.
@@ -21645,7 +21728,8 @@ _SyncEngine.MANIFEST_OWNERS_TTL_MS = 3e4, _SyncEngine.SEQ_HEAL_COOLDOWN_MS = 4e3
 var SyncEngine = _SyncEngine;
 
 // src/update-check.ts
-var import_obsidian22 = require("obsidian"), MANIFEST_URL = "https://raw.githubusercontent.com/engram-app/Engram-obsidian/master/manifest.json";
+var import_obsidian22 = require("obsidian");
+var MANIFEST_URL = "https://raw.githubusercontent.com/engram-app/Engram-obsidian/master/manifest.json";
 function isNewerVersion(latest, current) {
   var _a, _b;
   let a = latest.split(".").map((n) => Number.parseInt(n, 10) || 0), b = current.split(".").map((n) => Number.parseInt(n, 10) || 0);
@@ -21658,7 +21742,10 @@ function isNewerVersion(latest, current) {
 async function checkForPluginUpdate(currentVersion) {
   var _a;
   try {
-    let resp = await (0, import_obsidian22.requestUrl)({ url: MANIFEST_URL, method: "GET", throw: !1 });
+    let resp = await withTimeout(
+      (0, import_obsidian22.requestUrl)({ url: MANIFEST_URL, method: "GET", throw: !1 }),
+      1e4
+    );
     if (resp.status !== 200) return null;
     let latest = (_a = resp.json) == null ? void 0 : _a.version;
     return typeof latest == "string" && isNewerVersion(latest, currentVersion) ? latest : null;
@@ -22872,6 +22959,12 @@ function createCrdtWiring(deps) {
         "crdt",
         `IndexedDB persist error for ${path} \u2014 sync continues in-memory: ${errMsg(err)}`
       );
+    },
+    // Fix wave 1: op-level convergence proof. Fires on every non-empty
+    // inbound frame; commitCrdtConvergence is idempotent (no-op when nothing
+    // is staged for this note_id), so fire-and-forget is safe here.
+    onSynced: (noteId) => {
+      syncEngine.commitCrdtConvergence(noteId);
     }
   }), channel = new CrdtChannel({
     manager,
@@ -23801,13 +23894,16 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     var _a, _b, _c;
     if (this.settings.refreshToken) {
       let refreshFn = async (token) => {
-        let base = this.settings.apiUrl.replace(/\/+$/, ""), apiUrl = base.endsWith("/api") ? base : `${base}/api`, resp = await (0, import_obsidian26.requestUrl)({
-          url: `${apiUrl}/auth/token/refresh`,
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refresh_token: token }),
-          throw: !1
-        });
+        let base = this.settings.apiUrl.replace(/\/+$/, ""), apiUrl = base.endsWith("/api") ? base : `${base}/api`, resp = await withTimeout(
+          (0, import_obsidian26.requestUrl)({
+            url: `${apiUrl}/auth/token/refresh`,
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ refresh_token: token }),
+            throw: !1
+          }),
+          15e3
+        );
         if (resp.status < 200 || resp.status >= 300) {
           let e = new Error(`Refresh failed: ${resp.status}`);
           throw e.status = resp.status, e;

--- a/src/crdt/live/live-views.ts
+++ b/src/crdt/live/live-views.ts
@@ -4,12 +4,19 @@ import { MarkdownView as MdView, normalizePath } from "obsidian";
 import { Awareness } from "y-protocols/awareness";
 import type * as Y from "yjs";
 import * as YDoc from "yjs";
+import { devLog } from "../../dev-log";
+import { errMsg } from "../../error-util";
 import type { CrdtEnrollment } from "../enrollment";
 import type { CrdtManager } from "../manager";
 import { EditorController } from "./editor-controller";
 import { CrdtFrontmatterHook } from "./frontmatter-hook";
 import { getEditorViewForLeaf, getMarkdownFilePath } from "./obsidian-internals";
 import { CrdtReadingView } from "./reading-view";
+
+/** Fix wave 6: trailing debounce window for `requestSaveForBoundPath` — a
+ *  burst of remote deltas into the same bound doc collapses to one
+ *  `requestSave()` call. */
+const SAVE_NUDGE_DEBOUNCE_MS = 300;
 
 /** Per-path viewer refcount. A "viewer" is any live binding (editor pane or
  *  reading-view) currently holding a note open. While a path has at least one
@@ -85,6 +92,8 @@ export class CrdtLiveViews {
 	private readonly localAwareness = new Awareness(this.awarenessDoc);
 	/** One EditorController per live CodeMirror EditorView. */
 	private readonly controllers = new Map<EditorView, EditorController>();
+	/** Fix wave 6: per-path trailing-debounce timers for `requestSaveForBoundPath`. */
+	private readonly saveNudgeTimers = new Map<string, number>();
 
 	constructor(deps: CrdtLiveViewsDeps) {
 		this.deps = deps;
@@ -105,6 +114,45 @@ export class CrdtLiveViews {
 
 	isBound(path: string): boolean {
 		return this.refcount.isBound(path);
+	}
+
+	/** Fix wave 6: nudge Obsidian's own save pipeline for the bound editor
+	 *  showing `path`, after a remote merge painted into it. `onFlushToDisk`
+	 *  skips the disk write for a bound path (the editor owns the file) — but
+	 *  headless/unfocused Obsidian (CI) doesn't promptly flush a
+	 *  programmatically-updated buffer on its own, so a converged CRDT doc can
+	 *  sit unsaved on disk for tens of seconds. `requestSave()` is Obsidian's
+	 *  own API for this (it flushes through Obsidian's pipeline, so it cannot
+	 *  fight the binding — it IS the binding-authoritative save).
+	 *
+	 *  Debounced per path (trailing, `SAVE_NUDGE_DEBOUNCE_MS`) so a burst of
+	 *  deltas from one remote edit collapses to one save call. No-op when
+	 *  `path` has no active viewer — nothing to nudge, and no burst to
+	 *  coalesce (also means a note that closes mid-debounce simply never
+	 *  fires, which is correct: the last-viewer-release flush below already
+	 *  covers that case via `onLastViewerRelease`). Never throws. */
+	requestSaveForBoundPath(path: string): void {
+		if (!this.isBound(path)) return;
+		const existing = this.saveNudgeTimers.get(path);
+		if (existing !== undefined) window.clearTimeout(existing);
+		const timer = window.setTimeout(() => {
+			this.saveNudgeTimers.delete(path);
+			this.doRequestSave(path);
+		}, SAVE_NUDGE_DEBOUNCE_MS);
+		this.saveNudgeTimers.set(path, timer);
+	}
+
+	private doRequestSave(path: string): void {
+		try {
+			for (const leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
+				const view = leaf.view;
+				if (!(view instanceof MdView)) continue;
+				if (getMarkdownFilePath(view) !== path) continue;
+				view.requestSave();
+			}
+		} catch (e) {
+			devLog().log("crdt", `requestSaveForBoundPath failed for ${path}: ${errMsg(e)}`);
+		}
 	}
 
 	/** The last viewer of `path` left: persist the current Y.Text to disk, then
@@ -211,6 +259,12 @@ export class CrdtLiveViews {
 			ctrl.release(cm);
 		}
 		this.controllers.clear();
+		// Fix wave 6: cancel any pending save-nudge timers — nothing to save
+		// into once the plugin is tearing down.
+		for (const timer of this.saveNudgeTimers.values()) {
+			window.clearTimeout(timer);
+		}
+		this.saveNudgeTimers.clear();
 		// Detach all frontmatter + reading-view hooks.
 		this.frontmatter.detachAll();
 		this.reading.detachAll();

--- a/src/crdt/live/live-views.ts
+++ b/src/crdt/live/live-views.ts
@@ -142,6 +142,19 @@ export class CrdtLiveViews {
 		this.saveNudgeTimers.set(path, timer);
 	}
 
+	/** Fix wave 7 (#191 slice): read the live buffer of the editor currently
+	 *  showing `path`, for commitCrdtConvergence's phantom-binding check.
+	 *  Returns null when nothing shows the path (nothing to compare). */
+	boundBufferText(path: string): string | null {
+		for (const leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
+			const view = leaf.view;
+			if (!(view instanceof MdView)) continue;
+			if (getMarkdownFilePath(view) !== path) continue;
+			return view.getViewData();
+		}
+		return null;
+	}
+
 	private doRequestSave(path: string): void {
 		try {
 			for (const leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {

--- a/src/crdt/manager.ts
+++ b/src/crdt/manager.ts
@@ -109,6 +109,17 @@ export interface CrdtManagerOptions {
 	 * (matches pre-gate behavior — every existing test is unaffected).
 	 */
 	canSendLive?: (docId: string) => boolean;
+	/**
+	 * Fix wave 1 (single-path D3 review): called from `markSynced` — i.e. every
+	 * time `CrdtChannel.handleFrame` applies an inbound sync frame that leaves
+	 * the doc's text non-empty. This is op-level proof the doc actually holds
+	 * server content, unlike a text-equality guess. Wired to
+	 * `SyncEngine.commitCrdtConvergence`, which commits any staged
+	 * `pendingConvergence` entry for this note_id. Fires on every non-empty
+	 * frame (STEP2 or a later live update), not just the first — the commit
+	 * side is idempotent (no-op when nothing is staged), so this is cheap.
+	 */
+	onSynced?: (noteId: string) => void;
 }
 
 interface Entry {
@@ -197,10 +208,13 @@ export class CrdtManager {
 	/**
 	 * Mark `noteId` as having completed its server handshake (STEP2 received).
 	 * Called by `CrdtChannel.handleFrame` after any inbound sync frame is applied
-	 * to the doc. Idempotent — safe to call on every inbound frame.
+	 * to the doc. Idempotent — safe to call on every inbound frame. Also fires
+	 * `opts.onSynced` (fix wave 1) — this is the op-level "real ops landed"
+	 * signal SyncEngine commits a staged live-bound convergence on.
 	 */
 	markSynced(noteId: string): void {
 		this.synced.add(this.docId(noteId));
+		this.opts.onSynced?.(noteId);
 	}
 
 	/**

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -34,6 +34,16 @@ export interface CrdtWiringDeps {
 	 *  the binding stays authoritative. Backed lazily by CrdtLiveViews (which is
 	 *  constructed after this wiring), so it must be a closure, not a value. */
 	isBound: (path: string) => boolean;
+	/** Fix wave 6: called whenever a remote-merge flush is skipped BECAUSE
+	 *  `path` is bound (i.e. right where the editor binding painted the
+	 *  update instead of a disk write). Headless/unfocused Obsidian (CI)
+	 *  doesn't promptly flush a programmatically-updated editor buffer to
+	 *  disk on its own — this is the nudge: the caller (main.ts, which HAS
+	 *  Obsidian API access — this file deliberately doesn't) requests
+	 *  Obsidian's own save pipeline for the bound view, debounced. Optional;
+	 *  omitted in tests that don't exercise it. Never throws (the caller's
+	 *  contract, not enforced here). */
+	onBoundUpdate?: (path: string) => void;
 	/** True once `noteId`'s crdt_create has been server-acked (its DB row
 	 *  exists) — CrdtManagerOptions.canSendLive. A brand-new note's live edits
 	 *  land in the Y.Doc immediately (never lost) but must NOT stream a
@@ -229,7 +239,13 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 				healUnknownNoteId(noteId, content);
 				return;
 			}
-			if (deps.isBound(path)) return; // live editor owns disk
+			if (deps.isBound(path)) {
+				// The editor owns disk — but a remote update just painted into it,
+				// and headless/unfocused Obsidian may not save that buffer for a
+				// long time on its own (fix wave 6). Nudge it.
+				deps.onBoundUpdate?.(path);
+				return;
+			}
 			// Propagate a disk-write failure so applyRemoteUpdate rejects and the
 			// caller leaves crdtHead unadvanced (#235). flushFromCrdt returns false
 			// ONLY on an actual write failure; a skip (gate closed / idempotent) and

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -19,6 +19,7 @@ type WiringSyncEngine = Pick<
 	| "applyPushedNoteUpdate"
 	| "discoverAnnouncedNote"
 	| "applyLiveOpWithSeq"
+	| "commitCrdtConvergence"
 >;
 
 export interface CrdtWiringDeps {
@@ -249,6 +250,10 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 				`IndexedDB persist error for ${path} — sync continues in-memory: ${errMsg(err)}`,
 			);
 		},
+		// Fix wave 1: op-level convergence proof. Fires on every non-empty
+		// inbound frame; commitCrdtConvergence is idempotent (no-op when nothing
+		// is staged for this note_id), so fire-and-forget is safe here.
+		onSynced: (noteId) => void syncEngine.commitCrdtConvergence(noteId),
 	});
 
 	const channel = new CrdtChannel({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1879,6 +1879,10 @@ export default class EngramSyncPlugin extends Plugin {
 						// Backed lazily: crdtLiveViews is constructed just below, so this
 						// closure must read the field at call time, not capture a value.
 						isBound: (path) => this.crdtLiveViews?.isBound(path) ?? false,
+						// Fix wave 6: headless/unfocused Obsidian (CI) doesn't promptly
+						// flush a programmatically-updated bound editor to disk — nudge
+						// Obsidian's own save pipeline after a remote merge paints in.
+						onBoundUpdate: (path) => this.crdtLiveViews?.requestSaveForBoundPath(path),
 						// Gate live crdt_msg sends on the note's create-ack (create-before-edit):
 						// a brand-new note's crdt_create must land before any crdt_msg, or the
 						// server drops the edit (note_not_found) — see manager.ts canSendLive.

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,6 +433,16 @@ export default class EngramSyncPlugin extends Plugin {
 		// pre-seeded with the editor's content, so no in-flight edit is lost).
 		this.syncEngine.setCrdtEditorRebind((path) => this.crdtLiveViews?.rebindPath(path));
 
+		// Fix wave 7 (#191 slice): commitCrdtConvergence's phantom-binding
+		// check reads the bound editor's live buffer, and (on a rebind)
+		// nudges its save the same way wiring.ts's onBoundUpdate does.
+		this.syncEngine.setCrdtBoundBufferText(
+			(path) => this.crdtLiveViews?.boundBufferText(path) ?? null,
+		);
+		this.syncEngine.setCrdtRequestSave((path) =>
+			this.crdtLiveViews?.requestSaveForBoundPath(path),
+		);
+
 		// Base content store for 3-way merge (lazy-loaded after layout ready)
 		const basesPath = `${this.manifest.dir}/sync-bases.json`;
 		this.baseStore = new BaseStore(this.app.vault.adapter, basesPath);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3756,8 +3756,7 @@ export class SyncEngine {
 			const boundFile = this.app.vault.getFileByPath(path);
 			const stored = this.syncState.get(path);
 			const localHash =
-				stored?.hash ??
-				(boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0);
+				stored?.hash ?? (boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0);
 			this.syncState.set(path, {
 				...(this.syncState.get(path) ?? {}),
 				hash: localHash,
@@ -5137,7 +5136,10 @@ export class SyncEngine {
 							"pull",
 							`CRDT catch-up: diverged + live-bound, socket re-handshake (attempt ${attempts}) ${change.path}`,
 						);
-						this.crdtRehandshakeAttempts.set(key, { hash: change.content_hash, attempts });
+						this.crdtRehandshakeAttempts.set(key, {
+							hash: change.content_hash,
+							attempts,
+						});
 						if (noteId) {
 							// A fresh content_hash overwrites any prior stage — a new
 							// episode, never a stale commit of superseded server content.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5135,16 +5135,29 @@ export class SyncEngine {
 				// "we are behind" backfills a checkpoint-lagged projection over
 				// newer live content (the ModifyTest 40B/23B revert ping-pong; 1805
 				// backfills in one suite run). A row at or below the path's
-				// high-water seq (or recorded version) is history: skip the whole
-				// diverged block — nothing is recorded, so a genuinely newer row
-				// still converges on a later pass.
+				// high-water seq is history: skip the whole diverged block —
+				// nothing is recorded, so a genuinely newer row still converges on
+				// a later pass.
+				//
+				// seq is AUTHORITATIVE when both sides carry it (2026-07-22 D3 gate
+				// forensics, CI run 29917773065; issue #282's family): seq is the
+				// vault op-log position and strictly increases per materialized
+				// change, so it alone decides. version is only the FALLBACK when
+				// seq is unavailable on either side — version is checkpoint-lagged
+				// for CRDT notes (advances on checkpoint/materialization, not every
+				// live delta — see restConvergeCore's docstring), so an
+				// EQUAL-version row can legitimately carry content this device
+				// never saw. The old OR-of-both-checks let a stale-by-version-alone
+				// verdict mask a genuinely newer seq, fence-skipping the real edit
+				// (the deaf-note e2e gate flake: 2x "stale row" skips, the note
+				// converged only at teardown). The equal-SEQ case is unchanged
+				// (still <=, still history) — PR #280's scope, not touched here.
 				const staleRow =
-					(stored?.seq !== undefined &&
-						change.seq !== undefined &&
-						change.seq <= stored.seq) ||
-					(stored?.version !== undefined &&
-						change.version !== undefined &&
-						change.version <= stored.version);
+					stored?.seq !== undefined && change.seq !== undefined
+						? change.seq <= stored.seq
+						: stored?.version !== undefined &&
+							change.version !== undefined &&
+							change.version <= stored.version;
 				if (staleRow) {
 					rlog().info(
 						"pull",

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -684,14 +684,27 @@ export class SyncEngine {
 	 *  enroll (open, catch-up, and manifest heal can all independently detect
 	 *  the same divergence in quick succession; unconditional firing drains
 	 *  the handshake budget, the #193 starvation class). Value = last-fired
-	 *  `Date.now()`. `healCooldownMs` is a public instance field so tests can
-	 *  shrink it. */
+	 *  `Date.now()`, set ONLY when a handshake actually fires — never on a
+	 *  suppressed attempt. `healCooldownMs` is a public instance field so
+	 *  tests can shrink it. */
 	private crdtHealCooldown: Map<string, number> = new Map();
 
-	/** See `crdtHealCooldown`. 30s: long enough that open+catch-up+heal racing
-	 *  on the same note collapse to one handshake, short enough that a
-	 *  genuinely-still-diverged note keeps retrying within a session. */
-	healCooldownMs = 30_000;
+	/** Fix wave 2 (CI-found defect: `test_deaf_note_survives_handshake_rate_
+	 *  limit_and_heals_on_restore`): a poke suppressed by the cooldown must
+	 *  NOT be silently dropped — a deaf note's one recovery poke landing
+	 *  inside the window would otherwise never retry, stranding it until the
+	 *  next unrelated edit or the 5-min manifest pass. Mirrors
+	 *  `scheduleSeqHeal`'s trailing-edge throttle: a suppressed poke arms ONE
+	 *  trailing timer per note_id for the remaining window; further pokes for
+	 *  the same note while a trailing timer is armed coalesce into it (no
+	 *  second timer). Cleared in `destroy()`. */
+	private crdtHealTrailingTimers: Map<string, number> = new Map();
+
+	/** See `crdtHealCooldown`. 15s (fix wave 2, was 30s): long enough that
+	 *  open+catch-up+heal racing on the same note collapse to one handshake,
+	 *  short enough that a genuinely-still-diverged note keeps retrying
+	 *  within a session. */
+	healCooldownMs = 15_000;
 
 	/** Public: true once this SESSION observed this note's create-ack. Was
 	 *  formerly wired as `CrdtManagerOptions.canSendLive` in main.ts, but that
@@ -3720,17 +3733,41 @@ export class SyncEngine {
 	 *  note_id (`crdtHealCooldown`/`healCooldownMs`) so open+catch-up+heal all
 	 *  independently detecting the same divergence collapses to one handshake
 	 *  instead of draining the handshake budget (#193 starvation class).
-	 *  Never throws. */
+	 *
+	 *  Fix wave 2: a poke suppressed by the cooldown COALESCES into one
+	 *  trailing fire at window end (`crdtHealTrailingTimers`) instead of being
+	 *  dropped — mirrors `scheduleSeqHeal`'s trailing-edge throttle. Dropping
+	 *  it silently stranded a deaf note whose single recovery poke landed
+	 *  inside the window (CI: `test_deaf_note_survives_handshake_rate_limit_
+	 *  and_heals_on_restore`). Never throws. */
 	private socketConvergeLiveBound(path: string, noteId: string): void {
+		if (!this.crdtEnrollment) return;
 		const last = this.crdtHealCooldown.get(noteId);
-		if (last !== undefined && Date.now() - last < this.healCooldownMs) {
-			devLog().log("crdt", `socket converge: cooldown skip for ${path}`);
+		const now = Date.now();
+		if (last === undefined || now - last >= this.healCooldownMs) {
+			this.fireCrdtReHandshake(path, noteId);
 			return;
 		}
-		if (!this.crdtEnrollment) return;
+		if (this.crdtHealTrailingTimers.has(noteId)) {
+			devLog().log("crdt", `socket converge: cooldown skip for ${path} (already coalesced)`);
+			return;
+		}
+		devLog().log("crdt", `socket converge: cooldown skip for ${path} — arming trailing fire`);
+		const remaining = this.healCooldownMs - (now - last);
+		const timer = window.setTimeout(() => {
+			this.crdtHealTrailingTimers.delete(noteId);
+			this.fireCrdtReHandshake(path, noteId);
+		}, remaining);
+		this.crdtHealTrailingTimers.set(noteId, timer);
+	}
+
+	/** The actual STEP1 fire, shared by the immediate and trailing-coalesced
+	 *  paths in `socketConvergeLiveBound`. Records the cooldown timestamp —
+	 *  ONLY called on a real fire, never on a suppressed attempt. */
+	private fireCrdtReHandshake(path: string, noteId: string): void {
 		this.crdtHealCooldown.set(noteId, Date.now());
-		this.crdtEnrollment.reset(noteId);
-		this.crdtEnrollment.enroll(noteId);
+		this.crdtEnrollment?.reset(noteId);
+		this.crdtEnrollment?.enroll(noteId);
 		rlog().info("crdt", `socket converge: re-handshake fired for ${path}`);
 	}
 
@@ -7200,6 +7237,10 @@ export class SyncEngine {
 			window.clearTimeout(this.postPullDrainTimer);
 			this.postPullDrainTimer = null;
 		}
+		for (const timer of this.crdtHealTrailingTimers.values()) {
+			window.clearTimeout(timer);
+		}
+		this.crdtHealTrailingTimers.clear();
 		if (this.degradedNoticeTimer) window.clearTimeout(this.degradedNoticeTimer);
 		this.degradedNoticeTimer = null;
 		this.pendingDegraded.clear();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -673,10 +673,24 @@ export class SyncEngine {
 	 *  fresh content_hash overwrites any prior stage (new episode); nothing
 	 *  else prunes it — `commitCrdtConvergence` re-resolves the current path
 	 *  via noteIdMap and no-ops if the id was deleted, so a stale stage can
-	 *  never write syncState at a dead path. */
+	 *  never write syncState at a dead path.
+	 *
+	 *  Fix wave 5: `content` is the staged row's own plaintext, so
+	 *  `commitCrdtConvergence` can CONTENT-VERIFY the commit instead of
+	 *  trusting that the next `onSynced` fire is FOR this row — an unrelated
+	 *  inbound frame (a different concurrent edit on the same doc) could
+	 *  otherwise commit the stage a millisecond after it was staged, before
+	 *  the staged row's own ops ever arrived (CI run 29920053637: committed
+	 *  1ms after the re-handshake fired, fence-blinding every later row —
+	 *  deaf until teardown). The diverged live-bound leg has the row's
+	 *  `content` in scope and stages it; `healDivergedLiveBoundNotes` (the
+	 *  manifest heal) has no plaintext — only a keyed HMAC hash it cannot
+	 *  compute client-side — so it stages `content: null`, which keeps the
+	 *  pre-wave-5 best-effort behavior (commit on the next non-empty frame,
+	 *  unverified). */
 	private pendingConvergence: Map<
 		string,
-		{ path: string; serverHash: string; version?: number; seq?: number }
+		{ path: string; serverHash: string; content: string | null; version?: number; seq?: number }
 	> = new Map();
 
 	/** Fix wave 1: per-note_id cooldown for `socketConvergeLiveBound`'s STEP1
@@ -3775,16 +3789,51 @@ export class SyncEngine {
 	 *  ONLY place that leg's `serverHash`/`version`/`seq` get written. Wired
 	 *  from CrdtManager's `onSynced` (crdt/wiring.ts), which fires from
 	 *  `CrdtChannel.handleFrame` exactly when an inbound sync frame leaves the
-	 *  doc's text non-empty — real ops landed, not a guess. Idempotent and
-	 *  cheap when nothing is staged (steady-state live traffic fires this on
-	 *  every frame). Re-resolves the CURRENT path via `noteIdMap` rather than
-	 *  trusting the path captured at stage time, so a rename (path moved) or
-	 *  delete (id unmapped) between staging and commit can't write syncState
-	 *  at a stale/dead path — no separate teardown hook needed. Never throws
-	 *  into the CRDT manager's synchronous callback. */
+	 *  doc's text non-empty — real ops landed, not a guess.
+	 *
+	 *  Fix wave 5: "an inbound frame landed" is necessary but NOT sufficient
+	 *  proof the STAGED row's ops are the ones that landed — `onSynced` fires
+	 *  on every non-empty frame, including an unrelated concurrent edit on
+	 *  the same doc, which could commit a stage a millisecond after staging,
+	 *  before the staged row's own ops ever arrived (CI run 29920053637).
+	 *  When the stage carries plaintext (`content !== null`), commit ONLY if
+	 *  the doc's projection now strictly equals it — the ops that produced a
+	 *  match came from the server room round-trip, so post-handshake
+	 *  text-equality IS sound proof here (unlike the deleted verify-first
+	 *  skip, which compared BEFORE any handshake ever fired). On a mismatch
+	 *  (or a `projectedText` throw — treated as mismatch, never commit on
+	 *  error) the stage is left in place; the next inbound frame re-runs this
+	 *  check, so the real edit's arrival commits it. A `content: null` stage
+	 *  (manifest heal — hash-only, keyed HMAC, uncomputable client-side)
+	 *  keeps the pre-wave-5 best-effort behavior: commit unverified on the
+	 *  next non-empty frame.
+	 *
+	 *  Idempotent and cheap when nothing is staged (steady-state live traffic
+	 *  fires this on every frame). Re-resolves the CURRENT path via
+	 *  `noteIdMap` rather than trusting the path captured at stage time, so a
+	 *  rename (path moved) or delete (id unmapped) between staging and commit
+	 *  can't write syncState at a stale/dead path — no separate teardown hook
+	 *  needed. Never throws into the CRDT manager's synchronous callback. */
 	async commitCrdtConvergence(noteId: string): Promise<void> {
 		const staged = this.pendingConvergence.get(noteId);
 		if (!staged) return;
+		if (staged.content !== null) {
+			let matches = false;
+			if (this.crdt) {
+				try {
+					matches = (await this.crdt.projectedText(noteId)) === staged.content;
+				} catch (e) {
+					devLog().log(
+						"crdt",
+						`socket converge: projectedText failed for ${noteId}, deferring commit: ${errMsg(e)}`,
+					);
+				}
+			}
+			if (!matches) {
+				devLog().log("crdt", `commit deferred: doc not at staged row yet (${noteId})`);
+				return; // leave staged — the next inbound frame re-runs this check
+			}
+		}
 		this.pendingConvergence.delete(noteId);
 		this.crdtRehandshakeAttempts.delete(noteId);
 		const path = this.noteIdMap?.pathForId(noteId);
@@ -4897,7 +4946,15 @@ export class SyncEngine {
 
 			try {
 				if (entry.content_hash) {
-					this.pendingConvergence.set(noteId, { path, serverHash: entry.content_hash });
+					// content: null — the manifest carries a hash only (keyed HMAC,
+					// uncomputable client-side), so this stage cannot be
+					// content-verified; commitCrdtConvergence keeps the pre-wave-5
+					// best-effort behavior for it (commit on the next non-empty frame).
+					this.pendingConvergence.set(noteId, {
+						path,
+						serverHash: entry.content_hash,
+						content: null,
+					});
 				}
 				this.socketConvergeLiveBound(path, noteId);
 			} catch (e) {
@@ -5160,22 +5217,25 @@ export class SyncEngine {
 				// nothing is recorded, so a genuinely newer row still converges on
 				// a later pass.
 				//
-				// seq is AUTHORITATIVE when both sides carry it (2026-07-22 D3 gate
-				// forensics, CI run 29917773065; issue #282's family): seq is the
-				// vault op-log position and strictly increases per materialized
-				// change, so it alone decides. version is only the FALLBACK when
-				// seq is unavailable on either side — version is checkpoint-lagged
-				// for CRDT notes (advances on checkpoint/materialization, not every
-				// live delta — see restConvergeCore's docstring), so an
-				// EQUAL-version row can legitimately carry content this device
-				// never saw. The old OR-of-both-checks let a stale-by-version-alone
-				// verdict mask a genuinely newer seq, fence-skipping the real edit
-				// (the deaf-note e2e gate flake: 2x "stale row" skips, the note
-				// converged only at teardown). The equal-SEQ case is unchanged
-				// (still <=, still history) — PR #280's scope, not touched here.
+				// seq is AUTHORITATIVE whenever the ROW carries it (2026-07-22 D3
+				// gate forensics, CI run 29917773065 then 29920053637; issue #282's
+				// family): seq is the vault op-log position and strictly increases
+				// per materialized change, so a seq-bearing row is judged by seq
+				// ALONE — never falls back to version, even when this path has no
+				// recorded stored.seq yet. With no stored.seq there is nothing to be
+				// behind of, so the row is NOT stale (fixes CI run 29920053637: a
+				// seq-bearing row was skipped as `stale row (seq 33/- v1/1)` because
+				// stored.seq was undefined and the OLD condition — "both sides carry
+				// seq" — fell back to version equality). version is the fallback
+				// ONLY for a seq-LESS row (legacy /notes/changes shape) — version is
+				// checkpoint-lagged for CRDT notes (advances on checkpoint/
+				// materialization, not every live delta — see restConvergeCore's
+				// docstring), so an EQUAL-version row can legitimately carry content
+				// this device never saw. The equal-SEQ case is unchanged (still <=,
+				// still history) — PR #280's scope, not touched here.
 				const staleRow =
-					stored?.seq !== undefined && change.seq !== undefined
-						? change.seq <= stored.seq
+					change.seq !== undefined
+						? stored?.seq !== undefined && change.seq <= stored.seq
 						: stored?.version !== undefined &&
 							change.version !== undefined &&
 							change.version <= stored.version;
@@ -5214,9 +5274,13 @@ export class SyncEngine {
 						if (noteId) {
 							// A fresh content_hash overwrites any prior stage — a new
 							// episode, never a stale commit of superseded server content.
+							// content: the row's own plaintext (fix wave 5) — lets
+							// commitCrdtConvergence content-verify the commit instead of
+							// trusting that the next onSynced fire is FOR this row.
 							this.pendingConvergence.set(noteId, {
 								path: normalized,
 								serverHash: change.content_hash,
+								content,
 								version: change.version,
 								seq: change.seq,
 							});

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -657,8 +657,9 @@ export class SyncEngine {
 	/** Per-note re-handshake attempt tracking for the live-bound catch-up path,
 	 *  keyed by note_id. `hash` is the server content_hash being retried; a new
 	 *  hash starts a fresh episode. Purely diagnostic now (the logged attempt
-	 *  number): convergence comes from the deterministic REST delta pull, and a
-	 *  failed pull retries at the 5-min poll cadence — no give-up, no storm. */
+	 *  number): convergence comes from the socket-native verify-first primitive
+	 *  (`socketConvergeLiveBound`), and an unverified pass retries at the poll
+	 *  cadence — no give-up, no storm. */
 	private crdtRehandshakeAttempts: Map<string, { hash: string; attempts: number }> = new Map();
 
 	/** Public: true once this SESSION observed this note's create-ack. Was
@@ -3671,23 +3672,53 @@ export class SyncEngine {
 		}
 	}
 
-	/** Deterministic catch-up for a diverged LIVE-BOUND note: pull the delta
-	 *  since our real state vector over REST and apply it to the live Y.Doc —
-	 *  the editor binding paints it, no disk write. Returns true only when the
-	 *  doc verifiably reached server state (applied, no pending gap), so the
-	 *  caller records convergence for delivered data ONLY. Best-effort:
-	 *  isolates its own failure, never throws. */
-	private async restConvergeLiveBound(path: string, noteId: string): Promise<boolean> {
-		const head = await this.restConvergeCore(path, noteId);
-		if (head === null) return false;
-		this.setCrdtHead(path, head);
-		rlog().info("crdt", `REST converge: live-bound ${path} caught up to head=${head}`);
-		return true;
+	/** Socket-native converge for a diverged LIVE-BOUND note (single-path D3;
+	 *  replaces the deleted REST restConvergeLiveBound backstop). Verify-first:
+	 *  when the caller holds the row's content snapshot and the doc already
+	 *  projects exactly that text, the note is converged — record and stop, no
+	 *  wire traffic. Otherwise reset+enroll re-fires STEP1 and the room
+	 *  sv-exchange delivers whatever this doc is missing over the SOCKET
+	 *  (recreating the server room if it died — the 2026-07-14 deaf class).
+	 *  Returns true ONLY on verified convergence; an unverified heal is
+	 *  fire-and-forget and stays unrecorded so the caller's next replay or
+	 *  catch-up pass retries. Never throws.
+	 *  ponytail: without a snapshot (manifest heal, open heal) this never
+	 *  verifies, so a once-diverged open note re-fires one STEP1 per catch-up
+	 *  until a replay row verifies it or the note closes; add crdt_head to the
+	 *  manifest and skip on head-equality if that churn ever matters. */
+	private async socketConvergeLiveBound(
+		path: string,
+		noteId: string,
+		expected?: string,
+	): Promise<boolean> {
+		if (expected !== undefined && this.crdt) {
+			try {
+				if ((await this.crdt.projectedText(noteId)) === expected) {
+					rlog().info(
+						"crdt",
+						`socket converge: verified ${path} matches the row snapshot`,
+					);
+					return true;
+				}
+			} catch (e) {
+				rlog().warn(
+					"crdt",
+					`socket converge: projectedText failed for ${path}: ${errMsg(e)}`,
+				);
+			}
+		}
+		if (this.crdtEnrollment) {
+			this.crdtEnrollment.reset(noteId);
+			this.crdtEnrollment.enroll(noteId);
+			rlog().info("crdt", `socket converge: re-handshake fired for ${path}`);
+		}
+		return false;
 	}
 
 	/** Deterministic catch-up for a diverged NOT-live-bound (cold) CRDT note:
-	 *  same Yjs-delta core as restConvergeLiveBound, but there is no editor
-	 *  binding to paint the doc. Replaces the old content-snapshot
+	 *  same Yjs-delta REST core the live-bound leg used before the D3 socket
+	 *  migration (cold-leg REST stays — see restConvergeCore), but there is no
+	 *  editor binding to paint the doc. Replaces the old content-snapshot
 	 *  `flushFromCrdt(path, content)` backfill, which reverted a fresher live
 	 *  merge when the seq gap-heal's behind-detector fires a catch-up replay
 	 *  DURING active editing on this note from another device — the feed's
@@ -3708,7 +3739,7 @@ export class SyncEngine {
 	 *  `projectedText` is read once, purely so the caller can hash what
 	 *  actually landed for syncState bookkeeping — never to write disk again.
 	 *  Returns that text on success, or null on failure/pending-gap — mirrors
-	 *  restConvergeLiveBound's retry contract (never record convergence for
+	 *  socketConvergeLiveBound's retry contract (never record convergence for
 	 *  data that hasn't arrived). */
 	private async restConvergeAndFlush(path: string, noteId: string): Promise<string | null> {
 		const head = await this.restConvergeCore(path, noteId);
@@ -3732,9 +3763,8 @@ export class SyncEngine {
 	 *  that missed a live announce/STEP2 during a fan-out storm, WITHOUT its
 	 *  per-open synchronous manifest-hash check + forced re-handshake, the
 	 *  #203 false-fire that caused the open-path lag). Fire-and-forget from
-	 *  file-open: a single note, one delta-since-our-real-state-vector via the
-	 *  existing guarded `restConvergeLiveBound` — empty (near-no-op) when
-	 *  already converged. Live-bound-only first cut (design decision iii): a
+	 *  file-open: a single note, one STEP1 sv-exchange via `socketConvergeLiveBound`
+	 *  (near-no-op STEP2 when already converged). Live-bound-only first cut (design decision iii): a
 	 *  just-opened note is live-bound after CrdtLiveViews.refresh(), so this
 	 *  covers the real case without a vault-wide heads fetch on every open; an
 	 *  idle note is still covered by reconnect catch-up (#5). Never throws. */
@@ -3744,9 +3774,9 @@ export class SyncEngine {
 		const noteId = this.noteIdMap?.get(normalized) ?? null;
 		if (!noteId) return; // truly unknown — reconnect catch-up discovers it (#5)
 		try {
-			// Opened but never handshaked (discovered via catch-up/fan-out): the REST
-			// restConvergeLiveBound fast path needs a confirmed server row, so converge
-			// it over the seq-ordered op-log instead — a cold note must not stay
+			// Opened but never handshaked (discovered via catch-up/fan-out): the
+			// socket re-handshake needs a confirmed server row, so converge it
+			// over the seq-ordered op-log instead — a cold note must not stay
 			// unmaterialized until the next reconnect. Single-flight coalesced and
 			// cursor-based, so an already-converged vault is a near-no-op; the note's
 			// op carries full content (the one catch-up path, crdt_catchup_since).
@@ -3755,7 +3785,10 @@ export class SyncEngine {
 				return;
 			}
 			if (!this.isLiveBound(normalized)) return; // idle confirmed notes heal on reconnect (#5)
-			await this.restConvergeLiveBound(normalized, noteId);
+			// No `expected` snapshot at open time — a deaf doc matches its own
+			// stale disk perfectly, so passing disk content here would verify
+			// falsely and skip the heal. Always re-fires STEP1.
+			await this.socketConvergeLiveBound(normalized, noteId);
 		} catch (e) {
 			rlog().warn("crdt", `healNoteOnOpen ${path}: ${errMsg(e)}`);
 		}
@@ -4747,9 +4780,9 @@ export class SyncEngine {
 	 *  Before the REST purge, fullSync's pull had a SEPARATE cursor from the
 	 *  socket replay, so it re-delivered the diverged note and converged it; the
 	 *  cursor unification removed that. This restores it: a manifest snapshot
-	 *  re-detects the divergence every catch-up and re-fires the same idempotent
-	 *  `restConvergeLiveBound` (a converged note's serverHash already matches and
-	 *  is skipped). Only live-bound notes (the editor owns the body, so disk
+	 *  re-detects the divergence every catch-up and re-fires the idempotent
+	 *  `socketConvergeLiveBound` (a converged note's serverHash already matches
+	 *  and is skipped). Only live-bound notes (the editor owns the body, so disk
 	 *  writes are unsafe) need it — idle divergences heal through the normal
 	 *  op-log apply. Best-effort; never throws into catchUp. */
 	private async healDivergedLiveBoundNotes(manifest: ManifestResponse | null): Promise<void> {
@@ -4765,23 +4798,14 @@ export class SyncEngine {
 			if (!noteId) continue;
 
 			try {
-				const converged = await this.restConvergeLiveBound(path, noteId);
-				if (converged && entry.content_hash) {
-					// Record convergence so the next catch-up skips it. Mirror
-					// applyChange's live-bound success bookkeeping: the editor owns the
-					// body (no disk write), so keep the REAL local hash and only advance
-					// serverHash. Spread the existing entry — restConvergeLiveBound just
-					// recorded crdtHead into it, which coldReceive's cost gate reads.
-					const boundFile = this.app.vault.getFileByPath(path);
-					const localHash =
-						stored?.hash ??
-						(boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0);
-					this.syncState.set(path, {
-						...(this.syncState.get(path) ?? {}),
-						hash: localHash,
-						serverHash: entry.content_hash,
-					});
-				}
+				// Socket-native (D3): fire the STEP1 re-handshake; the sv-exchange
+				// delivers the missing ops and the binding paints them. The manifest
+				// carries hashes only (keyed HMAC — uncomputable client-side), so
+				// convergence cannot be verified here and serverHash stays
+				// unrecorded; the next replay row that matches the doc records it
+				// (applyChange's live-bound leg). Idempotent when already
+				// converged: STEP2 returns an empty diff.
+				await this.socketConvergeLiveBound(path, noteId);
 			} catch (e) {
 				rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
 			}
@@ -5035,19 +5059,12 @@ export class SyncEngine {
 				} else if (change.content_hash && stored?.serverHash !== change.content_hash) {
 					if (this.isLiveBound(normalized)) {
 						// An open, bound editor is the sole CRDT writer for the note —
-						// writing disk under it would fight the binding. Two recovery
-						// legs, both through the Y.Doc (the binding paints the editor):
-						//   1. reset+enroll re-fires STEP1 so the room subscription is
-						//      re-registered for FUTURE live updates;
-						//   2. a REST delta pull converges the doc NOW, deterministically.
-						// Leg 2 replaced the bounded give-up that recorded convergence
-						// after 3 failed re-handshakes WITHOUT the data ever arriving —
-						// that stopped the 2026-07-09 re-handshake storm by trading it
-						// for a silent data hole: a live-bound note whose room broadcast
-						// was lost went permanently deaf (2026-07-14 incident). REST
-						// converge terminates the loop by actually delivering the ops,
-						// so no give-up is needed; a REST failure retries at the poll
-						// cadence (5 min per note — bounded, not a storm).
+						// writing disk under it would fight the binding. Socket-native
+						// converge (single-path D3): verify-first against the row's
+						// snapshot, else re-fire STEP1 so the room sv-exchange delivers
+						// the missing ops over the socket. Recording stays verify-gated —
+						// never record convergence for data that has not verifiably
+						// arrived; an unverified pass retries at the next replay/poll.
 						const key = noteId ?? normalized;
 						const prevAttempt = this.crdtRehandshakeAttempts.get(key);
 						const attempts =
@@ -5056,14 +5073,10 @@ export class SyncEngine {
 								: 1;
 						rlog().warn(
 							"pull",
-							`CRDT catch-up: diverged + live-bound, re-handshake + REST converge (attempt ${attempts}) ${change.path}`,
+							`CRDT catch-up: diverged + live-bound, socket re-handshake (attempt ${attempts}) ${change.path}`,
 						);
-						if (noteId && this.crdtEnrollment) {
-							this.crdtEnrollment.reset(noteId);
-							this.crdtEnrollment.enroll(noteId);
-						}
 						const converged = noteId
-							? await this.restConvergeLiveBound(normalized, noteId)
+							? await this.socketConvergeLiveBound(normalized, noteId, content)
 							: false;
 						if (converged) {
 							this.crdtRehandshakeAttempts.delete(key);
@@ -5075,9 +5088,9 @@ export class SyncEngine {
 							const localHash =
 								stored?.hash ??
 								(boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0);
-							// Spread the existing entry: restConvergeLiveBound just recorded
-							// crdtHead into it, and a bare replacement would wipe that head,
-							// defeating coldReceive's cost gate (getCrdtHead === serverHead).
+							// Spread the existing entry so recorded crdtHead (maintained by
+							// the live fan-out path) survives — coldReceive's cost gate
+							// reads it.
 							this.syncState.set(normalized, {
 								...(this.syncState.get(normalized) ?? {}),
 								hash: localHash,
@@ -5086,7 +5099,7 @@ export class SyncEngine {
 								seq: change.seq,
 							});
 						} else {
-							// Keep serverHash UNrecorded so the next poll retries — never
+							// Keep serverHash UNrecorded so the next pass retries — never
 							// record convergence for data that has not arrived.
 							this.crdtRehandshakeAttempts.set(key, {
 								hash: change.content_hash,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5041,6 +5041,15 @@ export class SyncEngine {
 			throw new Error(`applyChange: missing content for ${change.path}`);
 		}
 
+		// C1's own predicates, hoisted above the anti-stale guard so both share
+		// ONE computation (fix wave 4 — never resolve noteId twice, a drift
+		// hazard). See C1 below for why noteId can be null (legacy
+		// /notes/changes path, or a note discovered without ever learning an
+		// id — src/sync.ts's discovery branch a few lines down never calls
+		// noteIdMap.set).
+		const crdtOwnsBody = !!(this.crdt && normalized.endsWith(".md"));
+		const noteId = this.noteIdMap?.get(normalized) ?? null;
+
 		// Anti-stale guard (review 2026-07-15, data-loss race): a push landing
 		// DURING a pull — the bounded post-pull drain, or a debounced edit —
 		// bumps syncState past entries this pull fetched BEFORE that push.
@@ -5050,7 +5059,19 @@ export class SyncEngine {
 		// synced carries nothing new. Gated on the file existing locally so a
 		// stale syncState row (crash, manual delete) can never mask a real
 		// re-materialization; forceOverwrite (explicit keep-remote) bypasses.
-		if (!forceOverwrite && change.version !== undefined) {
+		//
+		// LEGACY / no-id-only (fix wave 4, D3 gate forensics CI run
+		// 29917773065): this guard's `known >= change.version` has no seq
+		// awareness, so it could mask a checkpoint-lagged-but-genuinely-newer
+		// CRDT row (`applyChange skip (stale v1 <= synced v1)` — the row the
+		// CRDT block's own seq-first staleRow fence, wave 3, would correctly
+		// have judged NOT stale). Skipped here ONLY when CRDT owns the body
+		// AND we have a resolved noteId — those rows are judged by that
+		// seq-first fence instead. A CRDT row with NO resolvable noteId still
+		// falls through to the no-noteId sub-branch below (~5262), which does
+		// a raw content-snapshot write with no Yjs convergence — that sub-case
+		// keeps this version guard as its only stale protection.
+		if (!forceOverwrite && !(crdtOwnsBody && noteId) && change.version !== undefined) {
 			const known = this.syncState.get(normalized)?.version;
 			if (
 				known !== undefined &&
@@ -5075,13 +5096,13 @@ export class SyncEngine {
 		// the block falls through to the legacy conflict flow below instead of
 		// silently backfilling over the local edit.
 		let crdtConflictFallthrough = false;
-		if (this.crdt && normalized.endsWith(".md")) {
-			// Enroll by note_id (Task 6). This is populated for the merged-feed
-			// caller (applySyncChange learns `id` right before calling applyChange)
-			// but may be unknown for the legacy /notes/changes path (no `id` field
-			// on NoteChange) — skip enrolling gracefully in that case; the body is
-			// still materialized below directly from the pulled content.
-			const noteId = this.noteIdMap?.get(normalized) ?? null;
+		if (crdtOwnsBody) {
+			// noteId resolved above (shared with the anti-stale guard). This is
+			// populated for the merged-feed caller (applySyncChange learns `id`
+			// right before calling applyChange) but may be unknown for the
+			// legacy /notes/changes path (no `id` field on NoteChange) — skip
+			// enrolling gracefully in that case; the body is still materialized
+			// below directly from the pulled content.
 			// Discovery: a CRDT-managed note we don't have on disk yet. Enroll it
 			// (sync-step-1) so the body arrives over the CRDT handshake — the server
 			// seeds the room from notes.content when it has no CRDT state. We never

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -455,6 +455,28 @@ export class SyncEngine {
 		this.crdtEditorRebind = fn;
 	}
 
+	/** Fix wave 7 (#191 slice): reads the LIVE editor buffer currently shown
+	 *  for `path` (CrdtLiveViews.boundBufferText, wired by main.ts) — used by
+	 *  commitCrdtConvergence to detect a phantom binding (isLiveBound true but
+	 *  the editor's Yjs binding silently detached, so its buffer never
+	 *  repaints). Null in tests/headless — the phantom-binding check is then
+	 *  skipped (nothing to compare). */
+	private crdtBoundBufferText: ((path: string) => string | null) | null = null;
+
+	setCrdtBoundBufferText(fn: ((path: string) => string | null) | null): void {
+		this.crdtBoundBufferText = fn;
+	}
+
+	/** Fix wave 7: nudges the bound editor's save (CrdtLiveViews.requestSaveForBoundPath,
+	 *  the same debounced call wiring.ts's onBoundUpdate uses) after a phantom
+	 *  binding is rebound, so the freshly-repainted buffer actually reaches
+	 *  disk instead of waiting on the next unrelated remote update. */
+	private crdtRequestSave: ((path: string) => void) | null = null;
+
+	setCrdtRequestSave(fn: ((path: string) => void) | null): void {
+		this.crdtRequestSave = fn;
+	}
+
 	/** Path -> note_id sidecar (Task 4, `src/crdt/note-id-map.ts`). Owned by
 	 *  main.ts (persisted in data.json); wired here so pushFile can mint/send
 	 *  client_id for new notes, the pull path can learn ids, and handleRename
@@ -3832,6 +3854,30 @@ export class SyncEngine {
 			if (!matches) {
 				devLog().log("crdt", `commit deferred: doc not at staged row yet (${noteId})`);
 				return; // leave staged — the next inbound frame re-runs this check
+			}
+			// Fix wave 7 (#191 slice): the doc is content-verified converged, but a
+			// rejected STEP1 / unclean close during a rate-limited window can
+			// detach the editor's Yjs binding while isLiveBound stays true (CI run
+			// 29923077791) — onFlushToDisk then skips forever (thinks the editor
+			// owns disk) and nothing repaints the stale buffer, so the wave-6
+			// requestSave nudge just re-saves the same stale content. Detect it
+			// here: if the bound editor's actual buffer no longer matches the
+			// verified content, the binding is phantom — force a rebind through
+			// the existing bindEpoch-guarded machinery (never a raw setViewData,
+			// never spans an await between detach/rebind — see
+			// crdt-editor-bind-race-pollution.md) so it repaints, then nudge the
+			// save on the freshly-painted buffer.
+			const boundPath = this.noteIdMap?.pathForId(noteId);
+			if (boundPath && this.isLiveBound(boundPath)) {
+				const buffer = this.crdtBoundBufferText?.(boundPath) ?? null;
+				if (buffer !== null && buffer !== staged.content) {
+					rlog().warn(
+						"crdt",
+						`socket converge: phantom binding rebound for ${boundPath}`,
+					);
+					this.crdtEditorRebind?.(boundPath);
+					this.crdtRequestSave?.(boundPath);
+				}
 			}
 		}
 		this.pendingConvergence.delete(noteId);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -657,10 +657,41 @@ export class SyncEngine {
 	/** Per-note re-handshake attempt tracking for the live-bound catch-up path,
 	 *  keyed by note_id. `hash` is the server content_hash being retried; a new
 	 *  hash starts a fresh episode. Purely diagnostic now (the logged attempt
-	 *  number): convergence comes from the socket-native verify-first primitive
-	 *  (`socketConvergeLiveBound`), and an unverified pass retries at the poll
-	 *  cadence — no give-up, no storm. */
+	 *  number, and cleared on commit) — convergence recording lives entirely in
+	 *  `commitCrdtConvergence`; this map never gates a retry. */
 	private crdtRehandshakeAttempts: Map<string, { hash: string; attempts: number }> = new Map();
+
+	/** Fix wave 1 (single-path D3 review): staged convergence for a diverged
+	 *  LIVE-BOUND note, keyed by note_id. `socketConvergeLiveBound` no longer
+	 *  verifies-and-records by text equality — text equality does not prove
+	 *  the doc holds the server's actual Yjs ops (two independently-typed
+	 *  identical bodies are a disjoint lineage; recording on that basis is the
+	 *  duplication class this replaces). Instead a diverged pull entry STAGES
+	 *  what it would record here, and `commitCrdtConvergence` (wired from
+	 *  CrdtManager's onSynced, fired only when a real inbound frame leaves the
+	 *  doc non-empty) commits it — actual op-level proof, not a text guess. A
+	 *  fresh content_hash overwrites any prior stage (new episode); nothing
+	 *  else prunes it — `commitCrdtConvergence` re-resolves the current path
+	 *  via noteIdMap and no-ops if the id was deleted, so a stale stage can
+	 *  never write syncState at a dead path. */
+	private pendingConvergence: Map<
+		string,
+		{ path: string; serverHash: string; version?: number; seq?: number }
+	> = new Map();
+
+	/** Fix wave 1: per-note_id cooldown for `socketConvergeLiveBound`'s STEP1
+	 *  re-handshake — bounds how often a live-bound note can re-fire reset+
+	 *  enroll (open, catch-up, and manifest heal can all independently detect
+	 *  the same divergence in quick succession; unconditional firing drains
+	 *  the handshake budget, the #193 starvation class). Value = last-fired
+	 *  `Date.now()`. `healCooldownMs` is a public instance field so tests can
+	 *  shrink it. */
+	private crdtHealCooldown: Map<string, number> = new Map();
+
+	/** See `crdtHealCooldown`. 30s: long enough that open+catch-up+heal racing
+	 *  on the same note collapse to one handshake, short enough that a
+	 *  genuinely-still-diverged note keeps retrying within a session. */
+	healCooldownMs = 30_000;
 
 	/** Public: true once this SESSION observed this note's create-ack. Was
 	 *  formerly wired as `CrdtManagerOptions.canSendLive` in main.ts, but that
@@ -3672,47 +3703,72 @@ export class SyncEngine {
 		}
 	}
 
-	/** Socket-native converge for a diverged LIVE-BOUND note (single-path D3;
-	 *  replaces the deleted REST restConvergeLiveBound backstop). Verify-first:
-	 *  when the caller holds the row's content snapshot and the doc already
-	 *  projects exactly that text, the note is converged — record and stop, no
-	 *  wire traffic. Otherwise reset+enroll re-fires STEP1 and the room
-	 *  sv-exchange delivers whatever this doc is missing over the SOCKET
-	 *  (recreating the server room if it died — the 2026-07-14 deaf class).
-	 *  Returns true ONLY on verified convergence; an unverified heal is
-	 *  fire-and-forget and stays unrecorded so the caller's next replay or
-	 *  catch-up pass retries. Never throws.
-	 *  ponytail: without a snapshot (manifest heal, open heal) this never
-	 *  verifies, so a once-diverged open note re-fires one STEP1 per catch-up
-	 *  until a replay row verifies it or the note closes; add crdt_head to the
-	 *  manifest and skip on head-equality if that churn ever matters. */
-	private async socketConvergeLiveBound(
-		path: string,
-		noteId: string,
-		expected?: string,
-	): Promise<boolean> {
-		if (expected !== undefined && this.crdt) {
-			try {
-				if ((await this.crdt.projectedText(noteId)) === expected) {
-					rlog().info(
-						"crdt",
-						`socket converge: verified ${path} matches the row snapshot`,
-					);
-					return true;
-				}
-			} catch (e) {
-				rlog().warn(
-					"crdt",
-					`socket converge: projectedText failed for ${path}: ${errMsg(e)}`,
-				);
-			}
+	/** Socket-native re-handshake for a diverged LIVE-BOUND note (single-path
+	 *  D3, fix wave 1). Supersedes the original verify-by-text design: text
+	 *  equality between the doc's projection and a row snapshot does NOT prove
+	 *  the doc holds the server's actual Yjs ops — two independently-typed
+	 *  identical bodies are a disjoint lineage, and recording convergence on
+	 *  that basis let the doubling class through. Also, that design recorded
+	 *  on a match WITHOUT re-registering the room subscription, so a doc that
+	 *  happened to already match a DEAD room's row stayed silently deaf.
+	 *
+	 *  Always fires STEP1 (`reset`+`enroll`) on a diverged row — restores
+	 *  main's re-registration semantics unconditionally, no text compare.
+	 *  Convergence is recorded separately and ONLY on op-level proof: see
+	 *  `commitCrdtConvergence`, fired from CrdtManager's `onSynced` when a
+	 *  real inbound frame actually applies non-empty. Cooldown-gated per
+	 *  note_id (`crdtHealCooldown`/`healCooldownMs`) so open+catch-up+heal all
+	 *  independently detecting the same divergence collapses to one handshake
+	 *  instead of draining the handshake budget (#193 starvation class).
+	 *  Never throws. */
+	private socketConvergeLiveBound(path: string, noteId: string): void {
+		const last = this.crdtHealCooldown.get(noteId);
+		if (last !== undefined && Date.now() - last < this.healCooldownMs) {
+			devLog().log("crdt", `socket converge: cooldown skip for ${path}`);
+			return;
 		}
-		if (this.crdtEnrollment) {
-			this.crdtEnrollment.reset(noteId);
-			this.crdtEnrollment.enroll(noteId);
-			rlog().info("crdt", `socket converge: re-handshake fired for ${path}`);
+		if (!this.crdtEnrollment) return;
+		this.crdtHealCooldown.set(noteId, Date.now());
+		this.crdtEnrollment.reset(noteId);
+		this.crdtEnrollment.enroll(noteId);
+		rlog().info("crdt", `socket converge: re-handshake fired for ${path}`);
+	}
+
+	/** Commit a staged live-bound convergence (see `pendingConvergence`) — the
+	 *  ONLY place that leg's `serverHash`/`version`/`seq` get written. Wired
+	 *  from CrdtManager's `onSynced` (crdt/wiring.ts), which fires from
+	 *  `CrdtChannel.handleFrame` exactly when an inbound sync frame leaves the
+	 *  doc's text non-empty — real ops landed, not a guess. Idempotent and
+	 *  cheap when nothing is staged (steady-state live traffic fires this on
+	 *  every frame). Re-resolves the CURRENT path via `noteIdMap` rather than
+	 *  trusting the path captured at stage time, so a rename (path moved) or
+	 *  delete (id unmapped) between staging and commit can't write syncState
+	 *  at a stale/dead path — no separate teardown hook needed. Never throws
+	 *  into the CRDT manager's synchronous callback. */
+	async commitCrdtConvergence(noteId: string): Promise<void> {
+		const staged = this.pendingConvergence.get(noteId);
+		if (!staged) return;
+		this.pendingConvergence.delete(noteId);
+		this.crdtRehandshakeAttempts.delete(noteId);
+		const path = this.noteIdMap?.pathForId(noteId);
+		if (!path) return; // id unmapped since staging (deleted) — nothing to record
+		try {
+			const boundFile = this.app.vault.getFileByPath(path);
+			const stored = this.syncState.get(path);
+			const localHash =
+				stored?.hash ??
+				(boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0);
+			this.syncState.set(path, {
+				...(this.syncState.get(path) ?? {}),
+				hash: localHash,
+				serverHash: staged.serverHash,
+				version: staged.version,
+				seq: staged.seq,
+			});
+			rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
+		} catch (e) {
+			rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
 		}
-		return false;
 	}
 
 	/** Deterministic catch-up for a diverged NOT-live-bound (cold) CRDT note:
@@ -3738,9 +3794,9 @@ export class SyncEngine {
 	 *  then clobber it (the exact revert family this fixes elsewhere).
 	 *  `projectedText` is read once, purely so the caller can hash what
 	 *  actually landed for syncState bookkeeping — never to write disk again.
-	 *  Returns that text on success, or null on failure/pending-gap — mirrors
-	 *  socketConvergeLiveBound's retry contract (never record convergence for
-	 *  data that hasn't arrived). */
+	 *  Returns that text on success, or null on failure/pending-gap — never
+	 *  record convergence for data that hasn't arrived (same principle the
+	 *  live-bound leg's `commitCrdtConvergence` applies via op-level proof). */
 	private async restConvergeAndFlush(path: string, noteId: string): Promise<string | null> {
 		const head = await this.restConvergeCore(path, noteId);
 		if (head === null || !this.crdt) return null;
@@ -3763,8 +3819,10 @@ export class SyncEngine {
 	 *  that missed a live announce/STEP2 during a fan-out storm, WITHOUT its
 	 *  per-open synchronous manifest-hash check + forced re-handshake, the
 	 *  #203 false-fire that caused the open-path lag). Fire-and-forget from
-	 *  file-open: a single note, one STEP1 sv-exchange via `socketConvergeLiveBound`
-	 *  (near-no-op STEP2 when already converged). Live-bound-only first cut (design decision iii): a
+	 *  file-open: a single note, one STEP1 re-handshake via
+	 *  `socketConvergeLiveBound` — cheap even when already converged, since
+	 *  the per-note cooldown collapses a redundant fire into a no-op.
+	 *  Live-bound-only first cut (design decision iii): a
 	 *  just-opened note is live-bound after CrdtLiveViews.refresh(), so this
 	 *  covers the real case without a vault-wide heads fetch on every open; an
 	 *  idle note is still covered by reconnect catch-up (#5). Never throws. */
@@ -3785,10 +3843,7 @@ export class SyncEngine {
 				return;
 			}
 			if (!this.isLiveBound(normalized)) return; // idle confirmed notes heal on reconnect (#5)
-			// No `expected` snapshot at open time — a deaf doc matches its own
-			// stale disk perfectly, so passing disk content here would verify
-			// falsely and skip the heal. Always re-fires STEP1.
-			await this.socketConvergeLiveBound(normalized, noteId);
+			this.socketConvergeLiveBound(normalized, noteId);
 		} catch (e) {
 			rlog().warn("crdt", `healNoteOnOpen ${path}: ${errMsg(e)}`);
 		}
@@ -4780,11 +4835,18 @@ export class SyncEngine {
 	 *  Before the REST purge, fullSync's pull had a SEPARATE cursor from the
 	 *  socket replay, so it re-delivered the diverged note and converged it; the
 	 *  cursor unification removed that. This restores it: a manifest snapshot
-	 *  re-detects the divergence every catch-up and re-fires the idempotent
-	 *  `socketConvergeLiveBound` (a converged note's serverHash already matches
-	 *  and is skipped). Only live-bound notes (the editor owns the body, so disk
-	 *  writes are unsafe) need it — idle divergences heal through the normal
-	 *  op-log apply. Best-effort; never throws into catchUp. */
+	 *  re-detects the divergence every catch-up and re-fires the STEP1
+	 *  re-handshake (cooldown-gated, so a repeat detection is cheap). Only
+	 *  live-bound notes (the editor owns the body, so disk writes are unsafe)
+	 *  need it — idle divergences heal through the normal op-log apply.
+	 *
+	 *  Recording: this leg STAGES the manifest's `content_hash` into
+	 *  `pendingConvergence` (fix wave 1) rather than recording it directly —
+	 *  the manifest carries hashes only (keyed HMAC, uncomputable
+	 *  client-side), so this leg can never itself prove the doc holds the
+	 *  server's ops. `commitCrdtConvergence` commits the stage once a real
+	 *  STEP2/update frame actually applies. Best-effort; never throws into
+	 *  catchUp. */
 	private async healDivergedLiveBoundNotes(manifest: ManifestResponse | null): Promise<void> {
 		if (!manifest || !this.crdt) return;
 		for (const entry of manifest.notes) {
@@ -4798,14 +4860,10 @@ export class SyncEngine {
 			if (!noteId) continue;
 
 			try {
-				// Socket-native (D3): fire the STEP1 re-handshake; the sv-exchange
-				// delivers the missing ops and the binding paints them. The manifest
-				// carries hashes only (keyed HMAC — uncomputable client-side), so
-				// convergence cannot be verified here and serverHash stays
-				// unrecorded; the next replay row that matches the doc records it
-				// (applyChange's live-bound leg). Idempotent when already
-				// converged: STEP2 returns an empty diff.
-				await this.socketConvergeLiveBound(path, noteId);
+				if (entry.content_hash) {
+					this.pendingConvergence.set(noteId, { path, serverHash: entry.content_hash });
+				}
+				this.socketConvergeLiveBound(path, noteId);
 			} catch (e) {
 				rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
 			}
@@ -5060,11 +5118,15 @@ export class SyncEngine {
 					if (this.isLiveBound(normalized)) {
 						// An open, bound editor is the sole CRDT writer for the note —
 						// writing disk under it would fight the binding. Socket-native
-						// converge (single-path D3): verify-first against the row's
-						// snapshot, else re-fire STEP1 so the room sv-exchange delivers
-						// the missing ops over the socket. Recording stays verify-gated —
-						// never record convergence for data that has not verifiably
-						// arrived; an unverified pass retries at the next replay/poll.
+						// re-handshake (single-path D3, fix wave 1): ALWAYS fire STEP1 on
+						// a diverged row (no text-verify skip — text equality doesn't
+						// prove the doc holds the server's ops; see socketConvergeLiveBound
+						// docstring). Recording moves entirely out of this leg: it STAGES
+						// what it would record into `pendingConvergence`, and
+						// `commitCrdtConvergence` commits it only once a real inbound
+						// frame proves the ops landed (op-level proof, not a guess).
+						// `crdtRehandshakeAttempts` stays purely diagnostic (the logged
+						// attempt count) — this leg never writes serverHash itself.
 						const key = noteId ?? normalized;
 						const prevAttempt = this.crdtRehandshakeAttempts.get(key);
 						const attempts =
@@ -5075,36 +5137,17 @@ export class SyncEngine {
 							"pull",
 							`CRDT catch-up: diverged + live-bound, socket re-handshake (attempt ${attempts}) ${change.path}`,
 						);
-						const converged = noteId
-							? await this.socketConvergeLiveBound(normalized, noteId, content)
-							: false;
-						if (converged) {
-							this.crdtRehandshakeAttempts.delete(key);
-							// We did NOT write disk (the editor owns the body), so record
-							// the REAL local content hash — NOT a 0 sentinel, which a later
-							// cold-note check would misread as a local divergence and
-							// spuriously route to the conflict flow.
-							const boundFile = this.app.vault.getFileByPath(normalized);
-							const localHash =
-								stored?.hash ??
-								(boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0);
-							// Spread the existing entry so recorded crdtHead (maintained by
-							// the live fan-out path) survives — coldReceive's cost gate
-							// reads it.
-							this.syncState.set(normalized, {
-								...(this.syncState.get(normalized) ?? {}),
-								hash: localHash,
+						this.crdtRehandshakeAttempts.set(key, { hash: change.content_hash, attempts });
+						if (noteId) {
+							// A fresh content_hash overwrites any prior stage — a new
+							// episode, never a stale commit of superseded server content.
+							this.pendingConvergence.set(noteId, {
+								path: normalized,
 								serverHash: change.content_hash,
 								version: change.version,
 								seq: change.seq,
 							});
-						} else {
-							// Keep serverHash UNrecorded so the next pass retries — never
-							// record convergence for data that has not arrived.
-							this.crdtRehandshakeAttempts.set(key, {
-								hash: change.content_hash,
-								attempts,
-							});
+							this.socketConvergeLiveBound(normalized, noteId);
 						}
 					} else {
 						// Backfill is ONLY a catch-up for a CLEAN local file. If the

--- a/tests/crdt-live-views.test.ts
+++ b/tests/crdt-live-views.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, mock } from "bun:test";
+import { MarkdownView as MdView } from "obsidian";
 import { CrdtLiveViews, ViewerRefcount } from "../src/crdt/live/live-views";
 
 describe("ViewerRefcount", () => {
@@ -158,5 +159,74 @@ describe("CrdtLiveViews doc lifecycle (onLastViewerRelease)", () => {
 		rc.release("a.md", "v1");
 		await new Promise((r) => setTimeout(r, 0)); // let the fire-and-forget chain settle
 		expect(releaseErrors.map((e) => e.path)).toEqual(["a.md"]);
+	});
+});
+
+// Fix wave 6: headless/unfocused Obsidian (CI) doesn't promptly flush a
+// programmatically-updated bound editor buffer to disk, even though the CRDT
+// doc itself converges correctly (wave 5) — a remote merge can sit unsaved
+// for ~30s. requestSaveForBoundPath is the nudge: the caller (onFlushToDisk's
+// isBound skip, via main.ts's onBoundUpdate) requests Obsidian's own save
+// pipeline for the bound view, debounced so a burst of deltas coalesces.
+describe("CrdtLiveViews.requestSaveForBoundPath (fix wave 6)", () => {
+	const DEBOUNCE_WAIT_MS = 350; // > the 300ms production debounce window
+
+	function makeView(path: string): {
+		view: InstanceType<typeof MdView>;
+		requestSave: ReturnType<typeof mock>;
+	} {
+		const view = new MdView();
+		(view as unknown as { file: { path: string } }).file = { path };
+		const requestSave = mock();
+		(view as unknown as { requestSave: () => void }).requestSave = requestSave;
+		return { view, requestSave };
+	}
+
+	function makeLiveViewsWithViews(views: Array<InstanceType<typeof MdView>>) {
+		const app = { workspace: { getLeavesOfType: mock(() => views.map((view) => ({ view }))) } };
+		const manager = { getText: async (id: string) => `text-of-${id}`, closeDoc: () => {} };
+		const lv = new CrdtLiveViews({
+			app: app as never,
+			manager: manager as never,
+			enrollment: {} as never,
+			resolveId: (p: string) => `id:${p}`,
+			flushToDisk: async () => {},
+		});
+		return lv;
+	}
+
+	it("(a) a remote merge into a bound path calls requestSave once, after the debounce", async () => {
+		const { view, requestSave } = makeView("a.md");
+		const lv = makeLiveViewsWithViews([view]);
+		(lv as unknown as { refcount: ViewerRefcount }).refcount.bind("a.md", "v1");
+
+		lv.requestSaveForBoundPath("a.md");
+		expect(requestSave).not.toHaveBeenCalled(); // debounced, not immediate
+
+		await new Promise((r) => setTimeout(r, DEBOUNCE_WAIT_MS));
+		expect(requestSave).toHaveBeenCalledTimes(1);
+	});
+
+	it("(b) three rapid merges into the same bound path coalesce to ONE requestSave call", async () => {
+		const { view, requestSave } = makeView("a.md");
+		const lv = makeLiveViewsWithViews([view]);
+		(lv as unknown as { refcount: ViewerRefcount }).refcount.bind("a.md", "v1");
+
+		lv.requestSaveForBoundPath("a.md");
+		lv.requestSaveForBoundPath("a.md");
+		lv.requestSaveForBoundPath("a.md");
+
+		await new Promise((r) => setTimeout(r, DEBOUNCE_WAIT_MS));
+		expect(requestSave).toHaveBeenCalledTimes(1);
+	});
+
+	it("(c) an unbound path never calls requestSave", async () => {
+		const { view, requestSave } = makeView("a.md");
+		const lv = makeLiveViewsWithViews([view]);
+		// NOT bound — refcount.bind is never called for "a.md".
+
+		lv.requestSaveForBoundPath("a.md");
+		await new Promise((r) => setTimeout(r, DEBOUNCE_WAIT_MS));
+		expect(requestSave).not.toHaveBeenCalled();
 	});
 });

--- a/tests/crdt/wiring.test.ts
+++ b/tests/crdt/wiring.test.ts
@@ -75,6 +75,10 @@ function makeDevice(id: string, reconcile: () => number): Device {
 		// the manifest reconcile explicitly, so the coalesced trigger is a no-op.
 		ensureNoteIdMapped: () => {},
 		discoverAnnouncedNote: async () => {},
+		// Fix wave 1: CrdtManager's onSynced fires this on every non-empty
+		// inbound frame. These device-pair scenarios don't exercise the D3
+		// live-bound staging path, so a no-op is enough.
+		commitCrdtConvergence: async () => {},
 	};
 
 	const wiring = createCrdtWiring({

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -385,7 +385,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
 	});
 
-	test("diverged + live-bound: no disk write — forced re-handshake instead", async () => {
+	test("fix wave 1 (a): diverged + live-bound fires reset+enroll — NOTHING recorded until STEP2 commits", async () => {
 		const { engine, enroll, reset } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
@@ -410,85 +410,113 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(reset).toHaveBeenCalledWith("note-id-1");
 		expect(enroll).toHaveBeenCalledWith("note-id-1");
 		expect((mockApi as any).getUpdates).not.toHaveBeenCalled();
-	});
-
-	test("D3 verify-first: doc already projects the row snapshot — records convergence, NO handshake, NO REST", async () => {
-		const { engine, enroll, reset, projectedText } = crdtEngine();
-		projectedText.mockResolvedValue("caught up body");
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "old-hash" } });
-
-		await engine.applyChange({
-			path: "owned.md",
-			action: "upsert",
-			content: "caught up body",
-			content_hash: "new-hash",
-			version: 2,
-			mtime: 50,
-		} as any);
-
-		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
-		// `reset` only ever fires from socketConvergeLiveBound's unverified leg —
-		// the discriminator that proves verify-first skipped the re-handshake.
-		// (`enroll` alone is NOT that discriminator here: a pre-existing,
-		// out-of-scope safety net a few lines above this call — "an open, bound
-		// editor... this pull entry is the authoritative safety net" — enrolls
-		// any live-bound known note on every pull entry, converged or not, so it
-		// fires regardless of what socketConvergeLiveBound decides.)
-		expect(reset).not.toHaveBeenCalled();
-		expect((mockApi as any).getUpdates).not.toHaveBeenCalled();
-		expect(mockApp.vault.modify).not.toHaveBeenCalled();
-	});
-
-	test("D3 unverified: doc behind the row — fires reset+enroll over the socket, records NOTHING, NO REST", async () => {
-		const { engine, enroll, reset, projectedText } = crdtEngine();
-		projectedText.mockResolvedValue("stale local doc");
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "old-hash" } });
-
-		await engine.applyChange({
-			path: "owned.md",
-			action: "upsert",
-			content: "server body B never saw",
-			content_hash: "new-hash",
-			version: 2,
-			mtime: 50,
-		} as any);
-
-		expect(reset).toHaveBeenCalledWith("note-id-1");
-		expect(enroll).toHaveBeenCalledWith("note-id-1");
-		expect((mockApi as any).getUpdates).not.toHaveBeenCalled();
-		// never record convergence for data that has not verifiably arrived
+		// No text-verify shortcut anymore — a diverged row NEVER records on its
+		// own. Only a real STEP2/update apply (commitCrdtConvergence) can.
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
-		expect(mockApp.vault.modify).not.toHaveBeenCalled();
 	});
 
-	test("D3: projectedText throwing is isolated — falls through to the handshake, no convergence recorded", async () => {
-		const { engine, enroll, projectedText } = crdtEngine();
-		projectedText.mockRejectedValue(new Error("IDB dead"));
+	test("fix wave 1 (b): STEP2 commit records the staged serverHash/version/seq and clears bookkeeping", async () => {
+		const { engine } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		mockApp.vault.cachedRead.mockResolvedValue("real disk content");
 		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "old-hash" } });
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
 
 		await engine.applyChange({
 			path: "owned.md",
 			action: "upsert",
-			content: "server body",
+			content: "diverged body",
 			content_hash: "new-hash",
 			version: 2,
+			seq: 42,
 			mtime: 50,
 		} as any);
-
-		expect(enroll).toHaveBeenCalledWith("note-id-1");
+		// Nothing recorded yet — the diverged leg only staged it.
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+
+		// Simulates CrdtManager firing onSynced after a real inbound frame
+		// applies non-empty (see manager.ts markSynced / wiring.ts onSynced).
+		await engine.commitCrdtConvergence("note-id-1");
+
+		const state = engine.exportSyncState()["owned.md"];
+		expect(state?.serverHash).toBe("new-hash");
+		expect(state?.version).toBe(2);
+		expect(state?.seq).toBe(42);
+		// stored.hash was already 1 (imported baseline) — preserved, not
+		// recomputed from disk, since the editor owns the body.
+		expect(state?.hash).toBe(1);
+
+		// Idempotent: a second commit for the same id is a no-op (nothing
+		// staged anymore) — does not throw, does not touch syncState again.
+		await engine.commitCrdtConvergence("note-id-1");
+		expect(engine.exportSyncState()["owned.md"]).toEqual(state);
+	});
+
+	test("fix wave 1 (c): commit with nothing staged for the id is a no-op", async () => {
+		const { engine } = crdtEngine();
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await expect(engine.commitCrdtConvergence("never-staged-id")).resolves.toBeUndefined();
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+	});
+
+	test("fix wave 1 (d): per-note cooldown collapses two diverged rows to one handshake", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const c1 = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(c1);
+		await engine.applyChange(c1);
+
+		// Within the cooldown window (default 30s): only the first row actually
+		// fires STEP1 — the second is a cheap no-op, not a second handshake.
+		expect(reset).toHaveBeenCalledTimes(1);
+	});
+
+	test("fix wave 1 (f): a fresh content_hash overwrites the staged entry — commit lands the LATEST, not the first", async () => {
+		const { engine } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const c1 = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(c1);
+		// A NEWER row lands (e.g. a fan-out replay) before STEP2 ever committed
+		// h1 — this is a fresh episode and must overwrite the stage, not queue
+		// behind it.
+		await engine.applyChange({ ...c1, content_hash: "h2", version: 3 });
+
+		await engine.commitCrdtConvergence("note-id-1");
+
+		// h1 must never land — only the latest staged value commits.
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("h2");
+		expect(engine.exportSyncState()["owned.md"]?.version).toBe(3);
 	});
 
 	test("live-bound divergence for an UNMAPPED note (no note_id): quietly retries, never throws, never fakes convergence", async () => {
@@ -515,27 +543,25 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["unmapped.md"]?.serverHash).toBe("old-hash");
 	});
 
-	test("live-bound converge with no prior baseline records the REAL local hash, not a poisoning 0", async () => {
-		const { engine, projectedText } = crdtEngine();
+	test("STEP2 commit with no prior baseline records the REAL local hash, not a poisoning 0", async () => {
+		const { engine } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
 		mockApp.vault.cachedRead.mockResolvedValue("actual disk content");
-		// Row content ("x") already matches what the doc projects — verifies on
-		// the first pass, no getUpdates/REST involved.
-		projectedText.mockResolvedValue("x");
 		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		// NO importSyncState → stored is undefined for owned.md.
+		// NO importSyncState → stored is undefined for owned.md, so the commit
+		// falls back to reading disk (cachedRead) for the local hash.
 
-		const change = {
+		await engine.applyChange({
 			path: "owned.md",
 			action: "upsert",
 			content: "x",
 			content_hash: "h",
 			version: 2,
 			mtime: 1,
-		} as any;
-		for (let i = 0; i < 3; i++) await engine.applyChange(change);
+		} as any);
+		await engine.commitCrdtConvergence("note-id-1");
 
 		// A 0 sentinel here would later read as `fnv1a(local) !== 0` = local
 		// diverged, spuriously routing a note the user only VIEWED to the
@@ -544,43 +570,8 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["owned.md"]?.hash).not.toBe(0);
 	});
 
-	test("re-handshake attempt count resets when the server hash changes (new episode)", async () => {
-		const { engine, reset } = crdtEngine();
-		// REST catch-up unavailable in this scenario — only the episode
-		// bookkeeping of the re-handshake path is under test.
-		((mockApi as any).getUpdates as ReturnType<typeof mock>).mockRejectedValue(
-			new Error("HTTP 503"),
-		);
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({ "owned.md": { hash: 7, version: 1, serverHash: "h0" } });
-
-		// Two polls at hash h1 (attempts 1,2 — under the cap, not yet recorded).
-		const c1 = {
-			path: "owned.md",
-			action: "upsert",
-			content: "a",
-			content_hash: "h1",
-			version: 2,
-			mtime: 1,
-		} as any;
-		await engine.applyChange(c1);
-		await engine.applyChange(c1);
-		expect(reset).toHaveBeenCalledTimes(2);
-		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("h0");
-
-		// Server hash CHANGES (delivery progressed / a new remote edit): a fresh
-		// episode, so the count resets to 1 — it must NOT immediately give up and
-		// record convergence just because the total re-handshakes crossed the cap.
-		await engine.applyChange({ ...c1, content_hash: "h2", version: 3 });
-		expect(reset).toHaveBeenCalledTimes(3);
-		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("h0");
-	});
-
 	test("no spurious conflict: a VIEWED-then-cold note with the real hash recorded does NOT hit the conflict flow (#2 outcome)", async () => {
-		const { engine, projectedText } = crdtEngine({ conflictResolution: "modal" });
+		const { engine } = crdtEngine({ conflictResolution: "modal" });
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
@@ -588,12 +579,11 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		const onConflict = mock().mockResolvedValue({ choice: "skip" });
 		engine.onConflict = onConflict;
 
-		// Phase 1: note OPEN (live-bound), no prior baseline. The doc already
-		// projects the row's content ("x") — verifies immediately, records the
-		// REAL local disk hash, not a 0 sentinel.
+		// Phase 1: note OPEN (live-bound), no prior baseline. STEP2 commits the
+		// staged convergence, recording the REAL local disk hash, not a 0
+		// sentinel.
 		let live = true;
 		engine.setLiveBoundCheck((p: string) => live && p === "owned.md");
-		projectedText.mockResolvedValue("x");
 		const c1 = {
 			path: "owned.md",
 			action: "upsert",
@@ -602,7 +592,8 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 			version: 2,
 			mtime: 1,
 		} as any;
-		for (let i = 0; i < 3; i++) await engine.applyChange(c1);
+		await engine.applyChange(c1);
+		await engine.commitCrdtConvergence("note-id-1");
 		expect(engine.exportSyncState()["owned.md"]?.hash).toBe(fnv1a("viewed content"));
 
 		// Phase 2: user CLOSES the editor (note cold); a later poll brings a new

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -72,6 +72,13 @@ const mockApp = {
 	workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
 } as any;
 
+/** Real-timer wait, mirroring tests/sync-postpull-defer.test.ts's `flush` —
+ *  used with a shrunk `engine.healCooldownMs` to observe the trailing-fire
+ *  coalesce (fix wave 2) without mocking timers. */
+function flush(ms: number): Promise<void> {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
 function createEngine(overrides: Partial<typeof DEFAULT_SETTINGS> = {}): SyncEngine {
 	const engine = new SyncEngine(
 		mockApp,
@@ -485,8 +492,130 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		await engine.applyChange(c1);
 		await engine.applyChange(c1);
 
-		// Within the cooldown window (default 30s): only the first row actually
+		// Within the cooldown window (default 15s): only the first row actually
 		// fires STEP1 — the second is a cheap no-op, not a second handshake.
+		expect(reset).toHaveBeenCalledTimes(1);
+	});
+
+	test("fix wave 2 (a): a suppressed poke arms a trailing fire — reset+enroll fires exactly once more after the window", async () => {
+		const { engine, reset } = crdtEngine();
+		engine.healCooldownMs = 30;
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const c1 = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(c1); // immediate fire
+		expect(reset).toHaveBeenCalledTimes(1);
+
+		await engine.applyChange(c1); // suppressed — must NOT drop; arms a trailing fire
+		expect(reset).toHaveBeenCalledTimes(1);
+
+		await flush(60); // past the window
+		expect(reset).toHaveBeenCalledTimes(2);
+
+		engine.destroy();
+	});
+
+	test("fix wave 2 (b): three suppressed pokes for the same note coalesce into ONE trailing fire", async () => {
+		const { engine, reset } = crdtEngine();
+		engine.healCooldownMs = 30;
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const c1 = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(c1); // immediate fire
+		await engine.applyChange(c1); // suppressed — arms the trailing timer
+		await engine.applyChange(c1); // suppressed — already coalesced, no 2nd timer
+		await engine.applyChange(c1); // suppressed — already coalesced, no 3rd timer
+		expect(reset).toHaveBeenCalledTimes(1);
+
+		await flush(60);
+		// Exactly one trailing fire for all three coalesced pokes, not three.
+		expect(reset).toHaveBeenCalledTimes(2);
+
+		engine.destroy();
+	});
+
+	test("fix wave 2 (c): the trailing fire records a NEW cooldown timestamp (not stale from the suppressed poke)", async () => {
+		const { engine, reset } = crdtEngine();
+		engine.healCooldownMs = 30;
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const c1 = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(c1); // immediate fire #1, cooldown starts at t0
+		await engine.applyChange(c1); // suppressed — arms a trailing timer that
+		// fires at t0+healCooldownMs regardless of when this poke landed.
+		// Wait just past that (not a second full window) so the follow-up poke
+		// below still lands inside the trailing fire's OWN fresh window.
+		await flush(40);
+		expect(reset).toHaveBeenCalledTimes(2);
+
+		// A poke immediately after the trailing fire must be suppressed — if the
+		// trailing fire had NOT refreshed the cooldown timestamp (stayed at the
+		// original suppressed-attempt time, or unset), this would wrongly fire
+		// immediately as a 3rd handshake.
+		await engine.applyChange(c1);
+		expect(reset).toHaveBeenCalledTimes(2);
+
+		engine.destroy();
+	});
+
+	test("fix wave 2 (d): destroy() clears a pending trailing timer — it never fires after teardown", async () => {
+		const { engine, reset } = crdtEngine();
+		engine.healCooldownMs = 30;
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const c1 = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(c1); // immediate fire
+		await engine.applyChange(c1); // suppressed — arms the trailing timer
+		expect(reset).toHaveBeenCalledTimes(1);
+
+		engine.destroy();
+		await flush(60); // past what would have been the trailing-fire window
+
+		// Torn down: the armed trailing timer must never fire.
 		expect(reset).toHaveBeenCalledTimes(1);
 	});
 

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -477,6 +477,125 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 	});
 
+	test("fix wave 7 (a): verified commit + bound buffer already matches the converged doc — no rebind, no nudge", async () => {
+		const { engine, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		const rebinds: string[] = [];
+		engine.setCrdtEditorRebind((p: string) => rebinds.push(p));
+		const nudges: string[] = [];
+		engine.setCrdtRequestSave((p: string) => nudges.push(p));
+		// The editor repainted correctly — its buffer already holds the
+		// converged content.
+		engine.setCrdtBoundBufferText((p: string) => (p === "owned.md" ? "diverged body" : null));
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "diverged body",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 42,
+			mtime: 50,
+		} as any);
+
+		projectedText.mockResolvedValue("diverged body");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
+		expect(rebinds).toEqual([]);
+		expect(nudges).toEqual([]);
+	});
+
+	test("fix wave 7 (b): verified commit + STALE bound buffer (phantom binding, #191) — rebinds exactly once, then nudges the save", async () => {
+		const { engine, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		const rebinds: string[] = [];
+		engine.setCrdtEditorRebind((p: string) => rebinds.push(p));
+		const nudges: string[] = [];
+		engine.setCrdtRequestSave((p: string) => nudges.push(p));
+		// The editor's Yjs binding detached (unclean close during a rate-limit
+		// window) while isLiveBound stayed true — its buffer never repainted,
+		// so it still shows the pre-converge content.
+		engine.setCrdtBoundBufferText((p: string) =>
+			p === "owned.md" ? "STALE — never repainted" : null,
+		);
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "diverged body",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 42,
+			mtime: 50,
+		} as any);
+
+		projectedText.mockResolvedValue("diverged body");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		// Convergence still records — the doc itself is fine, only the editor
+		// binding was phantom.
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
+		expect(rebinds).toEqual(["owned.md"]);
+		expect(nudges).toEqual(["owned.md"]);
+	});
+
+	test("fix wave 7 (c): the path is no longer live-bound BY COMMIT TIME (editor closed meanwhile) — phantom-binding check never runs", async () => {
+		const { engine, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		let liveBound = true; // live-bound at staging time — required to stage content
+		engine.setLiveBoundCheck((p: string) => liveBound && p === "owned.md");
+		const rebinds: string[] = [];
+		engine.setCrdtEditorRebind((p: string) => rebinds.push(p));
+		const nudges: string[] = [];
+		engine.setCrdtRequestSave((p: string) => nudges.push(p));
+		const bufferReads: string[] = [];
+		engine.setCrdtBoundBufferText((p: string) => {
+			bufferReads.push(p);
+			return "would-mismatch-if-checked";
+		});
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "diverged body",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 42,
+			mtime: 50,
+		} as any);
+
+		// The editor closed between staging and the STEP2 commit — the note is
+		// no longer live-bound. The commit itself checks isLiveBound fresh, so
+		// this must gate the phantom-binding check off entirely (nothing to
+		// rebind — there's no editor left to be phantom).
+		liveBound = false;
+		projectedText.mockResolvedValue("diverged body");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
+		expect(bufferReads).toEqual([]); // gated by isLiveBound before ever reading the buffer
+		expect(rebinds).toEqual([]);
+		expect(nudges).toEqual([]);
+	});
+
 	test("fix wave 5 defect 2 (2): a mismatched projectedText defers the commit — stage retained; a later match commits it", async () => {
 		const { engine, projectedText } = crdtEngine();
 		const localFile = new TFile("owned.md");

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -409,40 +409,86 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(mockApp.vault.modify).not.toHaveBeenCalled();
 		expect(reset).toHaveBeenCalledWith("note-id-1");
 		expect(enroll).toHaveBeenCalledWith("note-id-1");
+		expect((mockApi as any).getUpdates).not.toHaveBeenCalled();
 	});
 
-	test("live-bound divergence: REST catch-up applies the missing delta to the live doc and records REAL convergence (2026-07-14 deaf-note fix)", async () => {
-		const { engine, reset, applyRemoteUpdate } = crdtEngine();
+	test("D3 verify-first: doc already projects the row snapshot — records convergence, NO handshake, NO REST", async () => {
+		const { engine, enroll, reset, projectedText } = crdtEngine();
+		projectedText.mockResolvedValue("caught up body");
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
 		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({
-			"owned.md": { hash: 7, version: 1, serverHash: "old-hash" },
-		});
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "old-hash" } });
 
 		await engine.applyChange({
 			path: "owned.md",
 			action: "upsert",
-			content: "diverged body",
+			content: "caught up body",
 			content_hash: "new-hash",
 			version: 2,
 			mtime: 50,
 		} as any);
 
-		// The missed ops are pulled over REST (deterministic — not a hope that
-		// the room broadcast works) and applied to the LIVE doc; the editor
-		// binding paints them. Only then is convergence recorded.
-		expect(reset).toHaveBeenCalledWith("note-id-1");
-		expect((mockApi as any).getUpdates).toHaveBeenCalledWith("note-id-1", expect.any(String));
-		expect(applyRemoteUpdate).toHaveBeenCalledWith("note-id-1", expect.any(Uint8Array));
-		expect(mockApp.vault.modify).not.toHaveBeenCalled();
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
-		// Editor owns the body (no disk write) → the real local hash is preserved.
-		expect(engine.exportSyncState()["owned.md"]?.hash).toBe(7);
-		// The converged head must SURVIVE the convergence record — a bare
-		// syncState replacement wiped it, defeating coldReceive's cost gate.
-		expect(engine.exportSyncState()["owned.md"]?.crdtHead).toBe("head-1");
+		// `reset` only ever fires from socketConvergeLiveBound's unverified leg —
+		// the discriminator that proves verify-first skipped the re-handshake.
+		// (`enroll` alone is NOT that discriminator here: a pre-existing,
+		// out-of-scope safety net a few lines above this call — "an open, bound
+		// editor... this pull entry is the authoritative safety net" — enrolls
+		// any live-bound known note on every pull entry, converged or not, so it
+		// fires regardless of what socketConvergeLiveBound decides.)
+		expect(reset).not.toHaveBeenCalled();
+		expect((mockApi as any).getUpdates).not.toHaveBeenCalled();
+		expect(mockApp.vault.modify).not.toHaveBeenCalled();
+	});
+
+	test("D3 unverified: doc behind the row — fires reset+enroll over the socket, records NOTHING, NO REST", async () => {
+		const { engine, enroll, reset, projectedText } = crdtEngine();
+		projectedText.mockResolvedValue("stale local doc");
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "old-hash" } });
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "server body B never saw",
+			content_hash: "new-hash",
+			version: 2,
+			mtime: 50,
+		} as any);
+
+		expect(reset).toHaveBeenCalledWith("note-id-1");
+		expect(enroll).toHaveBeenCalledWith("note-id-1");
+		expect((mockApi as any).getUpdates).not.toHaveBeenCalled();
+		// never record convergence for data that has not verifiably arrived
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+		expect(mockApp.vault.modify).not.toHaveBeenCalled();
+	});
+
+	test("D3: projectedText throwing is isolated — falls through to the handshake, no convergence recorded", async () => {
+		const { engine, enroll, projectedText } = crdtEngine();
+		projectedText.mockRejectedValue(new Error("IDB dead"));
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "old-hash" } });
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "server body",
+			content_hash: "new-hash",
+			version: 2,
+			mtime: 50,
+		} as any);
+
+		expect(enroll).toHaveBeenCalledWith("note-id-1");
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 	});
 
 	test("live-bound divergence for an UNMAPPED note (no note_id): quietly retries, never throws, never fakes convergence", async () => {
@@ -469,90 +515,15 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["unmapped.md"]?.serverHash).toBe("old-hash");
 	});
 
-	test("live-bound divergence: encodeStateVector throwing is isolated — retry next poll, no convergence recorded", async () => {
-		const { engine, encodeStateVector, applyRemoteUpdate } = crdtEngine();
-		encodeStateVector.mockRejectedValue(new Error("doc destroyed mid-open"));
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({
-			"owned.md": { hash: 7, version: 1, serverHash: "old-hash" },
-		});
-
-		await engine.applyChange({
-			path: "owned.md",
-			action: "upsert",
-			content: "diverged body",
-			content_hash: "new-hash",
-			version: 2,
-			mtime: 50,
-		} as any);
-
-		expect(applyRemoteUpdate).not.toHaveBeenCalled();
-		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
-	});
-
-	test("live-bound divergence: REST catch-up FAILURE never fakes convergence — serverHash stays unrecorded so every poll retries", async () => {
-		const { engine, reset, applyRemoteUpdate } = crdtEngine();
-		((mockApi as any).getUpdates as ReturnType<typeof mock>).mockRejectedValue(
-			new Error("HTTP 500"),
-		);
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({
-			"owned.md": { hash: 7, version: 1, serverHash: "old-hash" },
-		});
-
-		const change = {
-			path: "owned.md",
-			action: "upsert",
-			content: "diverged body",
-			content_hash: "new-hash",
-			version: 2,
-			mtime: 50,
-		} as any;
-		for (let i = 0; i < 5; i++) await engine.applyChange(change);
-
-		// The old bounded give-up recorded convergence after 3 attempts WITHOUT
-		// the data ever arriving — a silent data hole (the live-edit deaf-note
-		// incident). Now: keep retrying at the poll cadence, never lie.
-		expect(reset).toHaveBeenCalledTimes(5);
-		expect(applyRemoteUpdate).not.toHaveBeenCalled();
-		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
-	});
-
-	test("live-bound divergence: a delta that leaves a pending gap does NOT record convergence", async () => {
-		const { engine, hasPendingGap } = crdtEngine();
-		hasPendingGap.mockResolvedValue(true);
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		engine.setLiveBoundCheck((p: string) => p === "owned.md");
-		engine.importSyncState({
-			"owned.md": { hash: 7, version: 1, serverHash: "old-hash" },
-		});
-
-		await engine.applyChange({
-			path: "owned.md",
-			action: "upsert",
-			content: "diverged body",
-			content_hash: "new-hash",
-			version: 2,
-			mtime: 50,
-		} as any);
-
-		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
-	});
-
 	test("live-bound converge with no prior baseline records the REAL local hash, not a poisoning 0", async () => {
-		const { engine } = crdtEngine();
+		const { engine, projectedText } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
 		mockApp.vault.cachedRead.mockResolvedValue("actual disk content");
+		// Row content ("x") already matches what the doc projects — verifies on
+		// the first pass, no getUpdates/REST involved.
+		projectedText.mockResolvedValue("x");
 		engine.setLiveBoundCheck((p: string) => p === "owned.md");
 		// NO importSyncState → stored is undefined for owned.md.
 
@@ -609,7 +580,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	});
 
 	test("no spurious conflict: a VIEWED-then-cold note with the real hash recorded does NOT hit the conflict flow (#2 outcome)", async () => {
-		const { engine } = crdtEngine({ conflictResolution: "modal" });
+		const { engine, projectedText } = crdtEngine({ conflictResolution: "modal" });
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
@@ -617,10 +588,12 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		const onConflict = mock().mockResolvedValue({ choice: "skip" });
 		engine.onConflict = onConflict;
 
-		// Phase 1: note OPEN (live-bound), no prior baseline, diverges → after the
-		// retry cap it records the REAL local hash, not a 0 sentinel.
+		// Phase 1: note OPEN (live-bound), no prior baseline. The doc already
+		// projects the row's content ("x") — verifies immediately, records the
+		// REAL local disk hash, not a 0 sentinel.
 		let live = true;
 		engine.setLiveBoundCheck((p: string) => live && p === "owned.md");
+		projectedText.mockResolvedValue("x");
 		const c1 = {
 			path: "owned.md",
 			action: "upsert",

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -423,7 +423,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	});
 
 	test("fix wave 1 (b): STEP2 commit records the staged serverHash/version/seq and clears bookkeeping", async () => {
-		const { engine } = crdtEngine();
+		const { engine, projectedText } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
@@ -445,8 +445,12 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		// Nothing recorded yet — the diverged leg only staged it.
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 
-		// Simulates CrdtManager firing onSynced after a real inbound frame
-		// applies non-empty (see manager.ts markSynced / wiring.ts onSynced).
+		// Fix wave 5: the commit is content-verified — the doc must actually
+		// project the staged row's text before commitCrdtConvergence records
+		// anything. Simulates CrdtManager firing onSynced after the real
+		// inbound frame (the staged row's own ops) applies non-empty (see
+		// manager.ts markSynced / wiring.ts onSynced).
+		projectedText.mockResolvedValue("diverged body");
 		await engine.commitCrdtConvergence("note-id-1");
 
 		const state = engine.exportSyncState()["owned.md"];
@@ -470,6 +474,69 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		});
 
 		await expect(engine.commitCrdtConvergence("never-staged-id")).resolves.toBeUndefined();
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+	});
+
+	test("fix wave 5 defect 2 (2): a mismatched projectedText defers the commit — stage retained; a later match commits it", async () => {
+		const { engine, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "the real edit",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 10,
+			mtime: 50,
+		} as any);
+
+		// An UNRELATED inbound frame fires onSynced before the staged row's own
+		// ops land (CI run 29920053637: committed 1ms after the re-handshake
+		// fired) — the doc doesn't project the staged text yet.
+		projectedText.mockResolvedValue("some other concurrent doc state");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		// Deferred — nothing recorded, the stage is retained.
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+
+		// The staged row's own ops arrive — the doc now projects the staged
+		// text. The next onSynced fire (this commit call) records it.
+		projectedText.mockResolvedValue("the real edit");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("new-hash");
+	});
+
+	test("fix wave 5 defect 2 (4): projectedText throwing at commit time defers — never commits on error", async () => {
+		const { engine, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "the real edit",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 10,
+			mtime: 50,
+		} as any);
+
+		projectedText.mockRejectedValue(new Error("IDB dead"));
+		await expect(engine.commitCrdtConvergence("note-id-1")).resolves.toBeUndefined();
+
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 	});
 
@@ -714,6 +781,36 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 	});
 
+	test("fix wave 5 defect 1: a seq-bearing row with NO stored.seq is NOT stale, even at equal version (CI run 29920053637: `stale row (seq 33/- v1/1)`)", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		// stored carries NO seq (this device never recorded one for this path
+		// yet) but DOES carry version:1 — the wave-3 fence's old condition
+		// ("both sides carry seq") fell back to version equality here and
+		// wrongly judged the row stale. With no stored.seq there is nothing to
+		// be behind of, so a seq-bearing row must never fall back to version.
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "the real edit",
+			content_hash: "new-hash",
+			version: 1, // equal to stored — would mask under the version fallback
+			seq: 33,
+			mtime: 50,
+		} as any);
+
+		// The row carries seq, so it's judged by seq alone (no stored.seq to
+		// compare against) — NOT stale, the diverged leg must run.
+		expect(reset).toHaveBeenCalledWith("note-id-1");
+	});
+
 	test("fix wave 4 (a): CI scenario end-to-end — mapped CRDT note, version-equal seq-ahead row reaches the diverged leg WITHOUT forceOverwrite", async () => {
 		const { engine, reset } = crdtEngine();
 		const localFile = new TFile("owned.md");
@@ -794,7 +891,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	});
 
 	test("fix wave 1 (f): a fresh content_hash overwrites the staged entry — commit lands the LATEST, not the first", async () => {
-		const { engine } = crdtEngine();
+		const { engine, projectedText } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
@@ -815,6 +912,9 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		// behind it.
 		await engine.applyChange({ ...c1, content_hash: "h2", version: 3 });
 
+		// Fix wave 5: content-verify against the LATEST staged content ("a" —
+		// unchanged by the second applyChange call above).
+		projectedText.mockResolvedValue("a");
 		await engine.commitCrdtConvergence("note-id-1");
 
 		// h1 must never land — only the latest staged value commits.
@@ -847,7 +947,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	});
 
 	test("STEP2 commit with no prior baseline records the REAL local hash, not a poisoning 0", async () => {
-		const { engine } = crdtEngine();
+		const { engine, projectedText } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
@@ -864,6 +964,8 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 			version: 2,
 			mtime: 1,
 		} as any);
+		// Fix wave 5: content-verify against the staged row's own text ("x").
+		projectedText.mockResolvedValue("x");
 		await engine.commitCrdtConvergence("note-id-1");
 
 		// A 0 sentinel here would later read as `fnv1a(local) !== 0` = local
@@ -874,7 +976,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	});
 
 	test("no spurious conflict: a VIEWED-then-cold note with the real hash recorded does NOT hit the conflict flow (#2 outcome)", async () => {
-		const { engine } = crdtEngine({ conflictResolution: "modal" });
+		const { engine, projectedText } = crdtEngine({ conflictResolution: "modal" });
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
@@ -896,6 +998,8 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 			mtime: 1,
 		} as any;
 		await engine.applyChange(c1);
+		// Fix wave 5: content-verify against the staged row's own text ("x").
+		projectedText.mockResolvedValue("x");
 		await engine.commitCrdtConvergence("note-id-1");
 		expect(engine.exportSyncState()["owned.md"]?.hash).toBe(fnv1a("viewed content"));
 

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -714,6 +714,85 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 	});
 
+	test("fix wave 4 (a): CI scenario end-to-end — mapped CRDT note, version-equal seq-ahead row reaches the diverged leg WITHOUT forceOverwrite", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, seq: 40, version: 1, serverHash: "old-hash" },
+		});
+
+		// "owned.md" is mapped to "note-id-1" by crdtEngine()'s harness. The
+		// anti-stale guard (src/sync.ts ~5074) now skips only when CRDT owns
+		// the body AND a noteId resolves — this row satisfies both, so it
+		// reaches the CRDT block's own seq-first staleRow fence directly. No
+		// forceOverwrite lever needed (unlike wave 3's tests, written before
+		// this fix, which had to dodge the guard to reach the same fence).
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "unseen edit",
+			content_hash: "new-hash",
+			version: 1, // checkpoint-lagged, equal to stored
+			seq: 41,
+			mtime: 50,
+		} as any);
+
+		expect(reset).toHaveBeenCalledWith("note-id-1");
+	});
+
+	test("fix wave 4 (b): a non-CRDT note's version-equality is still guarded (legacy path preserved)", async () => {
+		const engine = createEngine(); // no setCrdtManager — this.crdt stays null
+		const localFile = new TFile("plain.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		engine.importSyncState({
+			"plain.md": { hash: fnv1a("body"), version: 1, serverHash: "h1" },
+		});
+
+		const applied = await engine.applyChange({
+			path: "plain.md",
+			action: "upsert",
+			content: "server body",
+			content_hash: "h2",
+			version: 1, // equal — crdtOwnsBody is false, the guard still applies
+			mtime: 50,
+		} as any);
+
+		expect(applied).toBe(false);
+		expect(mockApp.vault.modify).not.toHaveBeenCalled();
+	});
+
+	test("fix wave 4 (c2): a CRDT-managed row with NO resolvable noteId is still guarded (the no-noteId raw-write branch found in the safety check stays protected)", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("unmapped.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck(() => false); // cold — would otherwise reach the
+		// no-noteId sub-branch (src/sync.ts ~5262-5277) that does a raw
+		// content-snapshot write with no Yjs convergence.
+		engine.importSyncState({
+			"unmapped.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		// "unmapped.md" was never map.set() in crdtEngine()'s harness, so
+		// noteId resolves to null — crdtOwnsBody && noteId is false and the
+		// version guard still applies.
+		const applied = await engine.applyChange({
+			path: "unmapped.md",
+			action: "upsert",
+			content: "server body",
+			content_hash: "new-hash",
+			version: 1, // equal — no resolvable id, guard applies
+			mtime: 50,
+		} as any);
+
+		expect(applied).toBe(false);
+		expect(reset).not.toHaveBeenCalled();
+		expect(mockApp.vault.modify).not.toHaveBeenCalled();
+	});
+
 	test("fix wave 1 (f): a fresh content_hash overwrites the staged entry — commit lands the LATEST, not the first", async () => {
 		const { engine } = crdtEngine();
 		const localFile = new TFile("owned.md");

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -619,6 +619,101 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(reset).toHaveBeenCalledTimes(1);
 	});
 
+	test("fix wave 3 (a): seq decides the staleRow fence — a newer seq with equal version RUNS the diverged leg (D3 gate forensics, issue #282)", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, seq: 40, version: 1, serverHash: "old-hash" },
+		});
+
+		// forceOverwrite=true: isolates the CRDT-specific staleRow fence under
+		// test from the separate, out-of-scope, non-CRDT "anti-stale guard"
+		// (applyChange skip "stale vN <= synced vN", src/sync.ts:5053) — that
+		// guard runs BEFORE the CRDT block and independently short-circuits on
+		// change.version <= stored.version alone (no seq awareness at all), so
+		// this exact equal-version row would otherwise never reach the fence
+		// being fixed here. That guard is its own, separate concern (a
+		// mid-pull-push race guard, not CRDT-specific) — not touched by this
+		// task's scope.
+		await engine.applyChange(
+			{
+				path: "owned.md",
+				action: "upsert",
+				content: "unseen edit",
+				content_hash: "new-hash",
+				// Checkpoint-lagged version equal to stored — under the old
+				// OR-of-both-checks fence this alone masked the row as stale even
+				// though the seq below proves it's genuinely newer (the CI gate
+				// flake: "stale row" skip x2, the note converged only at teardown).
+				version: 1,
+				seq: 41,
+				mtime: 50,
+			} as any,
+			true,
+		);
+
+		// seq alone proves this row is newer — the diverged leg must run, not
+		// be fence-skipped as history.
+		expect(reset).toHaveBeenCalledWith("note-id-1");
+	});
+
+	test("fix wave 3 (b): equal seq is still stale — the fence is preserved (PR #280 scope, untouched)", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, seq: 40, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "replayed row",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 40, // equal to stored.seq — still history, must still skip
+			mtime: 50,
+		} as any);
+
+		expect(reset).not.toHaveBeenCalled();
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+	});
+
+	test("fix wave 3 (c): seq absent on the row falls back to version — the legacy skip path is preserved", async () => {
+		const { engine, reset } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" }, // no seq recorded
+		});
+
+		// forceOverwrite=true: same isolation as fix wave 3 (a) — an equal
+		// version here would ALSO trip the separate, out-of-scope anti-stale
+		// guard at src/sync.ts:5053 before ever reaching the CRDT fence's
+		// version-fallback branch this test targets.
+		await engine.applyChange(
+			{
+				path: "owned.md",
+				action: "upsert",
+				content: "legacy row, no seq field",
+				content_hash: "new-hash",
+				version: 1, // equal, no seq on either side — version fallback applies
+				mtime: 50,
+			} as any,
+			true,
+		);
+
+		expect(reset).not.toHaveBeenCalled();
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+	});
+
 	test("fix wave 1 (f): a fresh content_hash overwrites the staged entry — commit lands the LATEST, not the first", async () => {
 		const { engine } = crdtEngine();
 		const localFile = new TFile("owned.md");

--- a/tests/sync-heal-on-open.test.ts
+++ b/tests/sync-heal-on-open.test.ts
@@ -9,13 +9,13 @@
  * a fan-out storm stayed diverged until an unrelated reconnect, because
  * file-open (main.ts) is now a pure local bind with no convergence check.
  *
- * Why this doesn't reintroduce the old lag: healNoteOnOpen does no
- * synchronous manifest-hash comparison and no reset/enroll re-handshake — it
- * just asks for the delta since our real state vector for the ONE opened
- * note via the existing guarded `restConvergeLiveBound`, which is a no-op
- * when already converged. Live-bound-only first cut (design decision iii):
- * an idle (non-live-bound) note is left to reconnect catch-up (#5), so this
- * heal never does a vault-wide heads fetch.
+ * Single-path D3 (socket-native converge): healNoteOnOpen no longer pulls a
+ * REST delta. It fires `socketConvergeLiveBound` WITHOUT a row snapshot
+ * (there is none at open time — see src/sync.ts), so the primitive always
+ * re-fires STEP1 (reset+enroll); the room sv-exchange delivers whatever this
+ * doc is missing over the socket and paints it through the binding — a
+ * near-no-op STEP2 when the note was already converged. No manifest fetch,
+ * no REST round trip.
  *
  * Mirrors the mock-engine pattern from tests/sync-socket-catchup.test.ts.
  */
@@ -42,8 +42,11 @@ function confirm(engine: SyncEngine, noteId: string): void {
 function makeEngine(
 	crdt: Partial<CrdtManager>,
 	api: Partial<EngramApi>,
-	opts?: { liveBound?: boolean },
-): SyncEngine {
+	opts?: {
+		liveBound?: boolean;
+		enrollment?: { enroll: ReturnType<typeof mock>; reset: ReturnType<typeof mock> };
+	},
+): { engine: SyncEngine; enroll: ReturnType<typeof mock>; reset: ReturnType<typeof mock> } {
 	const mockApi = {
 		getUpdates: mock().mockResolvedValue({ update: new Uint8Array(), head: "head-1" }),
 		...api,
@@ -58,63 +61,51 @@ function makeEngine(
 	e.setCrdtManager(crdt as unknown as CrdtManager);
 	e.setReady();
 	e.setLiveBoundCheck(() => opts?.liveBound ?? true);
+	const enroll = opts?.enrollment?.enroll ?? mock();
+	const reset = opts?.enrollment?.reset ?? mock();
+	e.setCrdtEnrollment({ enroll, reset });
 	const map = new NoteIdMap();
 	map.set("Notes/a.md", "id-a");
 	e.setNoteIdMap(map);
 	confirm(e, "id-a");
-	return e;
+	return { engine: e, enroll, reset };
 }
 
 describe("healNoteOnOpen", () => {
-	test("live-bound note: applies the delta since our real state vector via restConvergeLiveBound", async () => {
-		const applied: Array<[string, Uint8Array]> = [];
-		const crdt = {
-			applyRemoteUpdate: (id: string, update: Uint8Array) => {
-				applied.push([id, update]);
-				return Promise.resolve();
-			},
-			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([1])),
-		};
-		const engine = makeEngine(crdt, {
-			getUpdates: mock().mockResolvedValue({
-				update: new Uint8Array([9, 9]),
-				head: "head-2",
-			}),
+	test("live-bound note: fires the socket re-handshake (reset+enroll) — no REST, no disk write", async () => {
+		const getUpdates = mock().mockResolvedValue({
+			update: new Uint8Array([9, 9]),
+			head: "head-2",
 		});
-
-		await engine.healNoteOnOpen("Notes/a.md");
-
-		expect(applied).toEqual([["id-a", new Uint8Array([9, 9])]]);
-		expect((engine as any).getCrdtHead("Notes/a.md")).toBe("head-2");
-	});
-
-	test("already-converged note: the delta is empty and the head still advances to the returned head — no reset, no re-handshake", async () => {
-		const applied: Array<[string, Uint8Array]> = [];
-		const getUpdates = mock().mockResolvedValue({ update: new Uint8Array(), head: "same" });
-		const crdt = {
-			applyRemoteUpdate: (id: string, update: Uint8Array) => {
-				applied.push([id, update]);
-				return Promise.resolve();
-			},
-			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([1])),
-		};
-		const engine = makeEngine(crdt, { getUpdates });
-
-		await engine.healNoteOnOpen("Notes/a.md");
-
-		expect(applied).toEqual([["id-a", new Uint8Array()]]); // empty delta — near-no-op
-		// Exactly one REST call (getUpdates) — no manifest fetch, no separate
-		// reset/enroll round trip: the #203 false-fire lag source is absent.
-		expect(getUpdates).toHaveBeenCalledTimes(1);
-	});
-
-	test("idle (not live-bound) confirmed note: no-op in the first cut — no catch-up replay", async () => {
 		const applyRemoteUpdate = mock().mockResolvedValue(undefined);
 		const crdt = {
 			applyRemoteUpdate,
-			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([1])),
+			projectedText: mock().mockResolvedValue("whatever"),
 		};
-		const engine = makeEngine(crdt, {}, { liveBound: false });
+		const { engine, enroll, reset } = makeEngine(crdt, { getUpdates });
+
+		await engine.healNoteOnOpen("Notes/a.md");
+
+		expect(reset).toHaveBeenCalledWith("id-a");
+		expect(enroll).toHaveBeenCalledWith("id-a");
+		expect(getUpdates).not.toHaveBeenCalled();
+		expect(applyRemoteUpdate).not.toHaveBeenCalled();
+	});
+
+	test("already-converged note: still fires reset+enroll (idempotent — STEP2 is a near-no-op server-side)", async () => {
+		const crdt = { projectedText: mock().mockResolvedValue("same") };
+		const { engine, enroll, reset } = makeEngine(crdt, {});
+
+		await engine.healNoteOnOpen("Notes/a.md");
+		await engine.healNoteOnOpen("Notes/a.md");
+
+		expect(reset).toHaveBeenCalledTimes(2);
+		expect(enroll).toHaveBeenCalledTimes(2);
+	});
+
+	test("idle (not live-bound) confirmed note: no-op in the first cut — no catch-up replay", async () => {
+		const crdt = { projectedText: mock().mockResolvedValue("x") };
+		const { engine, enroll, reset } = makeEngine(crdt, {}, { liveBound: false });
 		let replayed = false;
 		engine.setCrdtCatchupSince(async () => {
 			replayed = true;
@@ -124,15 +115,16 @@ describe("healNoteOnOpen", () => {
 		await engine.healNoteOnOpen("Notes/a.md");
 
 		expect(replayed).toBe(false); // confirmed + idle → left to reconnect catch-up (#5)
-		expect(applyRemoteUpdate).not.toHaveBeenCalled();
+		expect(reset).not.toHaveBeenCalled();
+		expect(enroll).not.toHaveBeenCalled();
 	});
 
 	test("unmapped path: no-op (nothing to heal against)", async () => {
-		const applyRemoteUpdate = mock().mockResolvedValue(undefined);
-		const engine = makeEngine({ applyRemoteUpdate }, {});
+		const { engine, reset, enroll } = makeEngine({}, {});
 
 		await expect(engine.healNoteOnOpen("Notes/unknown.md")).resolves.toBeUndefined();
-		expect(applyRemoteUpdate).not.toHaveBeenCalled();
+		expect(reset).not.toHaveBeenCalled();
+		expect(enroll).not.toHaveBeenCalled();
 	});
 
 	test("unconfirmed note: no-op (no server row known yet)", async () => {
@@ -159,14 +151,11 @@ describe("healNoteOnOpen", () => {
 	test("opened-but-unconfirmed note: converges over the seq-replay op-log, not REST", async () => {
 		// A note opened after being discovered via catch-up/fan-out but never
 		// handshaked (unconfirmed). It must not wait for the next reconnect — heal
-		// converges it over the one catch-up path (crdt_catchup_since), NOT via
-		// REST restConvergeLiveBound.
+		// converges it over the one catch-up path (crdt_catchup_since), NOT the
+		// socket re-handshake primitive.
 		const getUpdates = mock().mockResolvedValue({ update: new Uint8Array(), head: "h" });
-		const crdt = {
-			applyRemoteUpdate: mock().mockResolvedValue(undefined),
-			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([1])),
-		};
-		const engine = makeEngine(crdt, { getUpdates });
+		const crdt = { projectedText: mock().mockResolvedValue("x") };
+		const { engine, reset } = makeEngine(crdt, { getUpdates });
 		(engine as unknown as { confirmedNoteIds: Set<string> }).confirmedNoteIds.delete("id-a");
 		let replayed = false;
 		engine.setCrdtCatchupSince(async () => {
@@ -178,6 +167,7 @@ describe("healNoteOnOpen", () => {
 
 		expect(replayed).toBe(true); // seq-replay catch-up ran
 		expect(getUpdates).not.toHaveBeenCalled(); // NOT the REST heal path
+		expect(reset).not.toHaveBeenCalled(); // NOT the socket re-handshake path
 	});
 
 	test("crdt disabled: no-op", async () => {
@@ -194,12 +184,16 @@ describe("healNoteOnOpen", () => {
 		expect(applyRemoteUpdate).not.toHaveBeenCalled();
 	});
 
-	test("never throws — a failure in the delta fetch is caught and swallowed", async () => {
-		const crdt = {
-			applyRemoteUpdate: mock().mockResolvedValue(undefined),
-			encodeStateVector: (_id: string) => Promise.reject(new Error("boom")),
-		};
-		const engine = makeEngine(crdt, {});
+	test("never throws — a failure inside the socket re-handshake is caught and swallowed", async () => {
+		const crdt = {};
+		const failingReset = mock().mockImplementation(() => {
+			throw new Error("boom");
+		});
+		const { engine } = makeEngine(
+			crdt,
+			{},
+			{ enrollment: { enroll: mock(), reset: failingReset } },
+		);
 
 		await expect(engine.healNoteOnOpen("Notes/a.md")).resolves.toBeUndefined();
 	});

--- a/tests/sync-heal-on-open.test.ts
+++ b/tests/sync-heal-on-open.test.ts
@@ -9,12 +9,15 @@
  * a fan-out storm stayed diverged until an unrelated reconnect, because
  * file-open (main.ts) is now a pure local bind with no convergence check.
  *
- * Single-path D3 (socket-native converge): healNoteOnOpen no longer pulls a
- * REST delta. It fires `socketConvergeLiveBound` WITHOUT a row snapshot
- * (there is none at open time — see src/sync.ts), so the primitive always
- * re-fires STEP1 (reset+enroll); the room sv-exchange delivers whatever this
- * doc is missing over the socket and paints it through the binding — a
- * near-no-op STEP2 when the note was already converged. No manifest fetch,
+ * Single-path D3 (socket-native converge, fix wave 1): healNoteOnOpen no
+ * longer pulls a REST delta. It fires `socketConvergeLiveBound`, which always
+ * re-fires STEP1 (reset+enroll) on a diverged note — no text-verify skip
+ * (text equality doesn't prove the doc holds the server's ops); the room
+ * sv-exchange delivers whatever this doc is missing over the socket and
+ * paints it through the binding. A per-note_id cooldown
+ * (`crdtHealCooldown`/`healCooldownMs`) collapses repeated same-note
+ * detections (open + catch-up + heal racing) to one handshake instead of
+ * draining the handshake budget (#193 starvation class). No manifest fetch,
  * no REST round trip.
  *
  * Mirrors the mock-engine pattern from tests/sync-socket-catchup.test.ts.
@@ -92,9 +95,25 @@ describe("healNoteOnOpen", () => {
 		expect(applyRemoteUpdate).not.toHaveBeenCalled();
 	});
 
-	test("already-converged note: still fires reset+enroll (idempotent — STEP2 is a near-no-op server-side)", async () => {
+	test("repeated opens within the cooldown window collapse to ONE handshake (fix wave 1)", async () => {
 		const crdt = { projectedText: mock().mockResolvedValue("same") };
 		const { engine, enroll, reset } = makeEngine(crdt, {});
+
+		await engine.healNoteOnOpen("Notes/a.md");
+		await engine.healNoteOnOpen("Notes/a.md");
+
+		// Open + catch-up + heal can all independently detect the same
+		// divergence in quick succession — the per-note cooldown collapses
+		// them to one STEP1 instead of draining the handshake budget (#193
+		// starvation class).
+		expect(reset).toHaveBeenCalledTimes(1);
+		expect(enroll).toHaveBeenCalledTimes(1);
+	});
+
+	test("cooldown of 0 allows every open to independently re-fire the handshake", async () => {
+		const crdt = { projectedText: mock().mockResolvedValue("same") };
+		const { engine, enroll, reset } = makeEngine(crdt, {});
+		engine.healCooldownMs = 0;
 
 		await engine.healNoteOnOpen("Notes/a.md");
 		await engine.healNoteOnOpen("Notes/a.md");

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -579,7 +579,8 @@ describe("applyOp", () => {
 // unifying fullSync's pull cursor and the socket replay's catchupSeq onto ONE
 // watermark removed a live-bound note's second delivery chance. catchUp now
 // re-detects a diverged live-bound note from the manifest and re-converges it
-// via restConvergeLiveBound, independent of the seq cursor.
+// via the socket-native socketConvergeLiveBound primitive (single-path D3),
+// independent of the seq cursor.
 describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)", () => {
 	function manifestOf(notes: Array<{ id: string; path: string; content_hash: string }>) {
 		return {
@@ -591,11 +592,11 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		};
 	}
 
-	test("re-converges a diverged live-bound note independent of the seq cursor", async () => {
+	test("re-fires the socket re-handshake for a diverged live-bound note independent of the seq cursor", async () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck((p) => p === "Notes/a.md");
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
-		const converge = spyOn(engine as any, "restConvergeLiveBound").mockResolvedValue(true);
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockResolvedValue(false);
 
 		await (engine as any).healDivergedLiveBoundNotes(
 			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),
@@ -603,15 +604,18 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 
 		expect(converge).toHaveBeenCalledTimes(1);
 		expect(converge.mock.calls[0]).toEqual(["Notes/a.md", "id-a"]);
-		// Convergence recorded (serverHash advanced) so the next catch-up skips it.
-		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H2");
+		// The manifest carries hashes only (keyed HMAC — uncomputable
+		// client-side), so this leg cannot verify convergence — serverHash
+		// stays unrecorded; the next matching replay row records it via
+		// applyChange's live-bound leg.
+		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H1");
 	});
 
 	test("skips a CONVERGED live-bound note (serverHash already matches the manifest)", async () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck(() => true);
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H2" } });
-		const converge = spyOn(engine as any, "restConvergeLiveBound").mockResolvedValue(true);
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockResolvedValue(false);
 
 		await (engine as any).healDivergedLiveBoundNotes(
 			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),
@@ -624,7 +628,7 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck(() => false);
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
-		const converge = spyOn(engine as any, "restConvergeLiveBound").mockResolvedValue(true);
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockResolvedValue(false);
 
 		await (engine as any).healDivergedLiveBoundNotes(
 			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -612,7 +612,7 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H1");
 	});
 
-	test("fix wave 1 (e): stages the manifest's content_hash and commits it once a real STEP2/update lands", async () => {
+	test("fix wave 1 (e) / fix wave 5 (3): stages the manifest's content_hash (content:null — hash-only, uncomputable client-side) and commits UNVERIFIED on the next real STEP2/update, preserving the pre-wave-5 best-effort manifest-heal behavior", async () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck((p) => p === "Notes/a.md");
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
@@ -625,7 +625,10 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H1");
 
 		// Simulates CrdtManager's onSynced firing after a real inbound frame
-		// applies non-empty.
+		// applies non-empty. content:null means commitCrdtConvergence has no
+		// plaintext to content-verify against — it commits unverified, exactly
+		// like before fix wave 5 (the manifest heal's recording stays
+		// best-effort).
 		await engine.commitCrdtConvergence("id-a");
 
 		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H2");

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -596,7 +596,9 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck((p) => p === "Notes/a.md");
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
-		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockResolvedValue(false);
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockImplementation(
+			() => {},
+		);
 
 		await (engine as any).healDivergedLiveBoundNotes(
 			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),
@@ -606,16 +608,36 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		expect(converge.mock.calls[0]).toEqual(["Notes/a.md", "id-a"]);
 		// The manifest carries hashes only (keyed HMAC — uncomputable
 		// client-side), so this leg cannot verify convergence — serverHash
-		// stays unrecorded; the next matching replay row records it via
-		// applyChange's live-bound leg.
+		// stays unrecorded until a real STEP2/update commit lands (fix wave 1).
 		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H1");
+	});
+
+	test("fix wave 1 (e): stages the manifest's content_hash and commits it once a real STEP2/update lands", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setLiveBoundCheck((p) => p === "Notes/a.md");
+		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
+
+		await (engine as any).healDivergedLiveBoundNotes(
+			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),
+		);
+		// Staged, not recorded — the manifest heal alone cannot prove the doc
+		// holds the server's ops.
+		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H1");
+
+		// Simulates CrdtManager's onSynced firing after a real inbound frame
+		// applies non-empty.
+		await engine.commitCrdtConvergence("id-a");
+
+		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H2");
 	});
 
 	test("skips a CONVERGED live-bound note (serverHash already matches the manifest)", async () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck(() => true);
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H2" } });
-		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockResolvedValue(false);
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockImplementation(
+			() => {},
+		);
 
 		await (engine as any).healDivergedLiveBoundNotes(
 			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),
@@ -628,7 +650,9 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setLiveBoundCheck(() => false);
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
-		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockResolvedValue(false);
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockImplementation(
+			() => {},
+		);
 
 		await (engine as any).healDivergedLiveBoundNotes(
 			manifestOf([{ id: "id-a", path: "Notes/a.md", content_hash: "H2" }]),


### PR DESCRIPTION
## Why

Single-path CRDT migration, Phase D3 (spec §5, decision locked: gate + deletion in one PR). The one surviving REST convergence path on the markdown sync route was `restConvergeLiveBound` → `api.getUpdates`, kept as the deaf-note rescue (2026-07-14 incident). With D2's seq gap-heal merged (#278/#281 + backend #1058/#1059), a deaf live-bound note must heal over the SOCKET — and the paired e2e now proves it deterministically, so the backstop goes.

## What

- New `socketConvergeLiveBound(path, noteId, expected?)`: **verify-first** — when the caller holds the feed row's content snapshot and the doc already projects exactly that text, record convergence and stop (no wire traffic). Otherwise `reset+enroll` re-fires STEP1 so the room sv-exchange delivers the missing ops over the socket (recreating a dead server room). Returns true ONLY on verified convergence.
- Recording rule unchanged in spirit, tightened in mechanism: serverHash is recorded **only** on verified convergence; an unverified heal stays unrecorded so the next replay/poll retries. Never record convergence for data that hasn't verifiably arrived. (Server `content_hash` is a per-user keyed HMAC the client can never compute — verification is plaintext compare against the row snapshot, or nothing.)
- All three former call sites rewired: the seq-replay live-bound leg (row content as `expected`), `healNoteOnOpen` (no `expected` — deliberately NOT disk content: a deaf doc matches its own stale disk), `healDivergedLiveBoundNotes` (no `expected`, recording block removed; refires an idempotent STEP1 per catch-up until a replay row verifies — ponytail-commented; the terminating upgrade is `crdt_head` in the manifest, Phase E).
- `restConvergeLiveBound` deleted. `restConvergeCore`/`restConvergeAndFlush`/`api.getUpdates` stay for the cold leg — Phase E's business.

## Testing

- TDD: 3 new tests (verify-first records + no handshake; unverified fires reset+enroll + records nothing; projectedText throw isolated). Live-bound REST-converge tests rewritten/deleted per the socket contract; cold-leg tests untouched.
- Full suite 2171 pass / 0 fail; tsc + scoped biome + lint:obsidian + lint:css clean.
- Local paired e2e (backend branch same name): the flipped deaf gate **passes** with this plugin and **fails against plugin main** on the socket-converge presence oracle (negative control).

Pairs engram-app/Engram#1064 (same branch name). No version bump (release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VK9qUcRtS3tiW9wNhw83y7
