### PR TITLE
feat(sync): rename is one create op — delete the tombstone-resurrect dance (Phase E2)

### DIFF
--- a/main.js
+++ b/main.js
@@ -19170,7 +19170,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   }
   /** Handle a vault rename event. */
   async handleRename(file, oldPath) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+    var _a, _b, _c, _d, _e;
     if (this.syncBlocked) {
       devLog().log("sync-blocked", "handleRename short-circuited \u2014 gate closed");
       return;
@@ -19179,42 +19179,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let isBinary = this.isBinaryFile(file);
     if (isBinary || (_a = this.noteIdMap) == null || _a.rename(oldPath, file.path), !this.shouldIgnore(oldPath))
       try {
-        if (isBinary)
-          await this.api.deleteAttachment(oldPath), this.goOnline();
-        else if (oldPath.endsWith(".md")) {
-          let relocatedId = (_c = (_b = this.noteIdMap) == null ? void 0 : _b.get(file.path)) != null ? _c : null;
-          if (relocatedId)
-            if (this.crdtDelete && ((_e = (_d = this.crdtLive) == null ? void 0 : _d.call(this)) != null && _e))
-              try {
-                await this.crdtDelete(relocatedId), this.goOnline();
-              } catch (e) {
-                rlog().warn(
-                  "crdt",
-                  `rename tombstone ack failed, enqueuing durable delete for ${oldPath}: ${errMsg(e)}`
-                ), (_f = this.crdtEnqueue) == null || _f.call(this, {
-                  kind: "delete",
-                  docId: relocatedId,
-                  path: oldPath
-                });
-              }
-            else
-              (_g = this.crdtEnqueue) == null || _g.call(this, {
-                kind: "delete",
-                docId: relocatedId,
-                path: oldPath
-              });
-        } else
-          await this.api.deleteNote(oldPath), this.goOnline();
+        isBinary ? (await this.api.deleteAttachment(oldPath), this.goOnline()) : oldPath.endsWith(".md") || (await this.api.deleteNote(oldPath), this.goOnline());
       } catch (e) {
         isHttpStatus(e, 404) ? this.goOnline() : (console.error("Engram Sync: failed to delete old path %s", oldPath, e), await this.enqueueChange({
           path: oldPath,
           action: "delete",
           kind: isBinary ? "attachment" : "note",
           timestamp: Date.now(),
-          vaultId: (_h = this.settings.vaultId) != null ? _h : void 0
+          vaultId: (_b = this.settings.vaultId) != null ? _b : void 0
         }), this.maybeGoOffline(e));
       }
-    isBinary || ((_i = this.baseStore) == null || _i.rename((0, import_obsidian21.normalizePath)(oldPath), (0, import_obsidian21.normalizePath)(file.path)), this.syncState.delete((0, import_obsidian21.normalizePath)(oldPath)), this.unconfirmNoteId((_k = (_j = this.noteIdMap) == null ? void 0 : _j.get(file.path)) != null ? _k : null)), this.shouldIgnore(file.path) || await this.pushFile(file);
+    isBinary || ((_c = this.baseStore) == null || _c.rename((0, import_obsidian21.normalizePath)(oldPath), (0, import_obsidian21.normalizePath)(file.path)), this.syncState.delete((0, import_obsidian21.normalizePath)(oldPath)), this.unconfirmNoteId((_e = (_d = this.noteIdMap) == null ? void 0 : _d.get(file.path)) != null ? _e : null)), this.shouldIgnore(file.path) || await this.pushFile(file);
   }
   /** Push a folder-create from the vault to the server's explicit-folder
    *  table. Idempotent client-side (skips folders already in the set) and

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2220,47 +2220,16 @@ export class SyncEngine {
 					await this.api.deleteAttachment(oldPath);
 					this.goOnline();
 				} else if (oldPath.endsWith(".md")) {
-					// CRDT-authoritative rename = tombstone->resurrect, ORDERED. The
-					// backend has no live-note relocation: `genesis_crdt_note` replies
-					// `id_conflict` for a LIVE id at a new path (crdt_channel.ex:201), so
-					// the note moves only by tombstoning the old path first, then having
-					// the new-path `crdt_create` below hit the {:tombstone} ->
-					// `:announce_moved` resurrect (which re-paths the SAME row, so the
-					// server shows old-path gone + new-path present, matching test_10's
-					// asserts). noteIdMap.rename above moved the id onto file.path; the id
-					// (unchanged by a rename) is the tombstone target. No id means never
-					// synced, so there is nothing to tombstone.
-					//
-					// AWAIT a direct crdt_delete when the channel is live so the create
-					// sees the tombstone, never a live id_conflict, and the two ops never
-					// coalesce on the docId-keyed CrdtOpQueue (which would drop one).
-					// Offline / not-joined → durable enqueue; the reconnect re-push
-					// resurrects once the tombstone lands.
-					const relocatedId = this.noteIdMap?.get(file.path) ?? null;
-					if (relocatedId) {
-						if (this.crdtDelete && (this.crdtLive?.() ?? false)) {
-							try {
-								await this.crdtDelete(relocatedId);
-								this.goOnline();
-							} catch (e) {
-								rlog().warn(
-									"crdt",
-									`rename tombstone ack failed, enqueuing durable delete for ${oldPath}: ${errMsg(e)}`,
-								);
-								this.crdtEnqueue?.({
-									kind: "delete",
-									docId: relocatedId,
-									path: oldPath,
-								});
-							}
-						} else {
-							this.crdtEnqueue?.({
-								kind: "delete",
-								docId: relocatedId,
-								path: oldPath,
-							});
-						}
-					}
+					// Phase E2 (rename-as-move): NO tombstone. The pushFile below
+					// sends `crdt_create` for the SAME id at the new path and the
+					// backend relocates the live row in place
+					// (genesis_relocate_live -> move_note, :announce_moved fan-out);
+					// receivers move their local file via the id-keyed relocation
+					// (moveIfIdRelocated), same as a REST rename's :moved leg. The
+					// old tombstone->resurrect dance is gone with two hazards it
+					// carried: the #970 delete-wins window could eat a rename as a
+					// recreate-after-delete, and the delete+create pair could
+					// coalesce on the docId-keyed CrdtOpQueue (the test_10 class).
 				} else {
 					// Canvas / other non-md syncable text stays LWW REST (not CRDT-managed).
 					await this.api.deleteNote(oldPath);
@@ -2302,11 +2271,10 @@ export class SyncEngine {
 			// the old path — the new note's push is skipped and it never syncs).
 			// The new-path push below re-establishes sync-state under file.path.
 			this.syncState.delete(normalizePath(oldPath));
-			// The tombstone above made the note_id no longer server-live. Un-confirm
-			// it so pushFile below takes the `crdt_create` genesis branch (not the
-			// crdt_msg edit branch, which carries no path and can't move the row):
-			// against the fresh tombstone that create hits the {:tombstone} ->
-			// `:announce_moved` resurrect, re-pathing the SAME row to file.path.
+			// Un-confirm the id so pushFile below takes the `crdt_create` genesis
+			// branch (not the crdt_msg edit branch, which carries no path and
+			// can't move the row): the create for a LIVE id at the new path IS
+			// the relocation server-side (Phase E2, genesis_relocate_live).
 			this.unconfirmNoteId(this.noteIdMap?.get(file.path) ?? null);
 		}
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -337,16 +337,22 @@ describe("SyncEngine.handleRename", () => {
 		);
 	});
 
-	test("md rename tombstones the old path over the socket, never REST", async () => {
-		// A .md rename relocates via ordered tombstone->resurrect: an AWAITED direct
-		// crdt_delete for the (stable, shared) id, then pushFile's crdt_create
-		// resurrects it at the new path. It must NOT hit REST deleteNote/pushNote,
-		// and must NOT enqueue a coalescing durable delete (which would race the
-		// resurrect create on the docId-keyed queue — the test_10 regression).
+	test("md rename never emits a delete op — one create with the SAME id at the new path (Phase E2)", async () => {
+		// Rename-as-move: the backend relocates a LIVE id arriving via
+		// crdt_create at a new free path (genesis_relocate_live), so the plugin
+		// sends NO tombstone at all. Killing the delete also removes the #970
+		// delete-wins window from renames and the delete/create coalescing
+		// hazard on the docId-keyed op queue (the old test_10 class).
 		const engine = createEngine();
 		const crdtDelete = mock().mockResolvedValue({ doc_id: "id-md-move" });
+		const crdtCreate = mock().mockResolvedValue("id-md-move");
 		const enqueued: Array<{ kind: string; docId: string }> = [];
+		engine.setCrdtManager({
+			applyLocalEdit: mock(async (_id: string, c: string) => c),
+		} as any);
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# body");
 		engine.setCrdtDelete(crdtDelete);
+		engine.setCrdtCreate(crdtCreate);
 		engine.setCrdtLiveCheck(() => true);
 		engine.setCrdtEnqueue((op) => enqueued.push(op));
 
@@ -358,17 +364,21 @@ describe("SyncEngine.handleRename", () => {
 		const file = new TFile("Notes/New.md", Date.now());
 		await engine.handleRename(file, "Notes/Old.md");
 
-		expect(crdtDelete).toHaveBeenCalledWith("id-md-move");
+		expect(crdtDelete).not.toHaveBeenCalled();
+		expect(enqueued.some((op) => op.kind === "delete")).toBe(false);
+		expect(crdtCreate).toHaveBeenCalledWith("id-md-move", "Notes/New.md");
 		expect(mockApi.deleteNote).not.toHaveBeenCalled();
 		expect(mockApi.pushNote).not.toHaveBeenCalled();
-		// The id moved onto the new path; no delete should be durably queued.
-		expect(enqueued.some((op) => op.kind === "delete")).toBe(false);
 	});
 
-	test("md rename falls back to a durable delete when the channel is down", async () => {
+	test("md rename with the channel down durably enqueues the create, never a delete (Phase E2)", async () => {
 		const engine = createEngine();
 		const crdtDelete = mock().mockResolvedValue({ doc_id: "id-md-off" });
 		const enqueued: Array<{ kind: string; docId: string }> = [];
+		engine.setCrdtManager({
+			applyLocalEdit: mock(async (_id: string, c: string) => c),
+		} as any);
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# body");
 		engine.setCrdtDelete(crdtDelete);
 		engine.setCrdtLiveCheck(() => false); // channel not joined
 		engine.setCrdtEnqueue((op) => enqueued.push(op));
@@ -383,8 +393,11 @@ describe("SyncEngine.handleRename", () => {
 
 		expect(crdtDelete).not.toHaveBeenCalled();
 		expect(mockApi.deleteNote).not.toHaveBeenCalled();
+		expect(enqueued.some((op) => op.kind === "delete")).toBe(false);
+		// The reconnect drain replays the create; the backend relocation makes
+		// it the whole move.
 		expect(enqueued).toContainEqual(
-			expect.objectContaining({ kind: "delete", docId: "id-md-off" }),
+			expect.objectContaining({ kind: "create", docId: "id-md-off" }),
 		);
 	});
 });


### PR DESCRIPTION
Phase E2 of the single-path CRDT migration (rename-as-move, spec §4). Pairs backend branch `feat/crdt-rename-as-move-v2`.

## What
A .md rename no longer tombstones the old path: `handleRename` sends only the `crdt_create` for the SAME id at the new path (via the existing unconfirm→pushFile genesis route), and the paired backend relocates the live row in place. Receivers move their local file via the existing id-keyed relocation (`moveIfIdRelocated`) off the `:announce_moved` new-path upsert — the same contract REST renames already use.

## Why
The tombstone→resurrect dance carried two real hazards, both observed in CI forensics:
- the #970 delete-wins window could eat a rename as a recreate-after-delete (the test_10 `received=yes materialized=no` flake diagnosed 2026-07-22 under handshake rate-limit delay);
- the delete+create pair could coalesce on the docId-keyed op queue.

Offline renames now durably enqueue just the create (the drain replays it; the backend relocation makes it the whole move).

## Tests
Rewrote the two rename-ordering tests to pin the no-delete contract (live + channel-down). Full suite 2208 pass / 0 fail; build + biome (both versions) + eslint + stylelint green. No version bumps (release-please).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj