### PR TITLE
feat(sim): model editor enrollment → history-full notes; re-enable seeded random convergence suite

### DIFF
--- a/tests/sim/random-harness.ts
+++ b/tests/sim/random-harness.ts
@@ -17,12 +17,19 @@
 // that nothing silently wiped (#288).
 //
 // ============================================================================
-// WHY THIS IS A TOOL, NOT A GREEN TEST.
+// STATUS UPDATE (editor-enrollment landed): gap #1 below is now CLOSED — the
+// tier MODELS editor binding/enrollment (Replica.openNote → history-FULL Y.Doc),
+// so sustained CONCURRENT ONLINE editing now converges under the strict oracle
+// and is a committed gating suite: `tests/sim/random.test.ts`. THIS file stays a
+// TOOL (`.ts`, never collected by `bun test`) for exploring the STILL-gapped
+// configs the committed suite deliberately scopes out — offline-online editing,
+// create-during-edit, and delete/rename — which remain divergent for the
+// FIDELITY reason in gap #2 + the pull-only-rejoin limitation (documented in
+// random.test.ts's header). Its workload below still edits WITHOUT opening
+// (unbound, history-less), so it also preserves a live demonstration of the
+// pre-enrollment conflict-copy storm gap #1 described for comparison.
 //
-// This harness CANNOT be made deterministically green in the CURRENT sim tier
-// (measured: 5-replica ~0/12 seeds; even 2-replica no-delete ~1/10). It is kept
-// as runnable scaffolding + an executable spec of the blocker, so that when the
-// P2 fidelity work lands it can be promoted to a real suite and will pass.
+// WHY THIS WORKLOAD STILL DIVERGES (as a tool):
 //
 // It reliably DIVERGES because of TWO FOUNDATIONAL tier-fidelity limits, both of
 // which the tier's own design docs already disclose (see also

--- a/tests/sim/random.test.ts
+++ b/tests/sim/random.test.ts
@@ -1,0 +1,221 @@
+// tests/sim/random.test.ts
+//
+// SEEDED RANDOM CONVERGENCE SUITE — the gating counterpart to the scripted
+// differential gate (regressions.test.ts). Five real SyncEngine replicas share
+// one ModelServer + Scheduler and drive a long stream of RANDOM, INTERLEAVED
+// concurrent edits (kinds/targets/timings all from the scheduler's single seeded
+// PRNG). After the faults cease, the STRICT oracle (assertConverged: disk +
+// Y.Doc text + noteIdMap + findWipes, #288) demands every replica + the server
+// agree on every note.
+//
+// WHY THIS IS GREEN NOW (it was a de-tested tool — random-harness.ts — before):
+// the P2 tier-fidelity gap #1 is closed. This tier now MODELS editor
+// binding/enrollment (Replica.openNote → isBound true → real STEP1 enrollment →
+// history-FULL Y.Doc; edits stream via the live-editor path; deferUntilSeeded is
+// honored). With notes history-FULL, sustained concurrent editing converges
+// through the real 3-way CRDT merge instead of the history-less keep-both
+// conflict-copy storm that forced the old harness to stay a runnable tool. See
+// tests/sim/replica.ts's header + docs/context/crdt-convergence-sim-fidelity-gaps.md.
+//
+// ============================================================================
+// IN SCOPE (what this suite gates): sustained CONCURRENT ONLINE editing of a
+// working set of established notes, under drop faults + full-sync churn, with
+// notes opened (bound + enrolled) across replicas. This is the case gap #1 was
+// blocking: real 3-way merge convergence.
+//
+// TWO PHASES (why): a note only propagates a live edit once its server row is
+// confirmed (crdtHead set → canSendLive true → the manager sends the update
+// instead of HOLDING it; sync.ts flushHeldEditsOnCreateAck / canSendLive). Phase
+// 1 creates the working set and drains so every replica holds each note
+// history-FULL with a crdtHead. Phase 2 then edits concurrently — every edit can
+// reach the server, so no lineage gap forms.
+//
+// OUT OF SCOPE (documented tier gaps — deliberately NOT exercised here; NOT
+// oracle-loosening, these ops are simply not driven):
+//   * OFFLINE editing / offline-online churn. The CRDT rejoin handshake is
+//     PULL-ONLY — the backend never STEP1s back, so a client's offline (or
+//     otherwise gapped) Y.Doc ops are never re-pushed on reconnect; they reach
+//     the server only on the note's NEXT online edit via a full-state flush
+//     (sync.ts:786-790, flushHeldEditsOnCreateAck). A bound note's offline edit
+//     therefore does not converge in this CRDT-only model tier (its disk
+//     autosave is short-circuited by the isLiveBound gate, sync.ts:1982, so it
+//     can't fall back to the legacy REST queue either). The model faithfully
+//     reproduces this (model-server never solicits client ops on rejoin). This
+//     is a candidate real-fragility finding, not a plugin bug caught here — it
+//     needs isolation on the P2 real-backend tier before filing. See the report.
+//   * CREATE-during-concurrent-edit. Editing a note still racing its
+//     genesis/enrollment (crdtHead unset → canSendLive HOLDS the edit → a
+//     permanent lineage gap the pull-only handshake never heals). Phase 1
+//     establishes notes first to keep this out; it is the same pull-only-rejoin
+//     limitation as offline.
+//   * DELETE + RENAME. The model omits note_changed (documented divergence #2):
+//     a delete/rename only reaches other replicas via a later reconnect
+//     catch-up, stranding stale old-path files at quiescence. Unchanged from the
+//     harness. Belongs to the P2 real-backend tier.
+//
+// SEED HANDLING mirrors the old harness: each iteration draws a FRESH seed from
+// real entropy (the ONE sanctioned nondeterminism — WHICH seed to explore); the
+// run is then deterministic under it. SIM_SEED forces a single replay. The seed
+// is printed for every iteration with a copy-paste replay command, and
+// assertConverged embeds it in any divergence report. CI runs SIM_ITERATIONS=10.
+// ============================================================================
+import { afterAll, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { SimClock } from "./clock";
+import { ModelServer } from "./model-server";
+import { assertConverged } from "./oracle";
+import { Replica } from "./replica";
+import { Scheduler } from "./scheduler";
+
+// Restore the process-global boot() patches so later files in a full `bun test`
+// run don't inherit the frozen virtual clock / no-op setInterval.
+afterAll(() => Replica.restoreGlobals());
+
+const REPLICA_IDS = ["A", "B", "C", "D", "E"];
+const OPS = process.env.SIM_OPS ? Number(process.env.SIM_OPS) : 120;
+const NNOTES = 8;
+const NOTE_PATHS = Array.from({ length: NNOTES }, (_, i) => `n${i}.md`);
+
+type Rand = () => number;
+function pick<T>(rand: Rand, arr: T[]): T {
+	return arr[Math.floor(rand() * arr.length)];
+}
+
+/** Draw a fresh seed from real entropy BEFORE any Replica.boot installs the
+ *  SimClock (Date.now/Math.random are still the real globals here) — the
+ *  sanctioned "pick which seed to explore" step, not in-sim nondeterminism. */
+function pickSeed(): number {
+	return (Date.now() ^ (Math.random() * 2 ** 31)) >>> 0;
+}
+
+function readNote(r: Replica, notePath: string): string {
+	const p = path.join(r.vaultDir, notePath);
+	return fs.existsSync(p) ? fs.readFileSync(p, "utf8") : "";
+}
+
+/** One full seeded run. Boots 5 replicas, establishes the working set, drives a
+ *  random concurrent-edit stream, quiesces, and asserts strict convergence.
+ *  assertConverged throws (with the seed + replay command) on any divergence. */
+async function runSeed(seed: number): Promise<void> {
+	const clock = new SimClock();
+	const scheduler = new Scheduler(seed, clock);
+	const server = new ModelServer({ scheduler });
+	const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "sim-random-"));
+	const replicas: Replica[] = [];
+	for (const id of REPLICA_IDS) {
+		replicas.push(await Replica.boot({ id, server, scheduler, clock, rootDir }));
+	}
+	await scheduler.drain();
+
+	try {
+		// Phase 1 — establish the working set: A creates every note; drain so all
+		// replicas materialize them history-FULL; then every replica opens them
+		// (enroll → STEP1 → crdtHead) and drains so canSendLive is true everywhere.
+		for (const p of NOTE_PATHS) await replicas[0].createNote(p, `# ${p}\nbase\n`);
+		await scheduler.drain();
+		for (const r of replicas) for (const p of NOTE_PATHS) await r.openNote(p);
+		await scheduler.drain();
+
+		// Phase 2 — random concurrent edits + faults, interleaved by the seeded PRNG.
+		for (let i = 0; i < OPS; i++) {
+			const r = pick(scheduler.rand, replicas);
+			const roll = scheduler.rand();
+			if (roll < 0.8) {
+				// EDIT an established, open (history-full) note — concurrent 3-way merge.
+				const p = pick(scheduler.rand, NOTE_PATHS);
+				await r.editNote(p, `${readNote(r, p)}e${i}@${r.id}\n`);
+			} else if (roll < 0.9) {
+				// DROP the next server→client frame to r (transient loss; catch-up heals).
+				server.dropNext(r.id);
+			} else {
+				// FULL SYNC (REST round-trip) — fired, driven to completion by later steps.
+				void r.fullSync().catch(() => {});
+			}
+			// Interleave: advance the scheduler a seed-derived number of steps so
+			// deliveries partially overlap subsequent ops (the concurrency under test).
+			const steps = Math.floor(scheduler.rand() * 6);
+			for (let s = 0; s < steps; s++) if (!(await scheduler.step())) break;
+		}
+
+		// Faults cease: clear residual drops, re-open every note on every replica so
+		// any idle catch-up-delivered note hydrates its Y.Doc (idle notes are
+		// disk-only until opened — sync.ts:5184), then assert quiescent convergence.
+		server.clearDrops();
+		for (const r of replicas) {
+			await r.goOnline();
+			for (const p of NOTE_PATHS) await r.openNote(p);
+		}
+		await scheduler.drain();
+		await assertConverged(replicas, server, scheduler);
+	} finally {
+		fs.rmSync(rootDir, { recursive: true, force: true });
+	}
+}
+
+test("seeded random: 5 replicas × concurrent online editing converge (strict oracle)", async () => {
+	const iterations = process.env.SIM_SEED
+		? 1
+		: process.env.SIM_ITERATIONS
+			? Number(process.env.SIM_ITERATIONS)
+			: 6;
+	// A gating test whose job includes leaving a replayable seed breadcrumb on
+	// stdout BEFORE each run (so a hang/OOM still names the seed). Aliasing
+	// console.log keeps that intent explicit — same pattern as random-harness.ts.
+	const log = console.log;
+	for (let k = 0; k < iterations; k++) {
+		const seed = process.env.SIM_SEED ? Number(process.env.SIM_SEED) >>> 0 : pickSeed();
+		log(
+			`[sim/random] seed=${seed} (${OPS} ops × ${REPLICA_IDS.length} replicas)  ` +
+				`replay: SIM_SEED=${seed} bun test tests/sim/random.test.ts`,
+		);
+		await runSeed(seed);
+	}
+}, 600_000);
+
+// Deterministic editor-lifecycle coverage: open → concurrent edit → close (flush
+// + free the doc) → reopen → edit again, all converging. Guards the openNote /
+// closeNote flush+hydration seams the random suite leans on, in a scripted,
+// drain-between-ops (non-racy) shape so any regression in them is a hard failure.
+test("editor lifecycle: open, concurrent edit, close, reopen, edit — converges", async () => {
+	const clock = new SimClock();
+	const scheduler = new Scheduler(42, clock);
+	const server = new ModelServer({ scheduler });
+	const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "sim-lifecycle-"));
+	const a = await Replica.boot({ id: "A", server, scheduler, clock, rootDir });
+	const b = await Replica.boot({ id: "B", server, scheduler, clock, rootDir });
+	await scheduler.drain();
+	const p = "lifecycle.md";
+	try {
+		await a.createNote(p, "# lifecycle\nbase\n");
+		await scheduler.drain();
+
+		// Both open (enroll → history-full), then edit CONCURRENTLY (no drain between).
+		await a.openNote(p);
+		await b.openNote(p);
+		await scheduler.drain();
+		await a.editNote(p, `${readNote(a, p)}from-A\n`);
+		await b.editNote(p, `${readNote(b, p)}from-B\n`);
+		await scheduler.drain();
+		await assertConverged([a, b], server, scheduler);
+
+		// A closes the note (last-release flush to disk + closeDoc), then reopens and
+		// edits again — the reopen must re-hydrate and the new edit must converge.
+		await a.closeNote(p);
+		await scheduler.drain();
+		await a.openNote(p);
+		await scheduler.drain();
+		await a.editNote(p, `${readNote(a, p)}from-A-again\n`);
+		await scheduler.drain();
+		await assertConverged([a, b], server, scheduler);
+
+		// Sanity: the note carries all three edits, not a wiped/forked lineage.
+		const srv = server.state().notes.get(p);
+		expect(srv?.content).toContain("from-A");
+		expect(srv?.content).toContain("from-B");
+		expect(srv?.content).toContain("from-A-again");
+	} finally {
+		fs.rmSync(rootDir, { recursive: true, force: true });
+	}
+});

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -720,9 +720,15 @@ export class Replica {
 			// awaiting it before the caller drains would freeze the virtual clock. The
 			// real binding applies to Y.Text synchronously too — only persistence is
 			// async, and drain() completes it deterministically.
+			// Surface (don't swallow) an apply/persist failure: a systemically
+			// dropped edit would otherwise read as trivial oracle AGREEMENT (both
+			// replicas never see it), the one blind spot the convergence check
+			// can't catch on its own. Fires only on the error path — silent green.
 			void this.crdtManager
 				.applyLocalEdit(this.noteIdMap.getOrMint(path), content)
-				.catch(() => {});
+				.catch((err) =>
+					console.warn(`SIM editNote applyLocalEdit failed for ${path}:`, err),
+				);
 			// Obsidian's autosave still writes the editor buffer to disk (~2s); that
 			// modify event hits the bound short-circuit above and never re-pushes.
 			await this.app.vault.modify(file, content);

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -24,9 +24,19 @@
 //     (main.ts:1671-1698, connectChannel is single-shot here);
 //   - ensureDocSchema IDB-wipe (main.ts:1842-1868) — a schema-migration
 //     lifecycle step, not a convergence path;
-//   - CrdtLiveViews + editor extension (no Obsidian editor headless), so
-//     setLiveBoundCheck is left at its default (isLiveBound -> false), which is
-//     exactly correct: a headless note is never live-bound;
+//   - CrdtLiveViews + the CodeMirror editor extension (no Obsidian editor
+//     headless). The ONE convergence-relevant behaviour that binding drives —
+//     STEP1 enrollment (history-FULL Y.Doc) + the bound-note edit/flush routing
+//     it gates — is modeled DIRECTLY here (see openNote/closeNote/editNote and
+//     the boundPaths set) against the SAME real CrdtEnrollment / CrdtManager /
+//     SyncEngine seams main.ts wires (main.ts:623 enroll-on-open,
+//     :1912/:1962 isBound + setLiveBoundCheck, :1916 onBoundUpdate,
+//     reEnrollOpenCrdtNotes on rejoin). What is NOT reproduced is the
+//     per-keystroke y-codemirror.next binding: an edit to an OPEN note feeds the
+//     Y.Text via `manager.applyLocalEdit` (the same manager method routeModify
+//     drives) in ONE whole-content diff instead of keystroke deltas — end Y.Text
+//     state is identical, both emit valid Yjs updates on the shared lineage.
+//     This is the sim's one editor stand-in (T1); everything else is real-class;
 //   - the plan-state / folder-resync / vault-deleted / auth-provider / remote-
 //     logger plumbing — none of it touches the note-convergence data plane.
 //
@@ -51,13 +61,14 @@ import { EngramApi } from "../../src/api";
 import { NoteChannel } from "../../src/channel";
 import { makeCrdtOpSend } from "../../src/crdt-op-dispatch";
 import { type CrdtOp, CrdtOpQueue } from "../../src/crdt-op-queue";
+import type { CrdtEnrollment } from "../../src/crdt/enrollment";
 import type { CrdtManager } from "../../src/crdt/manager";
 import { NoteIdMap } from "../../src/crdt/note-id-map";
 import { createCrdtWiring } from "../../src/crdt/wiring";
 import { SyncEngine } from "../../src/sync";
 import { SyncLog } from "../../src/sync-log";
 import { DEFAULT_SETTINGS, type EngramSyncSettings } from "../../src/types";
-import { TFile, TFolder, requestUrl as baseRequestUrl } from "../__mocks__/obsidian";
+import { TFile, TFolder, requestUrl as baseRequestUrl, normalizePath } from "../__mocks__/obsidian";
 import type { SimClock } from "./clock";
 import type { ModelServer } from "./model-server";
 import { setRequestUrlHandler, requestUrl as shimRequestUrl } from "./obsidian-shim";
@@ -181,6 +192,19 @@ export class Replica {
 
 	private readonly app: SimApp;
 	private readonly channel: NoteChannel;
+	private readonly enrollment: CrdtEnrollment;
+	/** Paths this replica has "opened" in an editor (makes isBound true + drives
+	 *  the live-editor edit/flush routing). Modeled here because there is no real
+	 *  CrdtLiveViews headless — see the file header's editor-binding note. */
+	private readonly boundPaths: Set<string>;
+	/** Opened paths whose Y.Doc has been SEEDED (history-full) — the point the
+	 *  real EditorController activates its binding and starts forwarding edits.
+	 *  Before this, `bindTo` DEFERS (`deferUntilSeeded`, editor-controller.ts:110)
+	 *  precisely so a keystroke never seeds a second lineage on top of the
+	 *  server's (the #234/#846 doubling). editNote AND the bound-disk flush honor
+	 *  this gate: until seed, the editor BUFFER (= disk) is authoritative, so the
+	 *  flush must not overwrite disk with the still-empty Y.Text (a wipe). */
+	private readonly hydrated: Set<string>;
 
 	private constructor(args: {
 		id: string;
@@ -190,6 +214,9 @@ export class Replica {
 		crdtManager: CrdtManager;
 		app: SimApp;
 		channel: NoteChannel;
+		enrollment: CrdtEnrollment;
+		boundPaths: Set<string>;
+		hydrated: Set<string>;
 	}) {
 		this.id = args.id;
 		this.engine = args.engine;
@@ -198,6 +225,9 @@ export class Replica {
 		this.crdtManager = args.crdtManager;
 		this.app = args.app;
 		this.channel = args.channel;
+		this.enrollment = args.enrollment;
+		this.boundPaths = args.boundPaths;
+		this.hydrated = args.hydrated;
 	}
 
 	/** Oracle (Task 6) accessor: the #288 wipe-detector journal — every
@@ -481,18 +511,61 @@ export class Replica {
 			channel.crdtCatchupSince(cursorSeq, limit),
 		);
 
+		// Paths this replica has an editor open on (openNote adds, closeNote
+		// removes). Backs isBound + setLiveBoundCheck below, exactly as
+		// CrdtLiveViews.isBound does in production (main.ts:1912/1962).
+		const boundPaths = new Set<string>();
+		const hydrated = new Set<string>();
+		// Forward-ref (same pattern as `noteStream` above): the onBoundUpdate flush
+		// needs `manager`, which is only assigned after the wiring is built. The
+		// closure is never invoked until a runtime remote-merge fires onFlushToDisk,
+		// well after `boundFlush` is set below.
+		let boundFlush: (path: string) => void = () => {};
+
 		// CRDT data-plane wiring (main.ts:1875-2003 → createCrdtWiring + handlers).
 		const wiring = createCrdtWiring({
 			noteIdMap,
 			syncEngine: engine,
 			sendCrdt: (docId, frame) => channel.sendCrdt(docId, frame),
-			isBound: () => false, // no live editor headless
+			isBound: (path) => boundPaths.has(normalizePath(path)), // main.ts:1912
+			onBoundUpdate: (path) => boundFlush(path), // main.ts:1916
 			canSendLive: (noteId) => engine.hasServerNote(noteId), // main.ts:1890
 			// Sim seam: namespace the IndexedDB store per replica (see file header).
 			dbPrefix: id,
 		});
 		const manager = wiring.manager;
 		engine.setCrdtEnrollment(wiring.enrollment); // main.ts:1900
+		// Tell the engine which paths have a live editor binding so handleModify
+		// skips re-feeding disk content into the Y.Text for open notes (main.ts:1962).
+		engine.setLiveBoundCheck((path) => boundPaths.has(normalizePath(path)));
+
+		// requestSaveForBoundPath analogue (main.ts:1916 onBoundUpdate): a remote
+		// merge painted into a bound note's Y.Doc, but onFlushToDisk SKIPS the disk
+		// write for a bound path (the editor owns the file). Production nudges
+		// Obsidian's own save pipeline (view.requestSave) to flush the bound buffer;
+		// headless, we flush the projected Y.Text through the SAME
+		// SyncEngine.flushFromCrdt the live-views last-release path uses. Routed
+		// through a virtual timer so drain() drives it deterministically.
+		boundFlush = (path: string): void => {
+			window.setTimeout(() => {
+				void (async () => {
+					const norm = normalizePath(path);
+					// Only a SEEDED (hydrated) doc may overwrite disk: until seed the
+					// editor buffer (= disk) is authoritative and the Y.Text is empty —
+					// flushing it would wipe the note (real requestSave writes the
+					// buffer, never an empty projection).
+					if (!boundPaths.has(norm) || !hydrated.has(norm)) return;
+					const noteId = noteIdMap.get(path);
+					if (!noteId) return;
+					const text = await manager.projectedText(noteId);
+					// Never wipe: a transiently-empty projection (doc reset/reopened
+					// between the hydrated check and this read) must not overwrite the
+					// authoritative disk content — the real editor buffer still holds it.
+					if (text.length === 0) return;
+					await engine.flushFromCrdt(path, text);
+				})();
+			}, 0);
+		};
 		channel.onCrdtMessage = wiring.onCrdtMessage; // main.ts:1937
 		channel.onCrdtDocReady = wiring.onCrdtDocReady; // main.ts:1938
 		channel.onCrdtNoteNotFound = wiring.onCrdtNoteNotFound; // main.ts:1939
@@ -517,8 +590,10 @@ export class Replica {
 		};
 
 		// Mirror of main.ts's onCrdtTopicJoined (reconnect convergence): reconcile the
-		// id-map from the manifest, reset enrollments, then replay the seq op-log.
-		// reEnrollOpenCrdtNotes is a no-op headless (no open editors).
+		// id-map from the manifest, reset enrollments, re-enroll every open note, then
+		// replay the seq op-log. reEnrollOpenCrdtNotes (main.ts:1666) re-fires a fresh
+		// STEP1 for each note still open in an editor so the server re-registers this
+		// device as a room observer — headless, "open" is the boundPaths set.
 		async function onCrdtTopicJoined(): Promise<void> {
 			try {
 				await engine.reconcileNoteIdMapFromManifest();
@@ -527,6 +602,9 @@ export class Replica {
 			}
 			wiring.enrollment.resetAll();
 			wiring.clearStrandHealAttempts();
+			for (const p of boundPaths) {
+				wiring.enrollment.enroll(noteIdMap.getOrMint(p));
+			}
 			try {
 				await engine.catchupViaSeqReplay();
 			} catch {
@@ -540,7 +618,18 @@ export class Replica {
 
 		void channel.connect(); // main.ts:2013
 
-		return new Replica({ id, engine, vaultDir, noteIdMap, crdtManager: manager, app, channel });
+		return new Replica({
+			id,
+			engine,
+			vaultDir,
+			noteIdMap,
+			crdtManager: manager,
+			app,
+			channel,
+			enrollment: wiring.enrollment,
+			boundPaths,
+			hydrated,
+		});
 	}
 
 	// ------------------------------------------------------------------------
@@ -553,9 +642,92 @@ export class Replica {
 		await this.app.vault.create(path, content);
 	}
 
+	/** Open a note in an editor: makes isBound(path) true and fires the real
+	 *  STEP1 enrollment (main.ts:623 active-leaf-change → enroll(getOrMint(path))),
+	 *  so the note pulls remote CRDT history and becomes history-FULL. A real user
+	 *  must open a note before editing it; the random workload mirrors that.
+	 *
+	 *  Also arms the deferUntilSeeded gate: a doc that already carries history (a
+	 *  locally-created note) is editable at once; a history-less one (received via
+	 *  catch-up, disk-only) becomes editable only once STEP2 seeds it — matching
+	 *  EditorController.bindTo, which defers its binding until the doc is seeded. */
+	async openNote(path: string): Promise<void> {
+		const norm = normalizePath(path);
+		this.boundPaths.add(norm);
+		const id = this.noteIdMap.getOrMint(path);
+		this.enrollment.enroll(id);
+		// Fire-and-forget (scheduler-driven, like every CRDT op here): mark the
+		// note hydrated now if the Y.Text already has content, else once its first
+		// non-empty seed lands. Deterministic — the seed arrives via a scheduled
+		// STEP2 frame that drain() delivers in seed order.
+		void (async () => {
+			const text = (await this.crdtManager.getDoc(id)).getText("content");
+			if (text.length > 0) {
+				this.hydrated.add(norm);
+				return;
+			}
+			const onSeed = (): void => {
+				if (text.length > 0) {
+					this.hydrated.add(norm);
+					text.unobserve(onSeed);
+				}
+			};
+			text.observe(onSeed);
+		})().catch(() => {});
+	}
+
+	/** Close the editor: flush the projected Y.Text to disk and free the doc
+	 *  (mirrors CrdtLiveViews.onLastViewerRelease), then drop the binding. The
+	 *  flush awaits IndexedDB, which only the scheduler drives, so — like every
+	 *  other CRDT op in this tier — it is FIRED and the caller's drain() completes
+	 *  it (awaiting it here without a drain would deadlock the virtual clock). */
+	async closeNote(path: string): Promise<void> {
+		const norm = normalizePath(path);
+		if (!this.boundPaths.has(norm)) return;
+		this.boundPaths.delete(norm);
+		const wasHydrated = this.hydrated.delete(norm);
+		const noteId = this.noteIdMap.get(path);
+		if (!noteId) return;
+		void (async () => {
+			// Only flush a seeded doc (see boundFlush), and NEVER write an empty
+			// projection over disk (a transient reset would otherwise wipe the note —
+			// the real editor buffer still holds the content across a close).
+			if (wasHydrated) {
+				const text = await this.crdtManager.projectedText(noteId);
+				if (text.length > 0) await this.engine.flushFromCrdt(path, text);
+			}
+			this.crdtManager.closeDoc(noteId);
+		})().catch(() => {});
+	}
+
 	async editNote(path: string, content: string): Promise<void> {
 		const file = this.app.vault.getFileByPath(path);
 		if (!file) throw new Error(`editNote: no file at ${path}`);
+		if (this.boundPaths.has(normalizePath(path))) {
+			// deferUntilSeeded: the real editor does NOT forward a keystroke into a
+			// history-less doc (it would seed a second lineage → doubling). Until the
+			// server seeds this note's Y.Doc, the edit is buffered in the editor, not
+			// yet on the wire. Model that by dropping the edit here — a later edit
+			// (after hydration) forwards convergently. NEVER touch disk without the
+			// Y.Text, or the bound path would drift from its authoritative doc.
+			if (!this.hydrated.has(normalizePath(path))) return;
+			// Live-editor edit: the y-codemirror.next binding would stream keystrokes
+			// into the Y.Text; headless, feed the whole content through the SAME
+			// manager method routeModify drives (the one editor stand-in, see header).
+			// handleModify short-circuits the disk-driven CRDT route for a bound path
+			// (sync.ts:1982), so the Y.Text is the ONLY inbound edit channel here.
+			// FIRED not awaited: applyLocalEdit awaits IndexedDB (scheduler-driven);
+			// awaiting it before the caller drains would freeze the virtual clock. The
+			// real binding applies to Y.Text synchronously too — only persistence is
+			// async, and drain() completes it deterministically.
+			void this.crdtManager
+				.applyLocalEdit(this.noteIdMap.getOrMint(path), content)
+				.catch(() => {});
+			// Obsidian's autosave still writes the editor buffer to disk (~2s); that
+			// modify event hits the bound short-circuit above and never re-pushes.
+			await this.app.vault.modify(file, content);
+			return;
+		}
 		await this.app.vault.modify(file, content);
 	}
 


### PR DESCRIPTION
## Summary
Closes convergence-sim **fidelity gap #1** (headless replicas never enrolled → every note stayed history-less → concurrent edits took the keep-both conflict-copy storm), then re-enables the seeded random convergence suite as a committed, deterministically-green gating test.

## Enrollment model (mirrors real `isBound` / STEP1)
All in `tests/sim/replica.ts`, wired against the SAME real seams `main.ts` uses — no new stub classes (one disclosed T1 stand-in):
- `boundPaths` set backs **both** the wiring `isBound` (main.ts:1912) **and** `engine.setLiveBoundCheck` (main.ts:1962, never called before).
- `openNote(path)` = `boundPaths.add` + `enrollment.enroll(getOrMint(path))` — the exact `active-leaf-change` enroll (main.ts:623). Fires the real STEP1 → model replies STEP2 → note becomes **history-FULL**.
- `onBoundUpdate → boundFlush` reproduces `requestSaveForBoundPath` (main.ts:1916) via the real `SyncEngine.flushFromCrdt`.
- `closeNote` mirrors `CrdtLiveViews.onLastViewerRelease`; `onCrdtTopicJoined` re-enrolls bound notes on reconnect (`reEnrollOpenCrdtNotes`, main.ts:1666).
- A `hydrated` gate reproduces `EditorController.deferUntilSeeded` (editor-controller.ts:110): an edit forwards only to a **seeded** doc, and the bound flush never writes an empty projection over disk — preventing second-lineage doubling and transient-empty wipes.

**T1 disclosure (only stand-in):** a bound edit feeds Y.Text via the real `manager.applyLocalEdit` (whole-content diff, the method `routeModify` drives) instead of per-keystroke `y-codemirror.next` deltas — identical end state. Documented in `replica.ts`'s header.

## Random suite (`tests/sim/random.test.ts`)
5 replicas, strict oracle (disk + Y.Doc text + noteIdMap + findWipes), two-phase (establish notes → concurrent ONLINE editing + drop faults + full-sync):
- **50/50 fresh seeds converge** (100 & 200 ops); 40/40 at the committed 120-op default; deterministic under `SIM_SEED`. CI runs `SIM_ITERATIONS=10`.
- Plus a deterministic scripted `open → concurrent edit → close → reopen → edit` lifecycle test.

## In-scope vs still-gapped
**In-scope (gated):** create, open/close, sustained concurrent online edit (real 3-way merge), drop faults, full-sync.
**Gapped (documented, scoped out — NOT oracle-loosening):** offline/offline-online editing, create-during-edit, delete/rename.

## REAL finding (candidate, held for isolation — not filed)
**Pull-only CRDT rejoin handshake → offline/gapped bound edits can be permanently lost.** The backend never STEP1s-back (`sync.ts:786-790`), so a client's Y.Doc ops not delivered live (offline, or held by `canSendLive` before `crdtHead` is set) are never re-pushed on reconnect. A bound note's offline edit can't fall back to the legacy REST queue either (`handleModify` short-circuits the disk route for a live-bound path, `sync.ts:1982`). The model faithfully reproduces this (STEP2-only replies), so it's a candidate real fragility, not a plugin bug caught here — needs re-isolation on the P2 real-backend tier before filing.

## Verification
- `bun test`: **2248 pass, 1 skip (pre-existing), 0 fail** (existing sim suite: 45 pass, 0 fail — no regressions).
- `biome check src tests`: clean. `bun run build`: clean. No version bumps. All sim code under `tests/sim/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJksd3C2xLkXyucHRRnuVC