### PR TITLE
feat(sync): seq-diff vault validator — integer diff, bounded re-serve, head-equality heal skip (Phase E1)

### DIFF
--- a/main.js
+++ b/main.js
@@ -18167,8 +18167,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  Persisted under `manifestSeq`; wiped with the per-vault state. */
     this.manifestSeq = 0;
     /** Cursor value of the last validator rewind — bounds the validator to ONE
-     *  re-serve per distinct discrepancy per session (see validateFromManifest). */
-    this.lastValidatorRewind = -1;
+     *  re-serve per distinct discrepancy per session (see validateFromManifest).
+     *  null = no rewind yet (a numeric sentinel would collide with the
+     *  legitimate `minBehind - 1` target domain, which includes -1 and 0). */
+    this.lastValidatorRewind = null;
+    /** A pending validator rewind, consumed atomically by the next
+     *  `runSeqReplayOnce` (`catchupViaSeqReplay` is the SOLE cursor writer —
+     *  a direct `setCatchupSeq` here would race an in-flight replay's per-page
+     *  cursor persist and be silently clobbered). */
+    this.seqRewindFloor = null;
     /** When true, vault delete events are suppressed (used during local wipe). */
     this.suppressDeletes = !1;
     /** Paths modified during a pull that need pushing once pull completes. */
@@ -18961,7 +18968,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  point; a wipe that exists on only one path re-opens #200. */
   async wipePerVaultState() {
     var _a;
-    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.manifestSeq = 0, this.lastValidatorRewind = -1, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
+    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
   }
   /** Reset all per-vault sync bookkeeping. Used when the user switches the
    *  active server vault inside the SyncPreviewModal so the next sync starts
@@ -19750,8 +19757,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     return null;
   }
   /** The single catch-up path (socket-only, no REST fallback — a wedged socket
-   *  recovers on reconnect, Todd's call). Four responsibilities a bare op-log
-   *  replay can't cover, run around it:
+   *  recovers on reconnect, Todd's call). Five responsibilities a bare op-log
+   *  replay can't cover, run around it — the four below plus
+   *  `validateFromManifest` (E1 #1065), the whole-vault seq integer-diff that
+   *  re-serves consumed-but-unrecorded rows between steps 1 and 2:
    *   1. `reconcileFromManifest` — trash server-deletes even after op-log GC, and
    *      seed LOCAL empty-folder markers to the server.
    *   2. `catchupViaSeqReplay` — replay the seq-ordered op-log for note/attachment
@@ -19767,7 +19776,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *      and propagate remote folder deletes.
    *  Returns the applied-op count (for the progress recap / poll notice). Never
    *  throws — mirrors the old pull() error boundary so a caller (fullSync/poll)
-   *  never has to guard it. The manifest is fetched once and shared by steps 1
+   *  never has to guard it. The manifest is fetched once and shared by the
+   *  validator plus steps 1
    *  and 3. */
   async catchUp() {
     try {
@@ -19775,12 +19785,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         this.manifestSeq > 0 ? this.manifestSeq : void 0
       );
       if (manifest != null && manifest.unchanged) {
+        await this.seedEmptyFolders();
         let { applied: applied2 } = await this.catchupViaSeqReplay();
         return applied2;
       }
-      await this.reconcileFromManifest(manifest), this.validateFromManifest(manifest);
-      let { applied } = await this.catchupViaSeqReplay();
-      await this.healDivergedLiveBoundNotes(manifest);
+      await this.reconcileFromManifest(manifest);
+      let behind = this.validateFromManifest(manifest), { applied } = await this.catchupViaSeqReplay(), poked = await this.healDivergedLiveBoundNotes(manifest);
       try {
         await this.syncExplicitFolders();
       } catch (e) {
@@ -19790,7 +19800,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           e instanceof Error ? e.stack : void 0
         );
       }
-      return typeof (manifest == null ? void 0 : manifest.change_seq) == "number" && (this.setManifestSeq(manifest.change_seq), await this.saveData({ manifestSeq: this.manifestSeq })), applied;
+      return typeof (manifest == null ? void 0 : manifest.change_seq) == "number" && behind === 0 && poked === 0 && (this.setManifestSeq(manifest.change_seq), await this.saveData({ manifestSeq: this.manifestSeq })), applied;
     } catch (e) {
       return rlog().error(
         "pull",
@@ -19802,7 +19812,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   async runSeqReplayOnce(fromZero, serverIds, serverAttachmentPaths, enumerateOnly = !1) {
     var _a;
     if (!this.crdtCatchupSince || !this.crdt) return 0;
-    let activeVault = (_a = this.settings.vaultId) != null ? _a : null, cursor = fromZero ? 0 : this.syncStateVaultId === activeVault ? this.getCatchupSeq() : 0, applied = 0;
+    let activeVault = (_a = this.settings.vaultId) != null ? _a : null, cursor = fromZero ? 0 : this.syncStateVaultId === activeVault ? this.getCatchupSeq() : 0;
+    this.seqRewindFloor !== null && !fromZero && (cursor = Math.min(cursor, this.seqRewindFloor)), this.seqRewindFloor = null;
+    let applied = 0;
     for (let page = 0; page < 1e5; page++) {
       let resp;
       try {
@@ -20595,8 +20607,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  "received=yes materialized=no" class) — and rewinds the cursor so the
    *  next replay re-serves it. Rows beyond the cursor need nothing: the
    *  imminent replay fetches them anyway. A syncState entry without `seq` is
-   *  NOT flagged (the entry's existence proves a materialize happened; only
-   *  replay writes record seq). Returns the behind-row count.
+   *  NOT flagged (the entry's existence proves a materialize happened;
+   *  replay writes and seq-carrying live ops both record seq — an entry
+   *  without one predates the field). Returns the behind-row count.
    *  ponytail: one rewind per distinct discrepancy per session
    *  (lastValidatorRewind) — a re-served row whose apply still refuses to
    *  record stays behind forever and must not rewind-loop every poll. */
@@ -20618,34 +20631,36 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     ), behind) : (this.lastValidatorRewind = target, rlog().warn(
       "pull",
       `manifest validator: ${behind} consumed-but-unrecorded row(s) \u2014 rewinding cursor ${cursor} \u2192 ${target} to re-serve`
-    ), this.setCatchupSeq(target), behind);
+    ), this.seqRewindFloor = Math.max(0, target), behind);
   }
   async healDivergedLiveBoundNotes(manifest) {
     var _a, _b, _c;
-    if (!(!manifest || !this.crdt))
-      for (let entry of manifest.notes) {
-        let path = (0, import_obsidian21.normalizePath)(entry.path);
-        if (!this.isLiveBound(path)) continue;
-        let stored = this.syncState.get(path);
-        if (entry.crdt_head && (stored == null ? void 0 : stored.crdtHead) === entry.crdt_head || entry.content_hash && (stored == null ? void 0 : stored.serverHash) === entry.content_hash) continue;
-        let noteId = (_c = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(path)) != null ? _b : entry.id) != null ? _c : null;
-        if (noteId)
-          try {
-            entry.content_hash && this.pendingConvergence.set(noteId, {
-              path,
-              serverHash: entry.content_hash,
-              content: null
-            }), this.socketConvergeLiveBound(path, noteId);
-          } catch (e) {
-            rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
-          }
-      }
+    if (!manifest || !this.crdt) return 0;
+    let poked = 0;
+    for (let entry of manifest.notes) {
+      let path = (0, import_obsidian21.normalizePath)(entry.path);
+      if (!this.isLiveBound(path)) continue;
+      let stored = this.syncState.get(path);
+      if (entry.crdt_head && (stored == null ? void 0 : stored.crdtHead) === entry.crdt_head || entry.content_hash && (stored == null ? void 0 : stored.serverHash) === entry.content_hash) continue;
+      let noteId = (_c = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(path)) != null ? _b : entry.id) != null ? _c : null;
+      if (noteId)
+        try {
+          entry.content_hash && this.pendingConvergence.set(noteId, {
+            path,
+            serverHash: entry.content_hash,
+            content: null
+          }), this.socketConvergeLiveBound(path, noteId), poked++;
+        } catch (e) {
+          rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
+        }
+    }
+    return poked;
   }
   /** Apply a single remote change to the vault, with conflict detection.
    *  Returns true when a file was actually created, modified, or trashed.
    *  When forceOverwrite is true, skip conflict detection and always apply. */
   async applyChange(change, forceOverwrite = !1) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y, _z;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y, _z, _A, _B;
     if (this.shouldIgnore(change.path))
       return devLog().log("pull", `applyChange SKIP (ignored): ${change.path}`), !1;
     let normalized = (0, import_obsidian21.normalizePath)(change.path);
@@ -20900,13 +20915,19 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         return devLog().log("pull", `applyChange SKIP (identical): ${change.path}`), this.syncState.set(normalized, {
           hash: localHash,
           version: change.version,
-          serverHash: change.content_hash
-        }), change.version != null && ((_x = this.baseStore) == null || _x.set(normalized, content, change.version)), rlog().info("pull", `Unchanged: ${change.path}`), !1;
+          serverHash: change.content_hash,
+          // E1 (#1065): record the row's seq so the manifest validator can
+          // integer-diff this path (a legacy change without one keeps the
+          // prior value rather than erasing it).
+          seq: typeof change.seq == "number" ? change.seq : (_x = this.syncState.get(normalized)) == null ? void 0 : _x.seq
+        }), change.version != null && ((_y = this.baseStore) == null || _y.set(normalized, content, change.version)), rlog().info("pull", `Unchanged: ${change.path}`), !1;
       return devLog().log("pull", `applyChange OVERWRITE: ${change.path} (len=${content.length})`), await this.modifyFile(existing, content), this.syncState.set(normalized, {
         hash: fnv1a(content),
         version: change.version,
-        serverHash: change.content_hash
-      }), change.version != null && ((_y = this.baseStore) == null || _y.set(normalized, content, change.version)), rlog().info(
+        serverHash: change.content_hash,
+        // E1 (#1065): seq recorded for the manifest validator's integer diff.
+        seq: typeof change.seq == "number" ? change.seq : (_z = this.syncState.get(normalized)) == null ? void 0 : _z.seq
+      }), change.version != null && ((_A = this.baseStore) == null || _A.set(normalized, content, change.version)), rlog().info(
         "pull",
         `Applied: ${change.path} | localLen=${localContent.length} | remoteLen=${content.length}`
       ), !0;
@@ -20924,8 +20945,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     return this.syncState.set(normalized, {
       hash: fnv1a(content),
       version: change.version,
-      serverHash: change.content_hash
-    }), change.version != null && ((_z = this.baseStore) == null || _z.set(normalized, content, change.version)), rlog().info("pull", `Created: ${change.path} | len=${content.length}`), !0;
+      serverHash: change.content_hash,
+      // E1 (#1065): seq recorded for the manifest validator's integer diff.
+      seq: typeof change.seq == "number" ? change.seq : void 0
+    }), change.version != null && ((_B = this.baseStore) == null || _B.set(normalized, content, change.version)), rlog().info("pull", `Created: ${change.path} | len=${content.length}`), !0;
   }
   /** Apply a remote attachment change to the vault.
    *  If contentBase64 is provided (from WebSocket), use it directly. Otherwise fetch it.

--- a/main.js
+++ b/main.js
@@ -13486,9 +13486,10 @@ var EngramApi = class _EngramApi {
   }
   /** Fetch sync manifest for reconciliation.
    *  Returns null if the server doesn't support this endpoint (404). */
-  async getManifest() {
+  async getManifest(sinceSeq) {
+    let qs = typeof sinceSeq == "number" && Number.isFinite(sinceSeq) && sinceSeq >= 0 ? `?since_seq=${sinceSeq}` : "";
     try {
-      return (await this.request("GET", "/sync/manifest")).json;
+      return (await this.request("GET", `/sync/manifest${qs}`)).json;
     } catch (e) {
       if (typeof e == "object" && e !== null && e.status === 404)
         return null;
@@ -17936,6 +17937,18 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  short-circuits. Null in tests/headless — the adopt transfer branch is
      *  then skipped (no live editor to preserve) and the disk-seed path runs. */
     this.crdtEditorRebind = null;
+    /** Fix wave 7 (#191 slice): reads the LIVE editor buffer currently shown
+     *  for `path` (CrdtLiveViews.boundBufferText, wired by main.ts) — used by
+     *  commitCrdtConvergence to detect a phantom binding (isLiveBound true but
+     *  the editor's Yjs binding silently detached, so its buffer never
+     *  repaints). Null in tests/headless — the phantom-binding check is then
+     *  skipped (nothing to compare). */
+    this.crdtBoundBufferText = null;
+    /** Fix wave 7: nudges the bound editor's save (CrdtLiveViews.requestSaveForBoundPath,
+     *  the same debounced call wiring.ts's onBoundUpdate uses) after a phantom
+     *  binding is rebound, so the freshly-repainted buffer actually reaches
+     *  disk instead of waiting on the next unrelated remote update. */
+    this.crdtRequestSave = null;
     /** Path -> note_id sidecar (Task 4, `src/crdt/note-id-map.ts`). Owned by
      *  main.ts (persisted in data.json); wired here so pushFile can mint/send
      *  client_id for new notes, the pull path can learn ids, and handleRename
@@ -18014,20 +18027,46 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  fresh content_hash overwrites any prior stage (new episode); nothing
      *  else prunes it — `commitCrdtConvergence` re-resolves the current path
      *  via noteIdMap and no-ops if the id was deleted, so a stale stage can
-     *  never write syncState at a dead path. */
+     *  never write syncState at a dead path.
+     *
+     *  Fix wave 5: `content` is the staged row's own plaintext, so
+     *  `commitCrdtConvergence` can CONTENT-VERIFY the commit instead of
+     *  trusting that the next `onSynced` fire is FOR this row — an unrelated
+     *  inbound frame (a different concurrent edit on the same doc) could
+     *  otherwise commit the stage a millisecond after it was staged, before
+     *  the staged row's own ops ever arrived (CI run 29920053637: committed
+     *  1ms after the re-handshake fired, fence-blinding every later row —
+     *  deaf until teardown). The diverged live-bound leg has the row's
+     *  `content` in scope and stages it; `healDivergedLiveBoundNotes` (the
+     *  manifest heal) has no plaintext — only a keyed HMAC hash it cannot
+     *  compute client-side — so it stages `content: null`, which keeps the
+     *  pre-wave-5 best-effort behavior (commit on the next non-empty frame,
+     *  unverified). */
     this.pendingConvergence = /* @__PURE__ */ new Map();
     /** Fix wave 1: per-note_id cooldown for `socketConvergeLiveBound`'s STEP1
      *  re-handshake — bounds how often a live-bound note can re-fire reset+
      *  enroll (open, catch-up, and manifest heal can all independently detect
      *  the same divergence in quick succession; unconditional firing drains
      *  the handshake budget, the #193 starvation class). Value = last-fired
-     *  `Date.now()`. `healCooldownMs` is a public instance field so tests can
-     *  shrink it. */
+     *  `Date.now()`, set ONLY when a handshake actually fires — never on a
+     *  suppressed attempt. `healCooldownMs` is a public instance field so
+     *  tests can shrink it. */
     this.crdtHealCooldown = /* @__PURE__ */ new Map();
-    /** See `crdtHealCooldown`. 30s: long enough that open+catch-up+heal racing
-     *  on the same note collapse to one handshake, short enough that a
-     *  genuinely-still-diverged note keeps retrying within a session. */
-    this.healCooldownMs = 3e4;
+    /** Fix wave 2 (CI-found defect: `test_deaf_note_survives_handshake_rate_
+     *  limit_and_heals_on_restore`): a poke suppressed by the cooldown must
+     *  NOT be silently dropped — a deaf note's one recovery poke landing
+     *  inside the window would otherwise never retry, stranding it until the
+     *  next unrelated edit or the 5-min manifest pass. Mirrors
+     *  `scheduleSeqHeal`'s trailing-edge throttle: a suppressed poke arms ONE
+     *  trailing timer per note_id for the remaining window; further pokes for
+     *  the same note while a trailing timer is armed coalesce into it (no
+     *  second timer). Cleared in `destroy()`. */
+    this.crdtHealTrailingTimers = /* @__PURE__ */ new Map();
+    /** See `crdtHealCooldown`. 15s (fix wave 2, was 30s): long enough that
+     *  open+catch-up+heal racing on the same note collapse to one handshake,
+     *  short enough that a genuinely-still-diverged note keeps retrying
+     *  within a session. */
+    this.healCooldownMs = 15e3;
     /** Optional CRDT enrollment tracker. When set, a pull that surfaces a
      *  CRDT-managed markdown note we don't have locally enrolls it (sends a
      *  sync-step-1) so the body is pulled over the y-protocols handshake — the
@@ -18122,6 +18161,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  from here so only ops written while we were away are replayed. 0 = replay
      *  from genesis (first-ever connect / after a state wipe). */
     this.catchupSeq = 0;
+    /** The vault change_seq watermark of the last FULLY-processed manifest pass
+     *  (Phase E1 #1065). Sent as `?since_seq=` so an unchanged vault
+     *  short-circuits the manifest fetch + the manifest-driven catch-up steps.
+     *  Persisted under `manifestSeq`; wiped with the per-vault state. */
+    this.manifestSeq = 0;
+    /** Cursor value of the last validator rewind — bounds the validator to ONE
+     *  re-serve per distinct discrepancy per session (see validateFromManifest). */
+    this.lastValidatorRewind = -1;
     /** When true, vault delete events are suppressed (used during local wipe). */
     this.suppressDeletes = !1;
     /** Paths modified during a pull that need pushing once pull completes. */
@@ -18227,6 +18274,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   }
   setCrdtEditorRebind(fn) {
     this.crdtEditorRebind = fn;
+  }
+  setCrdtBoundBufferText(fn) {
+    this.crdtBoundBufferText = fn;
+  }
+  setCrdtRequestSave(fn) {
+    this.crdtRequestSave = fn;
   }
   setNoteIdMap(map3) {
     this.noteIdMap = map3;
@@ -18837,6 +18890,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   setCatchupSeq(seq3) {
     this.catchupSeq = Number.isFinite(seq3) && seq3 >= 0 ? seq3 : 0;
   }
+  getManifestSeq() {
+    return this.manifestSeq;
+  }
+  setManifestSeq(seq3) {
+    this.manifestSeq = Number.isFinite(seq3) && seq3 >= 0 ? seq3 : 0;
+  }
   /** Gap-heal decision for a live op carrying the backend's vault `seq`.
    *  `apply()` ALWAYS runs first, in every branch — Yjs updates are
    *  commutative + idempotent, so seq never gates application; a stale seq
@@ -18902,7 +18961,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  point; a wipe that exists on only one path re-opens #200. */
   async wipePerVaultState() {
     var _a;
-    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
+    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.manifestSeq = 0, this.lastValidatorRewind = -1, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
   }
   /** Reset all per-vault sync bookkeeping. Used when the user switches the
    *  active server vault inside the SyncPreviewModal so the next sync starts
@@ -19712,8 +19771,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  and 3. */
   async catchUp() {
     try {
-      let manifest = await this.api.getManifest();
-      await this.reconcileFromManifest(manifest);
+      let manifest = await this.api.getManifest(
+        this.manifestSeq > 0 ? this.manifestSeq : void 0
+      );
+      if (manifest != null && manifest.unchanged) {
+        let { applied: applied2 } = await this.catchupViaSeqReplay();
+        return applied2;
+      }
+      await this.reconcileFromManifest(manifest), this.validateFromManifest(manifest);
       let { applied } = await this.catchupViaSeqReplay();
       await this.healDivergedLiveBoundNotes(manifest);
       try {
@@ -19725,7 +19790,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           e instanceof Error ? e.stack : void 0
         );
       }
-      return applied;
+      return typeof (manifest == null ? void 0 : manifest.change_seq) == "number" && (this.setManifestSeq(manifest.change_seq), await this.saveData({ manifestSeq: this.manifestSeq })), applied;
     } catch (e) {
       return rlog().error(
         "pull",
@@ -19877,37 +19942,101 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  note_id (`crdtHealCooldown`/`healCooldownMs`) so open+catch-up+heal all
    *  independently detecting the same divergence collapses to one handshake
    *  instead of draining the handshake budget (#193 starvation class).
-   *  Never throws. */
+   *
+   *  Fix wave 2: a poke suppressed by the cooldown COALESCES into one
+   *  trailing fire at window end (`crdtHealTrailingTimers`) instead of being
+   *  dropped — mirrors `scheduleSeqHeal`'s trailing-edge throttle. Dropping
+   *  it silently stranded a deaf note whose single recovery poke landed
+   *  inside the window (CI: `test_deaf_note_survives_handshake_rate_limit_
+   *  and_heals_on_restore`). Never throws. */
   socketConvergeLiveBound(path, noteId) {
-    let last2 = this.crdtHealCooldown.get(noteId);
-    if (last2 !== void 0 && Date.now() - last2 < this.healCooldownMs) {
-      devLog().log("crdt", `socket converge: cooldown skip for ${path}`);
+    if (!this.crdtEnrollment) return;
+    let last2 = this.crdtHealCooldown.get(noteId), now = Date.now();
+    if (last2 === void 0 || now - last2 >= this.healCooldownMs) {
+      this.fireCrdtReHandshake(path, noteId);
       return;
     }
-    this.crdtEnrollment && (this.crdtHealCooldown.set(noteId, Date.now()), this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId), rlog().info("crdt", `socket converge: re-handshake fired for ${path}`));
+    if (this.crdtHealTrailingTimers.has(noteId)) {
+      devLog().log("crdt", `socket converge: cooldown skip for ${path} (already coalesced)`);
+      return;
+    }
+    devLog().log("crdt", `socket converge: cooldown skip for ${path} \u2014 arming trailing fire`);
+    let remaining = this.healCooldownMs - (now - last2), timer = window.setTimeout(() => {
+      this.crdtHealTrailingTimers.delete(noteId), this.fireCrdtReHandshake(path, noteId);
+    }, remaining);
+    this.crdtHealTrailingTimers.set(noteId, timer);
+  }
+  /** The actual STEP1 fire, shared by the immediate and trailing-coalesced
+   *  paths in `socketConvergeLiveBound`. Records the cooldown timestamp —
+   *  ONLY called on a real fire, never on a suppressed attempt. */
+  fireCrdtReHandshake(path, noteId) {
+    var _a, _b;
+    this.crdtHealCooldown.set(noteId, Date.now()), (_a = this.crdtEnrollment) == null || _a.reset(noteId), (_b = this.crdtEnrollment) == null || _b.enroll(noteId), rlog().info("crdt", `socket converge: re-handshake fired for ${path}`);
   }
   /** Commit a staged live-bound convergence (see `pendingConvergence`) — the
    *  ONLY place that leg's `serverHash`/`version`/`seq` get written. Wired
    *  from CrdtManager's `onSynced` (crdt/wiring.ts), which fires from
    *  `CrdtChannel.handleFrame` exactly when an inbound sync frame leaves the
-   *  doc's text non-empty — real ops landed, not a guess. Idempotent and
-   *  cheap when nothing is staged (steady-state live traffic fires this on
-   *  every frame). Re-resolves the CURRENT path via `noteIdMap` rather than
-   *  trusting the path captured at stage time, so a rename (path moved) or
-   *  delete (id unmapped) between staging and commit can't write syncState
-   *  at a stale/dead path — no separate teardown hook needed. Never throws
-   *  into the CRDT manager's synchronous callback. */
+   *  doc's text non-empty — real ops landed, not a guess.
+   *
+   *  Fix wave 5: "an inbound frame landed" is necessary but NOT sufficient
+   *  proof the STAGED row's ops are the ones that landed — `onSynced` fires
+   *  on every non-empty frame, including an unrelated concurrent edit on
+   *  the same doc, which could commit a stage a millisecond after staging,
+   *  before the staged row's own ops ever arrived (CI run 29920053637).
+   *  When the stage carries plaintext (`content !== null`), commit ONLY if
+   *  the doc's projection now strictly equals it — the ops that produced a
+   *  match came from the server room round-trip, so post-handshake
+   *  text-equality IS sound proof here (unlike the deleted verify-first
+   *  skip, which compared BEFORE any handshake ever fired). On a mismatch
+   *  (or a `projectedText` throw — treated as mismatch, never commit on
+   *  error) the stage is left in place; the next inbound frame re-runs this
+   *  check, so the real edit's arrival commits it. A `content: null` stage
+   *  (manifest heal — hash-only, keyed HMAC, uncomputable client-side)
+   *  keeps the pre-wave-5 best-effort behavior: commit unverified on the
+   *  next non-empty frame.
+   *
+   *  Idempotent and cheap when nothing is staged (steady-state live traffic
+   *  fires this on every frame). Re-resolves the CURRENT path via
+   *  `noteIdMap` rather than trusting the path captured at stage time, so a
+   *  rename (path moved) or delete (id unmapped) between staging and commit
+   *  can't write syncState at a stale/dead path — no separate teardown hook
+   *  needed. Never throws into the CRDT manager's synchronous callback. */
   async commitCrdtConvergence(noteId) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d, _e, _f, _g, _h;
     let staged = this.pendingConvergence.get(noteId);
     if (!staged) return;
+    if (staged.content !== null) {
+      let matches = !1;
+      if (this.crdt)
+        try {
+          matches = await this.crdt.projectedText(noteId) === staged.content;
+        } catch (e) {
+          devLog().log(
+            "crdt",
+            `socket converge: projectedText failed for ${noteId}, deferring commit: ${errMsg(e)}`
+          );
+        }
+      if (!matches) {
+        devLog().log("crdt", `commit deferred: doc not at staged row yet (${noteId})`);
+        return;
+      }
+      let boundPath = (_a = this.noteIdMap) == null ? void 0 : _a.pathForId(noteId);
+      if (boundPath && this.isLiveBound(boundPath)) {
+        let buffer = (_c = (_b = this.crdtBoundBufferText) == null ? void 0 : _b.call(this, boundPath)) != null ? _c : null;
+        buffer !== null && buffer !== staged.content && (rlog().warn(
+          "crdt",
+          `socket converge: phantom binding rebound for ${boundPath}`
+        ), (_d = this.crdtEditorRebind) == null || _d.call(this, boundPath), (_e = this.crdtRequestSave) == null || _e.call(this, boundPath));
+      }
+    }
     this.pendingConvergence.delete(noteId), this.crdtRehandshakeAttempts.delete(noteId);
-    let path = (_a = this.noteIdMap) == null ? void 0 : _a.pathForId(noteId);
+    let path = (_f = this.noteIdMap) == null ? void 0 : _f.pathForId(noteId);
     if (path)
       try {
-        let boundFile = this.app.vault.getFileByPath(path), stored = this.syncState.get(path), localHash = (_b = stored == null ? void 0 : stored.hash) != null ? _b : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
+        let boundFile = this.app.vault.getFileByPath(path), stored = this.syncState.get(path), localHash = (_g = stored == null ? void 0 : stored.hash) != null ? _g : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
         this.syncState.set(path, {
-          ...(_c = this.syncState.get(path)) != null ? _c : {},
+          ...(_h = this.syncState.get(path)) != null ? _h : {},
           hash: localHash,
           serverHash: staged.serverHash,
           version: staged.version,
@@ -20460,6 +20589,37 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  server's ops. `commitCrdtConvergence` commits the stage once a real
    *  STEP2/update frame actually applies. Best-effort; never throws into
    *  catchUp. */
+  /** Phase E1 (#1065): whole-vault seq integer diff. Flags a manifest note row
+   *  whose seq the replay has ALREADY consumed (row.seq <= catchupSeq) but
+   *  that this path never recorded — a silent apply-loss (the test_10
+   *  "received=yes materialized=no" class) — and rewinds the cursor so the
+   *  next replay re-serves it. Rows beyond the cursor need nothing: the
+   *  imminent replay fetches them anyway. A syncState entry without `seq` is
+   *  NOT flagged (the entry's existence proves a materialize happened; only
+   *  replay writes record seq). Returns the behind-row count.
+   *  ponytail: one rewind per distinct discrepancy per session
+   *  (lastValidatorRewind) — a re-served row whose apply still refuses to
+   *  record stays behind forever and must not rewind-loop every poll. */
+  validateFromManifest(manifest) {
+    var _a, _b;
+    if (!((_a = manifest == null ? void 0 : manifest.notes) != null && _a.length)) return 0;
+    let cursor = this.getCatchupSeq(), minBehind = Number.POSITIVE_INFINITY, behind = 0;
+    for (let entry of manifest.notes) {
+      let seq3 = entry.seq;
+      if (typeof seq3 != "number" || !Number.isFinite(seq3) || seq3 > cursor) continue;
+      let stored = this.syncState.get((0, import_obsidian21.normalizePath)(entry.path)), recorded = stored ? (_b = stored.seq) != null ? _b : Number.POSITIVE_INFINITY : -1;
+      seq3 > recorded && (behind++, seq3 < minBehind && (minBehind = seq3));
+    }
+    if (behind === 0) return 0;
+    let target = minBehind - 1;
+    return target === this.lastValidatorRewind ? (rlog().warn(
+      "pull",
+      `manifest validator: ${behind} row(s) still behind after a re-serve \u2014 not rewinding again (cursor=${cursor})`
+    ), behind) : (this.lastValidatorRewind = target, rlog().warn(
+      "pull",
+      `manifest validator: ${behind} consumed-but-unrecorded row(s) \u2014 rewinding cursor ${cursor} \u2192 ${target} to re-serve`
+    ), this.setCatchupSeq(target), behind);
+  }
   async healDivergedLiveBoundNotes(manifest) {
     var _a, _b, _c;
     if (!(!manifest || !this.crdt))
@@ -20467,11 +20627,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         let path = (0, import_obsidian21.normalizePath)(entry.path);
         if (!this.isLiveBound(path)) continue;
         let stored = this.syncState.get(path);
-        if (entry.content_hash && (stored == null ? void 0 : stored.serverHash) === entry.content_hash) continue;
+        if (entry.crdt_head && (stored == null ? void 0 : stored.crdtHead) === entry.crdt_head || entry.content_hash && (stored == null ? void 0 : stored.serverHash) === entry.content_hash) continue;
         let noteId = (_c = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(path)) != null ? _b : entry.id) != null ? _c : null;
         if (noteId)
           try {
-            entry.content_hash && this.pendingConvergence.set(noteId, { path, serverHash: entry.content_hash }), this.socketConvergeLiveBound(path, noteId);
+            entry.content_hash && this.pendingConvergence.set(noteId, {
+              path,
+              serverHash: entry.content_hash,
+              content: null
+            }), this.socketConvergeLiveBound(path, noteId);
           } catch (e) {
             rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
           }
@@ -20538,8 +20702,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let content = change.content;
     if (content === void 0)
       throw new Error(`applyChange: missing content for ${change.path}`);
-    if (!forceOverwrite && change.version !== void 0) {
-      let known = (_j = this.syncState.get(normalized)) == null ? void 0 : _j.version;
+    let crdtOwnsBody = !!(this.crdt && normalized.endsWith(".md")), noteId = (_k = (_j = this.noteIdMap) == null ? void 0 : _j.get(normalized)) != null ? _k : null;
+    if (!forceOverwrite && !(crdtOwnsBody && noteId) && change.version !== void 0) {
+      let known = (_l = this.syncState.get(normalized)) == null ? void 0 : _l.version;
       if (known !== void 0 && known >= change.version && this.app.vault.getFileByPath(normalized))
         return rlog().info(
           "pull",
@@ -20547,14 +20712,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         ), !1;
     }
     let crdtConflictFallthrough = !1;
-    if (this.crdt && normalized.endsWith(".md")) {
-      let noteId = (_l = (_k = this.noteIdMap) == null ? void 0 : _k.get(normalized)) != null ? _l : null;
+    if (crdtOwnsBody) {
       if (!this.app.vault.getFileByPath(normalized))
         noteId && this.isLiveBound(normalized) && ((_m = this.crdtEnrollment) == null || _m.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content);
       else {
         noteId && this.isLiveBound(normalized) && ((_n = this.crdtEnrollment) == null || _n.enroll(noteId));
         let stored = this.syncState.get(normalized);
-        if ((stored == null ? void 0 : stored.seq) !== void 0 && change.seq !== void 0 && change.seq <= stored.seq || (stored == null ? void 0 : stored.version) !== void 0 && change.version !== void 0 && change.version <= stored.version)
+        if (change.seq !== void 0 ? (stored == null ? void 0 : stored.seq) !== void 0 && change.seq <= stored.seq : (stored == null ? void 0 : stored.version) !== void 0 && change.version !== void 0 && change.version <= stored.version)
           rlog().info(
             "pull",
             `CRDT catch-up: stale row (seq ${(_o = change.seq) != null ? _o : "-"}/${(_p = stored == null ? void 0 : stored.seq) != null ? _p : "-"} v${(_q = change.version) != null ? _q : "-"}/${(_r = stored == null ? void 0 : stored.version) != null ? _r : "-"}) \u2014 history, skip ${change.path}`
@@ -20565,9 +20729,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             rlog().warn(
               "pull",
               `CRDT catch-up: diverged + live-bound, socket re-handshake (attempt ${attempts}) ${change.path}`
-            ), this.crdtRehandshakeAttempts.set(key, { hash: change.content_hash, attempts }), noteId && (this.pendingConvergence.set(noteId, {
+            ), this.crdtRehandshakeAttempts.set(key, {
+              hash: change.content_hash,
+              attempts
+            }), noteId && (this.pendingConvergence.set(noteId, {
               path: normalized,
               serverHash: change.content_hash,
+              content,
               version: change.version,
               seq: change.seq
             }), this.socketConvergeLiveBound(normalized, noteId));
@@ -21721,7 +21889,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     this.remotelyDeleted.clear();
     for (let timer of this.recentlyDeleted.values())
       window.clearTimeout(timer);
-    this.recentlyDeleted.clear(), this.pendingPostPullPushes.clear(), this.seqHealTimer !== null && (window.clearTimeout(this.seqHealTimer), this.seqHealTimer = null), this.postPullDrainTimer !== null && (window.clearTimeout(this.postPullDrainTimer), this.postPullDrainTimer = null), this.degradedNoticeTimer && window.clearTimeout(this.degradedNoticeTimer), this.degradedNoticeTimer = null, this.pendingDegraded.clear(), this.stopHealthCheck(), this.queue.destroy();
+    this.recentlyDeleted.clear(), this.pendingPostPullPushes.clear(), this.seqHealTimer !== null && (window.clearTimeout(this.seqHealTimer), this.seqHealTimer = null), this.postPullDrainTimer !== null && (window.clearTimeout(this.postPullDrainTimer), this.postPullDrainTimer = null);
+    for (let timer of this.crdtHealTrailingTimers.values())
+      window.clearTimeout(timer);
+    this.crdtHealTrailingTimers.clear(), this.degradedNoticeTimer && window.clearTimeout(this.degradedNoticeTimer), this.degradedNoticeTimer = null, this.pendingDegraded.clear(), this.stopHealthCheck(), this.queue.destroy();
   }
 };
 _SyncEngine.MANIFEST_OWNERS_TTL_MS = 3e4, _SyncEngine.SEQ_HEAL_COOLDOWN_MS = 4e3;
@@ -22619,7 +22790,7 @@ var CrdtReadingView = class {
 };
 
 // src/crdt/live/live-views.ts
-var ViewerRefcount = class {
+var SAVE_NUDGE_DEBOUNCE_MS = 300, ViewerRefcount = class {
   constructor(onLastRelease) {
     this.viewers = /* @__PURE__ */ new Map();
     this.onLastRelease = onLastRelease;
@@ -22648,6 +22819,8 @@ var ViewerRefcount = class {
     this.localAwareness = new Awareness(this.awarenessDoc);
     /** One EditorController per live CodeMirror EditorView. */
     this.controllers = /* @__PURE__ */ new Map();
+    /** Fix wave 6: per-path trailing-debounce timers for `requestSaveForBoundPath`. */
+    this.saveNudgeTimers = /* @__PURE__ */ new Map();
     this.deps = deps, this.refcount = new ViewerRefcount((path) => {
       this.onLastViewerRelease(path).catch((e) => {
         var _a, _b;
@@ -22663,6 +22836,51 @@ var ViewerRefcount = class {
   }
   isBound(path) {
     return this.refcount.isBound(path);
+  }
+  /** Fix wave 6: nudge Obsidian's own save pipeline for the bound editor
+   *  showing `path`, after a remote merge painted into it. `onFlushToDisk`
+   *  skips the disk write for a bound path (the editor owns the file) — but
+   *  headless/unfocused Obsidian (CI) doesn't promptly flush a
+   *  programmatically-updated buffer on its own, so a converged CRDT doc can
+   *  sit unsaved on disk for tens of seconds. `requestSave()` is Obsidian's
+   *  own API for this (it flushes through Obsidian's pipeline, so it cannot
+   *  fight the binding — it IS the binding-authoritative save).
+   *
+   *  Debounced per path (trailing, `SAVE_NUDGE_DEBOUNCE_MS`) so a burst of
+   *  deltas from one remote edit collapses to one save call. No-op when
+   *  `path` has no active viewer — nothing to nudge, and no burst to
+   *  coalesce (also means a note that closes mid-debounce simply never
+   *  fires, which is correct: the last-viewer-release flush below already
+   *  covers that case via `onLastViewerRelease`). Never throws. */
+  requestSaveForBoundPath(path) {
+    if (!this.isBound(path)) return;
+    let existing = this.saveNudgeTimers.get(path);
+    existing !== void 0 && window.clearTimeout(existing);
+    let timer = window.setTimeout(() => {
+      this.saveNudgeTimers.delete(path), this.doRequestSave(path);
+    }, SAVE_NUDGE_DEBOUNCE_MS);
+    this.saveNudgeTimers.set(path, timer);
+  }
+  /** Fix wave 7 (#191 slice): read the live buffer of the editor currently
+   *  showing `path`, for commitCrdtConvergence's phantom-binding check.
+   *  Returns null when nothing shows the path (nothing to compare). */
+  boundBufferText(path) {
+    for (let leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
+      let view = leaf.view;
+      if (view instanceof import_obsidian23.MarkdownView && getMarkdownFilePath(view) === path)
+        return view.getViewData();
+    }
+    return null;
+  }
+  doRequestSave(path) {
+    try {
+      for (let leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
+        let view = leaf.view;
+        view instanceof import_obsidian23.MarkdownView && getMarkdownFilePath(view) === path && view.requestSave();
+      }
+    } catch (e) {
+      devLog().log("crdt", `requestSaveForBoundPath failed for ${path}: ${errMsg(e)}`);
+    }
   }
   /** The last viewer of `path` left: persist the current Y.Text to disk, then
    *  free the doc so the resident set stays bounded by open notes (closeDoc was
@@ -22734,7 +22952,10 @@ var ViewerRefcount = class {
   destroy() {
     for (let [cm, ctrl] of this.controllers)
       ctrl.release(cm);
-    this.controllers.clear(), this.frontmatter.detachAll(), this.reading.detachAll(), this.localAwareness.destroy(), this.awarenessDoc.destroy();
+    this.controllers.clear();
+    for (let timer of this.saveNudgeTimers.values())
+      window.clearTimeout(timer);
+    this.saveNudgeTimers.clear(), this.frontmatter.detachAll(), this.reading.detachAll(), this.localAwareness.destroy(), this.awarenessDoc.destroy();
     for (let path of this.refcount.boundPaths()) {
       let noteId = this.deps.resolveId(path);
       this.deps.manager.getText(noteId).then((content) => this.deps.flushToDisk(path, content));
@@ -22939,12 +23160,17 @@ function createCrdtWiring(deps) {
     onUpdate: (docId, update) => box.channel.sendUpdateRaw(docId, update),
     canSendLive: deps.canSendLive,
     onFlushToDisk: async (noteId, content) => {
+      var _a2;
       let path = noteIdMap.pathForId(noteId);
       if (!path) {
         healUnknownNoteId(noteId, content);
         return;
       }
-      if (!deps.isBound(path) && await syncEngine.flushFromCrdt(path, content) === !1)
+      if (deps.isBound(path)) {
+        (_a2 = deps.onBoundUpdate) == null || _a2.call(deps, path);
+        return;
+      }
+      if (await syncEngine.flushFromCrdt(path, content) === !1)
         throw new Error(`flushFromCrdt reported a write failure for ${path}`);
     },
     // Adopt-first seed gate: never re-encode content the server already holds.
@@ -23411,7 +23637,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       "lifecycle",
       `Plugin loading | v${this.manifest.version} | ${import_obsidian26.Platform.isMobile ? "mobile" : "desktop"}`
     ), this.syncEngine = new SyncEngine(this.app, this.api, this.settings, async (data) => {
-      data.lastSync !== void 0 && this.syncEngine.setLastSync(data.lastSync), data.catchupSeq !== void 0 && this.syncEngine.setCatchupSeq(data.catchupSeq), await this.savePluginData(this.syncEngine.getLastSync());
+      data.lastSync !== void 0 && this.syncEngine.setLastSync(data.lastSync), data.catchupSeq !== void 0 && this.syncEngine.setCatchupSeq(data.catchupSeq), data.manifestSeq !== void 0 && this.syncEngine.setManifestSeq(data.manifestSeq), await this.savePluginData(this.syncEngine.getLastSync());
     }), this.syncLog = new SyncLog(), this.syncEngine.syncLog = this.syncLog, this.syncEngine.setCrdtLiveCheck(() => {
       var _a2, _b2;
       return (_b2 = (_a2 = this.noteStream) == null ? void 0 : _a2.isCrdtConnected()) != null ? _b2 : !1;
@@ -23421,7 +23647,17 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     }), this.syncEngine.setCrdtEditorRebind((path) => {
       var _a2;
       return (_a2 = this.crdtLiveViews) == null ? void 0 : _a2.rebindPath(path);
-    });
+    }), this.syncEngine.setCrdtBoundBufferText(
+      (path) => {
+        var _a2, _b2;
+        return (_b2 = (_a2 = this.crdtLiveViews) == null ? void 0 : _a2.boundBufferText(path)) != null ? _b2 : null;
+      }
+    ), this.syncEngine.setCrdtRequestSave(
+      (path) => {
+        var _a2;
+        return (_a2 = this.crdtLiveViews) == null ? void 0 : _a2.requestSaveForBoundPath(path);
+      }
+    );
     let basesPath = `${this.manifest.dir}/sync-bases.json`;
     this.baseStore = new BaseStore(this.app.vault.adapter, basesPath), this.syncEngine.baseStore = this.baseStore;
     let explicitFoldersPath = `${this.manifest.dir}/explicit-folders.json`;
@@ -23478,7 +23714,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       }
     );
     let saved = await this.loadPluginData();
-    saved != null && saved.lastSync && this.syncEngine.setLastSync(saved.lastSync), (saved == null ? void 0 : saved.catchupSeq) !== void 0 && this.syncEngine.setCatchupSeq(saved.catchupSeq), (_a = saved == null ? void 0 : saved.offlineQueue) != null && _a.length && this.syncEngine.queue.load(saved.offlineQueue), (_b = saved == null ? void 0 : saved.crdtOpQueue) != null && _b.length && ((_c = this.crdtOpQueue) == null || _c.load(saved.crdtOpQueue)), (saved == null ? void 0 : saved.syncStateVaultId) !== void 0 && this.syncEngine.setSyncStateVaultId(saved.syncStateVaultId), saved != null && saved.syncState ? this.syncEngine.importSyncState(saved.syncState) : saved != null && saved.syncedHashes && (this.syncEngine.importHashes(saved.syncedHashes), devLog().log("lifecycle", "Migrated legacy syncedHashes \u2192 syncState")), this.syncEngine.issues.hydrate(saved == null ? void 0 : saved.syncIssues), this.syncEngine.ignoredFiles.hydrate(saved == null ? void 0 : saved.ignoredFiles), this.settings.planState && this.syncEngine.hydratePlanState(this.settings.planState), this.settingTab = new EngramSyncSettingTab(this.app, this), this.addSettingTab(this.settingTab), this.registerEvent(
+    saved != null && saved.lastSync && this.syncEngine.setLastSync(saved.lastSync), (saved == null ? void 0 : saved.catchupSeq) !== void 0 && this.syncEngine.setCatchupSeq(saved.catchupSeq), (saved == null ? void 0 : saved.manifestSeq) !== void 0 && this.syncEngine.setManifestSeq(saved.manifestSeq), (_a = saved == null ? void 0 : saved.offlineQueue) != null && _a.length && this.syncEngine.queue.load(saved.offlineQueue), (_b = saved == null ? void 0 : saved.crdtOpQueue) != null && _b.length && ((_c = this.crdtOpQueue) == null || _c.load(saved.crdtOpQueue)), (saved == null ? void 0 : saved.syncStateVaultId) !== void 0 && this.syncEngine.setSyncStateVaultId(saved.syncStateVaultId), saved != null && saved.syncState ? this.syncEngine.importSyncState(saved.syncState) : saved != null && saved.syncedHashes && (this.syncEngine.importHashes(saved.syncedHashes), devLog().log("lifecycle", "Migrated legacy syncedHashes \u2192 syncState")), this.syncEngine.issues.hydrate(saved == null ? void 0 : saved.syncIssues), this.syncEngine.ignoredFiles.hydrate(saved == null ? void 0 : saved.ignoredFiles), this.settings.planState && this.syncEngine.hydratePlanState(this.settings.planState), this.settingTab = new EngramSyncSettingTab(this.app, this), this.addSettingTab(this.settingTab), this.registerEvent(
       this.app.vault.on("modify", (file) => {
         this.syncEngine.handleModify(file);
       })
@@ -23845,6 +24081,9 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       // reason (like deviceId) or the next saveData() wipes it; 0 = replay
       // from genesis.
       catchupSeq: this.syncEngine.getCatchupSeq(),
+      // Manifest since_seq watermark (E1 #1065) — re-listed for the same
+      // wholesale-save reason.
+      manifestSeq: this.syncEngine.getManifestSeq(),
       offlineQueue: offlineQueue != null ? offlineQueue : this.syncEngine.queue.all(),
       // Re-listed on every wholesale save (like offlineQueue) or the next
       // saveData() wipes the durable CRDT ops.
@@ -24087,6 +24326,13 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           isBound: (path) => {
             var _a2, _b2;
             return (_b2 = (_a2 = this.crdtLiveViews) == null ? void 0 : _a2.isBound(path)) != null ? _b2 : !1;
+          },
+          // Fix wave 6: headless/unfocused Obsidian (CI) doesn't promptly
+          // flush a programmatically-updated bound editor to disk — nudge
+          // Obsidian's own save pipeline after a remote merge paints in.
+          onBoundUpdate: (path) => {
+            var _a2;
+            return (_a2 = this.crdtLiveViews) == null ? void 0 : _a2.requestSaveForBoundPath(path);
           },
           // Gate live crdt_msg sends on the note's create-ack (create-before-edit):
           // a brand-new note's crdt_create must land before any crdt_msg, or the

--- a/src/api.ts
+++ b/src/api.ts
@@ -592,9 +592,13 @@ export class EngramApi {
 
 	/** Fetch sync manifest for reconciliation.
 	 *  Returns null if the server doesn't support this endpoint (404). */
-	async getManifest(): Promise<ManifestResponse | null> {
+	async getManifest(sinceSeq?: number): Promise<ManifestResponse | null> {
+		const qs =
+			typeof sinceSeq === "number" && Number.isFinite(sinceSeq) && sinceSeq >= 0
+				? `?since_seq=${sinceSeq}`
+				: "";
 		try {
-			const resp = await this.request("GET", "/sync/manifest");
+			const resp = await this.request("GET", `/sync/manifest${qs}`);
 			return resp.json as ManifestResponse;
 		} catch (e) {
 			if (typeof e === "object" && e !== null && (e as { status?: number }).status === 404) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -388,7 +388,7 @@ export default class EngramSyncPlugin extends Plugin {
 		);
 
 		this.syncEngine = new SyncEngine(this.app, this.api, this.settings, async (data) => {
-			// Merge whichever of {lastSync, catchupSeq} the engine handed us into
+			// Merge whichever of {lastSync, catchupSeq, manifestSeq} the engine handed us into
 			// the in-memory engine state, then persist the WHOLE PluginData via
 			// savePluginData (saveData overwrites data.json wholesale). Each field
 			// the payload omits falls through to the engine's current value, so a

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,9 @@ interface PluginData {
 	 *  offlineQueue: flat pending list, restored on startup, pruned past TTL. */
 	crdtOpQueue?: CrdtOp[];
 	catchupSeq?: number;
+	/** Manifest change_seq watermark of the last fully-processed catch-up pass
+	 *  (Phase E1 #1065) — sent as ?since_seq= to short-circuit an unchanged vault. */
+	manifestSeq?: number;
 	/** New unified sync state (hash + version per file). */
 	syncState?: Record<string, FileSyncState>;
 	/** The server vaultId that `syncState` was recorded under. Used to
@@ -396,6 +399,9 @@ export default class EngramSyncPlugin extends Plugin {
 			if (data.catchupSeq !== undefined) {
 				this.syncEngine.setCatchupSeq(data.catchupSeq);
 			}
+			if (data.manifestSeq !== undefined) {
+				this.syncEngine.setManifestSeq(data.manifestSeq);
+			}
 			await this.savePluginData(this.syncEngine.getLastSync());
 		});
 
@@ -546,6 +552,9 @@ export default class EngramSyncPlugin extends Plugin {
 		}
 		if (saved?.catchupSeq !== undefined) {
 			this.syncEngine.setCatchupSeq(saved.catchupSeq);
+		}
+		if (saved?.manifestSeq !== undefined) {
+			this.syncEngine.setManifestSeq(saved.manifestSeq);
 		}
 		if (saved?.offlineQueue?.length) {
 			this.syncEngine.queue.load(saved.offlineQueue);
@@ -1294,6 +1303,9 @@ export default class EngramSyncPlugin extends Plugin {
 			// reason (like deviceId) or the next saveData() wipes it; 0 = replay
 			// from genesis.
 			catchupSeq: this.syncEngine.getCatchupSeq(),
+			// Manifest since_seq watermark (E1 #1065) — re-listed for the same
+			// wholesale-save reason.
+			manifestSeq: this.syncEngine.getManifestSeq(),
 			offlineQueue: offlineQueue ?? this.syncEngine.queue.all(),
 			// Re-listed on every wholesale save (like offlineQueue) or the next
 			// saveData() wipes the durable CRDT ops.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1680,8 +1680,16 @@ export class SyncEngine {
 	private manifestSeq = 0;
 
 	/** Cursor value of the last validator rewind — bounds the validator to ONE
-	 *  re-serve per distinct discrepancy per session (see validateFromManifest). */
-	private lastValidatorRewind = -1;
+	 *  re-serve per distinct discrepancy per session (see validateFromManifest).
+	 *  null = no rewind yet (a numeric sentinel would collide with the
+	 *  legitimate `minBehind - 1` target domain, which includes -1 and 0). */
+	private lastValidatorRewind: number | null = null;
+
+	/** A pending validator rewind, consumed atomically by the next
+	 *  `runSeqReplayOnce` (`catchupViaSeqReplay` is the SOLE cursor writer —
+	 *  a direct `setCatchupSeq` here would race an in-flight replay's per-page
+	 *  cursor persist and be silently clobbered). */
+	private seqRewindFloor: number | null = null;
 
 	getManifestSeq(): number {
 		return this.manifestSeq;
@@ -1791,7 +1799,7 @@ export class SyncEngine {
 		// stale since_seq could integer-collide with the NEW vault's change_seq
 		// and wrongly short-circuit the first reconcile after a swap.
 		this.manifestSeq = 0;
-		this.lastValidatorRewind = -1;
+		this.lastValidatorRewind = null;
 		// The note-id map and confirmed set are per-vault identity state.
 		// Carrying them across vaults keys CRDT frames/rooms by another
 		// vault's note ids — the cross-vault flavor of the 2026-07-07
@@ -3445,8 +3453,10 @@ export class SyncEngine {
 	}
 
 	/** The single catch-up path (socket-only, no REST fallback — a wedged socket
-	 *  recovers on reconnect, Todd's call). Four responsibilities a bare op-log
-	 *  replay can't cover, run around it:
+	 *  recovers on reconnect, Todd's call). Five responsibilities a bare op-log
+	 *  replay can't cover, run around it — the four below plus
+	 *  `validateFromManifest` (E1 #1065), the whole-vault seq integer-diff that
+	 *  re-serves consumed-but-unrecorded rows between steps 1 and 2:
 	 *   1. `reconcileFromManifest` — trash server-deletes even after op-log GC, and
 	 *      seed LOCAL empty-folder markers to the server.
 	 *   2. `catchupViaSeqReplay` — replay the seq-ordered op-log for note/attachment
@@ -3462,7 +3472,8 @@ export class SyncEngine {
 	 *      and propagate remote folder deletes.
 	 *  Returns the applied-op count (for the progress recap / poll notice). Never
 	 *  throws — mirrors the old pull() error boundary so a caller (fullSync/poll)
-	 *  never has to guard it. The manifest is fetched once and shared by steps 1
+	 *  never has to guard it. The manifest is fetched once and shared by the
+	 *  validator plus steps 1
 	 *  and 3. */
 	async catchUp(): Promise<number> {
 		try {
@@ -3472,17 +3483,22 @@ export class SyncEngine {
 			if (manifest?.unchanged) {
 				// E1 (#1065): the vault's change_seq still equals our last fully
 				// processed watermark — no server write happened, so the
-				// manifest-driven steps (reconcile, validator, live-bound heal,
-				// folder sync — every server mutation bumps change_seq) have
-				// nothing to see. The replay still runs: its cursor is an
-				// independent watermark and stays authoritative.
+				// SERVER→LOCAL manifest-driven steps (delete-reconcile, validator,
+				// live-bound heal, explicit-folder pull — every server mutation
+				// bumps change_seq) have nothing to see. The replay still runs:
+				// its cursor is an independent watermark and stays authoritative.
+				// seedEmptyFolders is LOCAL→SERVER (retry backstop for a failed
+				// handleFolderCreate push) and is NOT gated by the server
+				// watermark — an idle vault must not strand a local empty folder
+				// forever. Cheap: no-ops when nothing local is untracked.
+				await this.seedEmptyFolders();
 				const { applied } = await this.catchupViaSeqReplay();
 				return applied;
 			}
 			await this.reconcileFromManifest(manifest);
-			this.validateFromManifest(manifest);
+			const behind = this.validateFromManifest(manifest);
 			const { applied } = await this.catchupViaSeqReplay();
-			await this.healDivergedLiveBoundNotes(manifest);
+			const poked = await this.healDivergedLiveBoundNotes(manifest);
 			try {
 				await this.syncExplicitFolders();
 			} catch (e) {
@@ -3492,10 +3508,12 @@ export class SyncEngine {
 					e instanceof Error ? e.stack : undefined,
 				);
 			}
-			// Record the watermark only after the whole manifest-driven pass
-			// completed — a thrown step must not let the next poll short-circuit
-			// past work this pass never finished.
-			if (typeof manifest?.change_seq === "number") {
+			// Record the watermark ONLY on a fully-CLEAN pass: a validator rewind
+			// or a fired live-bound heal is fire-and-forget work whose convergence
+			// hasn't landed yet — recording would let every later poll take the
+			// unchanged fast path and never re-check an idle vault (the retry net
+			// the heal step exists to be). A thrown step skips this too.
+			if (typeof manifest?.change_seq === "number" && behind === 0 && poked === 0) {
 				this.setManifestSeq(manifest.change_seq);
 				await this.saveData({ manifestSeq: this.manifestSeq });
 			}
@@ -3530,6 +3548,16 @@ export class SyncEngine {
 			: this.syncStateVaultId === activeVault
 				? this.getCatchupSeq()
 				: 0;
+		// E1 (#1065): consume a validator rewind atomically at run start. The
+		// validator must NOT write the cursor directly — an in-flight replay
+		// persists its own monotonically-advanced cursor per page and would
+		// silently clobber a direct rewind (catchupViaSeqReplay stays the sole
+		// cursor writer). The single-flight loop re-enters here, so a floor set
+		// mid-run is picked up by the coalesced re-run.
+		if (this.seqRewindFloor !== null && !fromZero) {
+			cursor = Math.min(cursor, this.seqRewindFloor);
+		}
+		this.seqRewindFloor = null;
 		let applied = 0;
 		// Bound the loop far above any real backlog (matches pullViaCursor). Applies
 		// are idempotent, so persisting the cursor per page is at-least-once safe.
@@ -5028,8 +5056,9 @@ export class SyncEngine {
 	 *  "received=yes materialized=no" class) — and rewinds the cursor so the
 	 *  next replay re-serves it. Rows beyond the cursor need nothing: the
 	 *  imminent replay fetches them anyway. A syncState entry without `seq` is
-	 *  NOT flagged (the entry's existence proves a materialize happened; only
-	 *  replay writes record seq). Returns the behind-row count.
+	 *  NOT flagged (the entry's existence proves a materialize happened;
+	 *  replay writes and seq-carrying live ops both record seq — an entry
+	 *  without one predates the field). Returns the behind-row count.
 	 *  ponytail: one rewind per distinct discrepancy per session
 	 *  (lastValidatorRewind) — a re-served row whose apply still refuses to
 	 *  record stays behind forever and must not rewind-loop every poll. */
@@ -5062,12 +5091,17 @@ export class SyncEngine {
 			"pull",
 			`manifest validator: ${behind} consumed-but-unrecorded row(s) — rewinding cursor ${cursor} → ${target} to re-serve`,
 		);
-		this.setCatchupSeq(target);
+		// Handed to runSeqReplayOnce (the sole cursor writer) rather than
+		// written directly — a direct setCatchupSeq would race an in-flight
+		// replay's per-page cursor persist and be silently clobbered. Clamped:
+		// a seq-0 row yields target -1, which means replay-from-genesis.
+		this.seqRewindFloor = Math.max(0, target);
 		return behind;
 	}
 
-	private async healDivergedLiveBoundNotes(manifest: ManifestResponse | null): Promise<void> {
-		if (!manifest || !this.crdt) return;
+	private async healDivergedLiveBoundNotes(manifest: ManifestResponse | null): Promise<number> {
+		if (!manifest || !this.crdt) return 0;
+		let poked = 0;
 		for (const entry of manifest.notes) {
 			const path = normalizePath(entry.path);
 			if (!this.isLiveBound(path)) continue;
@@ -5095,10 +5129,12 @@ export class SyncEngine {
 					});
 				}
 				this.socketConvergeLiveBound(path, noteId);
+				poked++;
 			} catch (e) {
 				rlog().warn("crdt", `live-bound heal failed for ${path}: ${errMsg(e)}`);
 			}
 		}
+		return poked;
 	}
 
 	/** Apply a single remote change to the vault, with conflict detection.
@@ -5693,6 +5729,10 @@ export class SyncEngine {
 					hash: localHash,
 					version: change.version,
 					serverHash: change.content_hash,
+					// E1 (#1065): record the row's seq so the manifest validator can
+					// integer-diff this path (a legacy change without one keeps the
+					// prior value rather than erasing it).
+					seq: typeof change.seq === "number" ? change.seq : this.syncState.get(normalized)?.seq,
 				});
 				if (change.version != null) {
 					this.baseStore?.set(normalized, content, change.version);
@@ -5708,6 +5748,8 @@ export class SyncEngine {
 				hash: fnv1a(content),
 				version: change.version,
 				serverHash: change.content_hash,
+				// E1 (#1065): seq recorded for the manifest validator's integer diff.
+				seq: typeof change.seq === "number" ? change.seq : this.syncState.get(normalized)?.seq,
 			});
 			if (change.version != null) {
 				this.baseStore?.set(normalized, content, change.version);
@@ -5734,6 +5776,8 @@ export class SyncEngine {
 			hash: fnv1a(content),
 			version: change.version,
 			serverHash: change.content_hash,
+			// E1 (#1065): seq recorded for the manifest validator's integer diff.
+			seq: typeof change.seq === "number" ? change.seq : undefined,
 		});
 		if (change.version != null) {
 			this.baseStore?.set(normalized, content, change.version);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5732,7 +5732,10 @@ export class SyncEngine {
 					// E1 (#1065): record the row's seq so the manifest validator can
 					// integer-diff this path (a legacy change without one keeps the
 					// prior value rather than erasing it).
-					seq: typeof change.seq === "number" ? change.seq : this.syncState.get(normalized)?.seq,
+					seq:
+						typeof change.seq === "number"
+							? change.seq
+							: this.syncState.get(normalized)?.seq,
 				});
 				if (change.version != null) {
 					this.baseStore?.set(normalized, content, change.version);
@@ -5749,7 +5752,10 @@ export class SyncEngine {
 				version: change.version,
 				serverHash: change.content_hash,
 				// E1 (#1065): seq recorded for the manifest validator's integer diff.
-				seq: typeof change.seq === "number" ? change.seq : this.syncState.get(normalized)?.seq,
+				seq:
+					typeof change.seq === "number"
+						? change.seq
+						: this.syncState.get(normalized)?.seq,
 			});
 			if (change.version != null) {
 				this.baseStore?.set(normalized, content, change.version);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1590,6 +1590,7 @@ export class SyncEngine {
 		private saveData: (data: {
 			lastSync?: string;
 			catchupSeq?: number;
+			manifestSeq?: number;
 			// Signals the engine mutated the shared noteIdMap and it should be
 			// persisted. main.ts's savePluginData writes the map instance directly
 			// (same object), so the callback need not read this — it just triggers
@@ -1670,6 +1671,24 @@ export class SyncEngine {
 
 	setCatchupSeq(seq: number): void {
 		this.catchupSeq = Number.isFinite(seq) && seq >= 0 ? seq : 0;
+	}
+
+	/** The vault change_seq watermark of the last FULLY-processed manifest pass
+	 *  (Phase E1 #1065). Sent as `?since_seq=` so an unchanged vault
+	 *  short-circuits the manifest fetch + the manifest-driven catch-up steps.
+	 *  Persisted under `manifestSeq`; wiped with the per-vault state. */
+	private manifestSeq = 0;
+
+	/** Cursor value of the last validator rewind — bounds the validator to ONE
+	 *  re-serve per distinct discrepancy per session (see validateFromManifest). */
+	private lastValidatorRewind = -1;
+
+	getManifestSeq(): number {
+		return this.manifestSeq;
+	}
+
+	setManifestSeq(seq: number): void {
+		this.manifestSeq = Number.isFinite(seq) && seq >= 0 ? seq : 0;
 	}
 
 	/** Gap-heal decision for a live op carrying the backend's vault `seq`.
@@ -1768,6 +1787,11 @@ export class SyncEngine {
 		// seq feed — reset to 0 so the next catch-up replays the new vault from
 		// genesis (else a stale high seq would suppress it entirely).
 		this.catchupSeq = 0;
+		// Same cross-vault hazard for the manifest watermark (E1 #1065): a
+		// stale since_seq could integer-collide with the NEW vault's change_seq
+		// and wrongly short-circuit the first reconcile after a swap.
+		this.manifestSeq = 0;
+		this.lastValidatorRewind = -1;
 		// The note-id map and confirmed set are per-vault identity state.
 		// Carrying them across vaults keys CRDT frames/rooms by another
 		// vault's note ids — the cross-vault flavor of the 2026-07-07
@@ -3442,8 +3466,21 @@ export class SyncEngine {
 	 *  and 3. */
 	async catchUp(): Promise<number> {
 		try {
-			const manifest = await this.api.getManifest();
+			const manifest = await this.api.getManifest(
+				this.manifestSeq > 0 ? this.manifestSeq : undefined,
+			);
+			if (manifest?.unchanged) {
+				// E1 (#1065): the vault's change_seq still equals our last fully
+				// processed watermark — no server write happened, so the
+				// manifest-driven steps (reconcile, validator, live-bound heal,
+				// folder sync — every server mutation bumps change_seq) have
+				// nothing to see. The replay still runs: its cursor is an
+				// independent watermark and stays authoritative.
+				const { applied } = await this.catchupViaSeqReplay();
+				return applied;
+			}
 			await this.reconcileFromManifest(manifest);
+			this.validateFromManifest(manifest);
 			const { applied } = await this.catchupViaSeqReplay();
 			await this.healDivergedLiveBoundNotes(manifest);
 			try {
@@ -3454,6 +3491,13 @@ export class SyncEngine {
 					`Explicit-folder sync failed (non-fatal): ${errMsg(e)}`,
 					e instanceof Error ? e.stack : undefined,
 				);
+			}
+			// Record the watermark only after the whole manifest-driven pass
+			// completed — a thrown step must not let the next poll short-circuit
+			// past work this pass never finished.
+			if (typeof manifest?.change_seq === "number") {
+				this.setManifestSeq(manifest.change_seq);
+				await this.saveData({ manifestSeq: this.manifestSeq });
 			}
 			return applied;
 		} catch (e) {
@@ -4978,12 +5022,60 @@ export class SyncEngine {
 	 *  server's ops. `commitCrdtConvergence` commits the stage once a real
 	 *  STEP2/update frame actually applies. Best-effort; never throws into
 	 *  catchUp. */
+	/** Phase E1 (#1065): whole-vault seq integer diff. Flags a manifest note row
+	 *  whose seq the replay has ALREADY consumed (row.seq <= catchupSeq) but
+	 *  that this path never recorded — a silent apply-loss (the test_10
+	 *  "received=yes materialized=no" class) — and rewinds the cursor so the
+	 *  next replay re-serves it. Rows beyond the cursor need nothing: the
+	 *  imminent replay fetches them anyway. A syncState entry without `seq` is
+	 *  NOT flagged (the entry's existence proves a materialize happened; only
+	 *  replay writes record seq). Returns the behind-row count.
+	 *  ponytail: one rewind per distinct discrepancy per session
+	 *  (lastValidatorRewind) — a re-served row whose apply still refuses to
+	 *  record stays behind forever and must not rewind-loop every poll. */
+	private validateFromManifest(manifest: ManifestResponse | null): number {
+		if (!manifest?.notes?.length) return 0;
+		const cursor = this.getCatchupSeq();
+		let minBehind = Number.POSITIVE_INFINITY;
+		let behind = 0;
+		for (const entry of manifest.notes) {
+			const seq = entry.seq;
+			if (typeof seq !== "number" || !Number.isFinite(seq) || seq > cursor) continue;
+			const stored = this.syncState.get(normalizePath(entry.path));
+			const recorded = stored ? (stored.seq ?? Number.POSITIVE_INFINITY) : -1;
+			if (seq > recorded) {
+				behind++;
+				if (seq < minBehind) minBehind = seq;
+			}
+		}
+		if (behind === 0) return 0;
+		const target = minBehind - 1;
+		if (target === this.lastValidatorRewind) {
+			rlog().warn(
+				"pull",
+				`manifest validator: ${behind} row(s) still behind after a re-serve — not rewinding again (cursor=${cursor})`,
+			);
+			return behind;
+		}
+		this.lastValidatorRewind = target;
+		rlog().warn(
+			"pull",
+			`manifest validator: ${behind} consumed-but-unrecorded row(s) — rewinding cursor ${cursor} → ${target} to re-serve`,
+		);
+		this.setCatchupSeq(target);
+		return behind;
+	}
+
 	private async healDivergedLiveBoundNotes(manifest: ManifestResponse | null): Promise<void> {
 		if (!manifest || !this.crdt) return;
 		for (const entry of manifest.notes) {
 			const path = normalizePath(entry.path);
 			if (!this.isLiveBound(path)) continue;
 			const stored = this.syncState.get(path);
+			// E1 (#1065): head equality is op-level proof the doc already holds
+			// the server state — terminates the STEP1-refire ceiling for open
+			// notes whose serverHash never recorded (unverified heals).
+			if (entry.crdt_head && stored?.crdtHead === entry.crdt_head) continue;
 			// Already converged (serverHash matches the server's current hash) → skip.
 			if (entry.content_hash && stored?.serverHash === entry.content_hash) continue;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -438,6 +438,13 @@ export interface ManifestEntry {
 	path: string;
 	content_hash: string;
 	version?: number;
+	/** Vault-global change seq of the row's last write (Phase E1 #1065) — the
+	 *  integer-diff validation hook. Optional: a pre-E1 backend omits it. */
+	seq?: number;
+	/** CRDT head fingerprint (notes only, Phase E1) — equality with the
+	 *  locally-recorded crdtHead proves a live-bound doc converged without
+	 *  content transfer. Optional: pre-E1 backend / attachment rows omit it. */
+	crdt_head?: string;
 }
 
 /** Per-file sync metadata tracked by the plugin. */
@@ -581,6 +588,9 @@ export interface ManifestResponse {
 	/** Cursor-pull bootstrap watermark (backend PR B1) — the change seq the
 	 *  manifest reflects, used to seed the cursor for the first delta pull. */
 	change_seq?: number;
+	/** Phase E1 (#1065): true when `?since_seq=` matched the server watermark —
+	 *  nothing changed, and the notes/attachments body is OMITTED. */
+	unchanged?: boolean;
 }
 
 /** Response from POST /api/vaults/register */

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -391,6 +391,25 @@ describe("EngramApi", () => {
 			mockRequestUrl.mockRejectedValueOnce({ status: 500 });
 			await expect(api.getManifest()).rejects.toEqual({ status: 500 });
 		});
+
+		test("passes since_seq and surfaces the unchanged short-circuit (Phase E1)", async () => {
+			mockRequestUrl.mockResolvedValueOnce({
+				status: 200,
+				json: { unchanged: true, change_seq: 42 },
+			} as any);
+			const res = await api.getManifest(42);
+			const req = mockRequestUrl.mock.calls.at(-1)?.[0] as { url: string };
+			expect(req.url).toContain("/sync/manifest?since_seq=42");
+			expect(res?.unchanged).toBe(true);
+			expect(res?.change_seq).toBe(42);
+		});
+
+		test("omits since_seq when not a non-negative finite number", async () => {
+			mockRequestUrl.mockResolvedValueOnce({ status: 200, json: { notes: [] } } as any);
+			await api.getManifest(Number.NaN);
+			const req = mockRequestUrl.mock.calls.at(-1)?.[0] as { url: string };
+			expect(req.url).not.toContain("since_seq");
+		});
 	});
 
 	describe("search", () => {

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -663,4 +663,179 @@ describe("healDivergedLiveBoundNotes (cursor-independent live-bound re-converge)
 
 		expect(converge).not.toHaveBeenCalled();
 	});
+
+	test("E1: skips when the manifest crdt_head equals the recorded crdtHead — op-level converged, no STEP1 refire", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setLiveBoundCheck((p) => p === "Notes/a.md");
+		// serverHash is stale (a fan-out recorded crdtHead but not serverHash),
+		// yet the head matches — the doc provably holds the server state.
+		engine.importSyncState({
+			"Notes/a.md": { hash: 1, serverHash: "H1", crdtHead: "HEAD-X" },
+		});
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockImplementation(
+			() => {},
+		);
+
+		await (engine as any).healDivergedLiveBoundNotes({
+			...manifestOf([
+				{ id: "id-a", path: "Notes/a.md", content_hash: "H2", crdt_head: "HEAD-X" } as any,
+			]),
+		});
+
+		expect(converge).not.toHaveBeenCalled();
+	});
+
+	test("E1: fires STEP1 when the manifest crdt_head DIFFERS from the recorded crdtHead", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setLiveBoundCheck((p) => p === "Notes/a.md");
+		engine.importSyncState({
+			"Notes/a.md": { hash: 1, serverHash: "H1", crdtHead: "HEAD-X" },
+		});
+		const converge = spyOn(engine as any, "socketConvergeLiveBound").mockImplementation(
+			() => {},
+		);
+
+		await (engine as any).healDivergedLiveBoundNotes({
+			...manifestOf([
+				{ id: "id-a", path: "Notes/a.md", content_hash: "H2", crdt_head: "HEAD-Y" } as any,
+			]),
+		});
+
+		expect(converge).toHaveBeenCalledTimes(1);
+	});
+});
+
+// Phase E1 (#1065): the whole-vault seq-diff validator. A manifest row whose
+// seq the replay has ALREADY consumed (row.seq <= cursor) but this path never
+// recorded is a silent apply-loss (the test_10 "received=yes materialized=no"
+// class) — rewind the cursor so the next replay re-serves it. Rows with
+// seq > cursor need nothing: the imminent replay fetches them anyway.
+describe("validateFromManifest (Phase E1 seq integer diff)", () => {
+	function manifest(notes: Array<Record<string, unknown>>) {
+		return {
+			notes,
+			attachments: [],
+			total_notes: notes.length,
+			total_attachments: 0,
+			change_seq: 100,
+		} as any;
+	}
+
+	test("consumed-but-unrecorded row (no syncState entry) rewinds the cursor to seq-1", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		const behind = (engine as any).validateFromManifest(
+			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
+		);
+		expect(behind).toBe(1);
+		expect(engine.getCatchupSeq()).toBe(13);
+	});
+
+	test("consumed row newer than the path's recorded seq rewinds", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		engine.importSyncState({ "Notes/a.md": { hash: 1, seq: 10 } });
+		(engine as any).validateFromManifest(
+			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
+		);
+		expect(engine.getCatchupSeq()).toBe(13);
+	});
+
+	test("row beyond the cursor does NOT rewind — the next replay fetches it anyway", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		(engine as any).validateFromManifest(
+			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 25 }]),
+		);
+		expect(engine.getCatchupSeq()).toBe(20);
+	});
+
+	test("legacy syncState entry without seq is NOT flagged (entry exists = it materialized)", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		engine.importSyncState({ "Notes/a.md": { hash: 1 } });
+		(engine as any).validateFromManifest(
+			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
+		);
+		expect(engine.getCatchupSeq()).toBe(20);
+	});
+
+	test("row without seq (old backend) is skipped — never NaN-rewinds", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		(engine as any).validateFromManifest(
+			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H" }]),
+		);
+		expect(engine.getCatchupSeq()).toBe(20);
+	});
+
+	test("the SAME discrepancy does not rewind twice (bounded retry, no rewind loop)", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		const m = manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]);
+		(engine as any).validateFromManifest(m);
+		expect(engine.getCatchupSeq()).toBe(13);
+		// replay re-consumed up to 20, apply still failed, same row still behind
+		engine.setCatchupSeq(20);
+		(engine as any).validateFromManifest(m);
+		expect(engine.getCatchupSeq()).toBe(20);
+	});
+});
+
+describe("catchUp manifestSeq short-circuit (Phase E1)", () => {
+	function stubCatchUpInternals(engine: SyncEngine) {
+		const reconcile = spyOn(engine as any, "reconcileFromManifest").mockResolvedValue(
+			undefined,
+		);
+		const heal = spyOn(engine as any, "healDivergedLiveBoundNotes").mockResolvedValue(
+			undefined,
+		);
+		const validate = spyOn(engine as any, "validateFromManifest").mockReturnValue(0);
+		const replay = spyOn(engine as any, "catchupViaSeqReplay").mockResolvedValue({
+			applied: 0,
+			serverIds: new Set(),
+			serverAttachmentPaths: new Set(),
+			ran: true,
+		});
+		const folders = spyOn(engine as any, "syncExplicitFolders").mockResolvedValue(undefined);
+		return { reconcile, heal, validate, replay, folders };
+	}
+
+	test("unchanged response skips the manifest-driven steps but still replays", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		(engine as any).manifestSeq = 42;
+		const { reconcile, heal, validate, replay } = stubCatchUpInternals(engine);
+		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValueOnce({
+			unchanged: true,
+			change_seq: 42,
+		});
+
+		await engine.catchUp();
+
+		expect((mockApi.getManifest as ReturnType<typeof mock>).mock.calls.at(-1)).toEqual([42]);
+		expect(reconcile).not.toHaveBeenCalled();
+		expect(heal).not.toHaveBeenCalled();
+		expect(validate).not.toHaveBeenCalled();
+		expect(replay).toHaveBeenCalledTimes(1);
+	});
+
+	test("a full manifest pass runs all steps and records change_seq as the new watermark", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		const { reconcile, heal, validate, replay } = stubCatchUpInternals(engine);
+		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValueOnce({
+			notes: [],
+			attachments: [],
+			total_notes: 0,
+			total_attachments: 0,
+			change_seq: 7,
+		});
+
+		await engine.catchUp();
+
+		expect(reconcile).toHaveBeenCalledTimes(1);
+		expect(validate).toHaveBeenCalledTimes(1);
+		expect(heal).toHaveBeenCalledTimes(1);
+		expect(replay).toHaveBeenCalledTimes(1);
+		expect((engine as any).manifestSeq).toBe(7);
+	});
 });

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -721,24 +721,41 @@ describe("validateFromManifest (Phase E1 seq integer diff)", () => {
 		} as any;
 	}
 
-	test("consumed-but-unrecorded row (no syncState entry) rewinds the cursor to seq-1", () => {
+	test("consumed-but-unrecorded row (no syncState entry) floors the next replay at seq-1", () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setCatchupSeq(20);
 		const behind = (engine as any).validateFromManifest(
 			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
 		);
 		expect(behind).toBe(1);
-		expect(engine.getCatchupSeq()).toBe(13);
+		// The validator never writes the cursor directly (an in-flight replay's
+		// per-page persist would clobber it) — it hands a floor to the sole
+		// cursor writer, runSeqReplayOnce.
+		expect((engine as any).seqRewindFloor).toBe(13);
+		expect(engine.getCatchupSeq()).toBe(20);
 	});
 
-	test("consumed row newer than the path's recorded seq rewinds", () => {
+	test("the next replay consumes the floor: crdt_catchup_since is called from the rewound cursor", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(20);
+		const catchupSince = mock(async () => ({ changes: [], has_more: false, next_seq: null }));
+		engine.setCrdtCatchupSince(catchupSince as any);
+		(engine as any).validateFromManifest(
+			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
+		);
+		await engine.catchupViaSeqReplay();
+		expect(catchupSince.mock.calls[0]?.[0]).toBe(13);
+		expect((engine as any).seqRewindFloor).toBeNull();
+	});
+
+	test("consumed row newer than the path's recorded seq floors the replay", () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		engine.setCatchupSeq(20);
 		engine.importSyncState({ "Notes/a.md": { hash: 1, seq: 10 } });
 		(engine as any).validateFromManifest(
 			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
 		);
-		expect(engine.getCatchupSeq()).toBe(13);
+		expect((engine as any).seqRewindFloor).toBe(13);
 	});
 
 	test("row beyond the cursor does NOT rewind — the next replay fetches it anyway", () => {
@@ -747,7 +764,7 @@ describe("validateFromManifest (Phase E1 seq integer diff)", () => {
 		(engine as any).validateFromManifest(
 			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 25 }]),
 		);
-		expect(engine.getCatchupSeq()).toBe(20);
+		expect((engine as any).seqRewindFloor).toBeNull();
 	});
 
 	test("legacy syncState entry without seq is NOT flagged (entry exists = it materialized)", () => {
@@ -757,7 +774,7 @@ describe("validateFromManifest (Phase E1 seq integer diff)", () => {
 		(engine as any).validateFromManifest(
 			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]),
 		);
-		expect(engine.getCatchupSeq()).toBe(20);
+		expect((engine as any).seqRewindFloor).toBeNull();
 	});
 
 	test("row without seq (old backend) is skipped — never NaN-rewinds", () => {
@@ -766,7 +783,7 @@ describe("validateFromManifest (Phase E1 seq integer diff)", () => {
 		(engine as any).validateFromManifest(
 			manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H" }]),
 		);
-		expect(engine.getCatchupSeq()).toBe(20);
+		expect((engine as any).seqRewindFloor).toBeNull();
 	});
 
 	test("the SAME discrepancy does not rewind twice (bounded retry, no rewind loop)", () => {
@@ -774,11 +791,11 @@ describe("validateFromManifest (Phase E1 seq integer diff)", () => {
 		engine.setCatchupSeq(20);
 		const m = manifest([{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 14 }]);
 		(engine as any).validateFromManifest(m);
-		expect(engine.getCatchupSeq()).toBe(13);
-		// replay re-consumed up to 20, apply still failed, same row still behind
-		engine.setCatchupSeq(20);
+		expect((engine as any).seqRewindFloor).toBe(13);
+		// replay consumed the floor, apply still failed, same row still behind
+		(engine as any).seqRewindFloor = null;
 		(engine as any).validateFromManifest(m);
-		expect(engine.getCatchupSeq()).toBe(20);
+		expect((engine as any).seqRewindFloor).toBeNull();
 	});
 });
 
@@ -787,9 +804,7 @@ describe("catchUp manifestSeq short-circuit (Phase E1)", () => {
 		const reconcile = spyOn(engine as any, "reconcileFromManifest").mockResolvedValue(
 			undefined,
 		);
-		const heal = spyOn(engine as any, "healDivergedLiveBoundNotes").mockResolvedValue(
-			undefined,
-		);
+		const heal = spyOn(engine as any, "healDivergedLiveBoundNotes").mockResolvedValue(0);
 		const validate = spyOn(engine as any, "validateFromManifest").mockReturnValue(0);
 		const replay = spyOn(engine as any, "catchupViaSeqReplay").mockResolvedValue({
 			applied: 0,
@@ -801,10 +816,14 @@ describe("catchUp manifestSeq short-circuit (Phase E1)", () => {
 		return { reconcile, heal, validate, replay, folders };
 	}
 
-	test("unchanged response skips the manifest-driven steps but still replays", async () => {
+	test("unchanged response skips the server→local manifest steps but still replays AND still seeds local empty folders", async () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		(engine as any).manifestSeq = 42;
 		const { reconcile, heal, validate, replay } = stubCatchUpInternals(engine);
+		// seedEmptyFolders is LOCAL→SERVER (retry backstop for a failed folder
+		// push) — the server watermark says nothing about local state, so the
+		// unchanged fast path must NOT skip it (review finding, agent #3).
+		const seed = spyOn(engine as any, "seedEmptyFolders").mockResolvedValue(undefined);
 		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValueOnce({
 			unchanged: true,
 			change_seq: 42,
@@ -816,7 +835,22 @@ describe("catchUp manifestSeq short-circuit (Phase E1)", () => {
 		expect(reconcile).not.toHaveBeenCalled();
 		expect(heal).not.toHaveBeenCalled();
 		expect(validate).not.toHaveBeenCalled();
+		expect(seed).toHaveBeenCalledTimes(1);
 		expect(replay).toHaveBeenCalledTimes(1);
+	});
+
+	test("a seq-0 behind row floors at genesis (sentinel does not mask target -1)", () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.setCatchupSeq(5);
+		(engine as any).validateFromManifest({
+			notes: [{ id: "id-a", path: "Notes/a.md", content_hash: "H", seq: 0 }],
+			attachments: [],
+			total_notes: 1,
+			total_attachments: 0,
+			change_seq: 5,
+		} as any);
+		// target = -1, clamped to 0 — replay from genesis.
+		expect((engine as any).seqRewindFloor).toBe(0);
 	});
 
 	test("a full manifest pass runs all steps and records change_seq as the new watermark", async () => {
@@ -837,5 +871,25 @@ describe("catchUp manifestSeq short-circuit (Phase E1)", () => {
 		expect(heal).toHaveBeenCalledTimes(1);
 		expect(replay).toHaveBeenCalledTimes(1);
 		expect((engine as any).manifestSeq).toBe(7);
+	});
+
+	test("an UNCLEAN pass (heal poked / validator behind) does NOT record the watermark — the retry net stays live", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		const { heal, validate } = stubCatchUpInternals(engine);
+		heal.mockResolvedValue(1); // one diverged live-bound note was poked
+		validate.mockReturnValue(0);
+		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValueOnce({
+			notes: [],
+			attachments: [],
+			total_notes: 0,
+			total_attachments: 0,
+			change_seq: 7,
+		});
+
+		await engine.catchUp();
+
+		// Fire-and-forget heal hasn't proven convergence — recording now would
+		// let every later poll short-circuit and never re-check an idle vault.
+		expect((engine as any).manifestSeq).toBe(0);
 	});
 });


### PR DESCRIPTION
Phase E1 of the single-path CRDT migration — the plugin half of the seq-diff bulk vault validator (Engram#1065, LOCKED addition). Pairs backend branch `feat/crdt-manifest-seq-validator` (same name — cross-repo e2e pairs on it).

## What
- **`validateFromManifest`** — pure integer diff: flags a manifest note row whose `seq` the replay already CONSUMED (`row.seq <= catchupSeq`) but the path never recorded — the silent apply-loss class behind e2e test_10's `received=yes materialized=no` — and rewinds the cursor to `min(behind)-1` so ONE replay re-serves everything. Rows beyond the cursor are untouched (the imminent replay fetches them anyway). Bounded: one rewind per distinct discrepancy per session — no rewind loops.
- **`healDivergedLiveBoundNotes`** — skips on `crdt_head` equality: op-level proof the doc holds the server state, terminating the D3 STEP1-refire ceiling for open notes whose serverHash never recorded (the ponytail ceiling noted in #284).
- **`catchUp`** — sends `?since_seq=<manifestSeq>`; an `unchanged` response skips every manifest-driven step (reconcile, validator, heal, folder sync — every server write bumps `change_seq`) while the seq replay still runs on its own cursor. The watermark records only after a fully-completed pass and is wiped with per-vault state (cross-vault integer-collision guard).
- Types: `ManifestEntry.seq/crdt_head`, `ManifestResponse.unchanged`; `getManifest(sinceSeq?)`.

## Why not hashes
`content_hash` is a per-user keyed HMAC (uncomputable client-side) and equality is direction-blind (the D2 stomp class) — decision locked 2026-07-22, see the Phase E plan + #1065.

## Tests
10 new unit tests (validator diff cases incl. legacy-entry/old-backend/bounded-retry, head-equality skip both ways, catchUp short-circuit + watermark recording). Full suite 2204 pass / 0 fail; build + biome + eslint + stylelint green. No version bumps (release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj