### PR TITLE
fix: CRDT error guards — replay mint refusal, enrollment retry, frame/flush logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -23009,7 +23009,7 @@ var CrdtEnrollment = class {
         var _a;
         return (_a = this.onAfterEnroll) == null ? void 0 : _a.call(this, noteId);
       }).catch((e) => {
-        this.enrolled.delete(noteId), rlog().warn(
+        this.enrolled.delete(noteId), this.resetSync(noteId), rlog().warn(
           "crdt",
           `enroll startSync failed for ${noteId}: ${errMsg(e)} \u2014 will retry on next open`
         );
@@ -23082,7 +23082,10 @@ function createCrdtWiring(deps) {
       ), healUnknownNoteId(id2, content);
     for (let { path, content } of toFlush)
       deps.isBound(path) || syncEngine.flushFromCrdt(path, content).then((ok) => {
-        ok || rlog().warn("crdt", `strand-heal flush refused for ${path} \u2014 retained in Y.Doc`);
+        ok || rlog().warn(
+          "crdt",
+          `strand-heal flush refused for ${path} \u2014 retained in Y.Doc`
+        );
       }).catch(
         (e) => rlog().warn(
           "crdt",
@@ -23162,7 +23165,10 @@ function createCrdtWiring(deps) {
     }
   }), onCrdtMessage = (docId, b64) => {
     channel.handleFrame(docId, b64).catch((e) => {
-      rlog().warn("crdt", `handleFrame failed for note_id=${docId}: ${errMsg(e)} \u2014 frame dropped`);
+      rlog().warn(
+        "crdt",
+        `handleFrame failed for note_id=${docId}: ${errMsg(e)} \u2014 frame dropped`
+      );
     });
   }, onNoteYjsUpdate = (noteId, b64, head, seq3) => {
     syncEngine.applyLiveOpWithSeq(

--- a/main.js
+++ b/main.js
@@ -17432,23 +17432,31 @@ var _CrdtManager = class _CrdtManager {
     if (cached)
       return await cached.ready, cached;
     let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), text2 = doc2.getText(CONTENT_KEY), ready = persistence.whenSynced.then(() => {
-    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0 };
+    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0, hadContent: !1 };
     return persistence.on("error", (err) => {
       var _a, _b;
       return (_b = (_a = this.opts).onPersistError) == null ? void 0 : _b.call(_a, noteId, err);
     }), doc2.on("update", (update, origin) => {
-      origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
+      text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
     }), doc2.on("update", (_u, origin) => {
-      if (origin !== REMOTE_ORIGIN) return;
+      if (text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN) return;
       entry.remoteSeq += 1;
-      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON(), flush = Promise.resolve(
+      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON();
+      if (body.length === 0 && !entry.hadContent) {
+        rlog().warn(
+          "crdt",
+          `remote-merge flush SKIPPED for ${noteId}: empty body on never-seeded doc (#288 genesis guard)`
+        );
+        return;
+      }
+      let flush = Promise.resolve(
         this.opts.onFlushToDisk(noteId, projectNote(order, values, body, raws))
       );
       this.pendingFlush.set(id2, flush), flush.catch(() => {
       }).finally(() => {
         this.pendingFlush.get(id2) === flush && this.pendingFlush.delete(id2);
       });
-    }), this.docs.set(id2, entry), await ready, entry;
+    }), this.docs.set(id2, entry), await ready, text2.length > 0 && (entry.hadContent = !0), entry;
   }
   /**
    * Returns true when the Y.Text already carries CRDT history (content
@@ -21732,7 +21740,16 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             content = await this.app.vault.cachedRead(file), mtime = file.stat.mtime / 1e3;
           }
           let replayNp = (0, import_obsidian21.normalizePath)(entry.path), replayId = (_k = (_j = this.noteIdMap) == null ? void 0 : _j.get(replayNp)) != null ? _k : null;
-          !replayId && this.noteIdMap && (replayId = uuid7(), this.noteIdMap.set(replayNp, replayId));
+          if (!replayId && this.noteIdMap) {
+            if (this.shouldDeferMint(replayNp)) {
+              rlog().info(
+                "queue",
+                `Replay mint refused (engine-flushed, id relocated away): ${entry.path}`
+              );
+              continue;
+            }
+            replayId = uuid7(), this.noteIdMap.set(replayNp, replayId);
+          }
           let replayState = this.syncState.get(replayNp), replayBase = replayState == null ? void 0 : replayState.serverHash, resp = replayBase !== void 0 ? await this.api.pushNote(
             entry.path,
             content,
@@ -22991,6 +23008,11 @@ var CrdtEnrollment = class {
       this.active++, this.startSync(noteId).then(() => {
         var _a;
         return (_a = this.onAfterEnroll) == null ? void 0 : _a.call(this, noteId);
+      }).catch((e) => {
+        this.enrolled.delete(noteId), rlog().warn(
+          "crdt",
+          `enroll startSync failed for ${noteId}: ${errMsg(e)} \u2014 will retry on next open`
+        );
       }).finally(() => {
         this.active--, this.drain();
       });
@@ -23059,7 +23081,14 @@ function createCrdtWiring(deps) {
         `onFlushToDisk: still no path for note_id=${id2} after heal \u2014 retrying`
       ), healUnknownNoteId(id2, content);
     for (let { path, content } of toFlush)
-      deps.isBound(path) || syncEngine.flushFromCrdt(path, content);
+      deps.isBound(path) || syncEngine.flushFromCrdt(path, content).then((ok) => {
+        ok || rlog().warn("crdt", `strand-heal flush refused for ${path} \u2014 retained in Y.Doc`);
+      }).catch(
+        (e) => rlog().warn(
+          "crdt",
+          `strand-heal flush failed for ${path}: ${errMsg(e)} \u2014 retained in Y.Doc`
+        )
+      );
   }
   function healUnknownNoteId(noteId, content) {
     strandedFlushes.set(noteId, content), strandHealTimer === null && (strandHealTimer = window.setTimeout(() => {
@@ -23132,7 +23161,9 @@ function createCrdtWiring(deps) {
       await manager.flattenIfBloated(noteId);
     }
   }), onCrdtMessage = (docId, b64) => {
-    channel.handleFrame(docId, b64);
+    channel.handleFrame(docId, b64).catch((e) => {
+      rlog().warn("crdt", `handleFrame failed for note_id=${docId}: ${errMsg(e)} \u2014 frame dropped`);
+    });
   }, onNoteYjsUpdate = (noteId, b64, head, seq3) => {
     syncEngine.applyLiveOpWithSeq(
       noteId,

--- a/src/crdt/enrollment.ts
+++ b/src/crdt/enrollment.ts
@@ -25,6 +25,9 @@
  *     fresh handshake fires after a disconnect (mirrors `CrdtChannel.resetSync`).
  */
 
+import { errMsg } from "../error-util";
+import { rlog } from "../remote-log";
+
 export class CrdtEnrollment {
 	/** note_ids that have already received (or been queued for) a startSync this session. */
 	private readonly enrolled = new Set<string>();
@@ -85,6 +88,16 @@ export class CrdtEnrollment {
 			this.active++;
 			void this.startSync(noteId)
 				.then(() => this.onAfterEnroll?.(noteId))
+				.catch((e) => {
+					// Failed handshake: un-mark so a later enroll() retries — a
+					// permanent `enrolled` latch would leave the note deaf to remote
+					// CRDT state for the whole session, with nothing logged.
+					this.enrolled.delete(noteId);
+					rlog().warn(
+						"crdt",
+						`enroll startSync failed for ${noteId}: ${errMsg(e)} — will retry on next open`,
+					);
+				})
 				.finally(() => {
 					this.active--;
 					this.drain();

--- a/src/crdt/enrollment.ts
+++ b/src/crdt/enrollment.ts
@@ -92,7 +92,11 @@ export class CrdtEnrollment {
 					// Failed handshake: un-mark so a later enroll() retries — a
 					// permanent `enrolled` latch would leave the note deaf to remote
 					// CRDT state for the whole session, with nothing logged.
+					// resetSync clears the channel's once-per-doc `initiated` latch
+					// too (set BEFORE startSync's first await) — without it the
+					// retry's startSync early-returns and never sends a STEP1.
 					this.enrolled.delete(noteId);
+					this.resetSync(noteId);
 					rlog().warn(
 						"crdt",
 						`enroll startSync failed for ${noteId}: ${errMsg(e)} — will retry on next open`,

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -201,7 +201,24 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		}
 		for (const { path, content } of toFlush) {
 			if (deps.isBound(path)) continue; // live editor owns disk
-			void syncEngine.flushFromCrdt(path, content);
+			// The primary onFlushToDisk path throws on a refused write; this healed
+			// path can't await (fire-and-forget batch), so surface refusal/failure
+			// via rlog instead of discarding it — content stays safe in the Y.Doc.
+			syncEngine
+				.flushFromCrdt(path, content)
+				.then((ok) => {
+					if (!ok)
+						rlog().warn(
+							"crdt",
+							`strand-heal flush refused for ${path} — retained in Y.Doc`,
+						);
+				})
+				.catch((e) =>
+					rlog().warn(
+						"crdt",
+						`strand-heal flush failed for ${path}: ${errMsg(e)} — retained in Y.Doc`,
+					),
+				);
 		}
 	}
 
@@ -308,7 +325,14 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 
 	// docId is the bare note_id (Task 6) — forwarded to handleFrame directly.
 	const onCrdtMessage = (docId: string, b64: string): void => {
-		void channel.handleFrame(docId, b64);
+		channel.handleFrame(docId, b64).catch((e) => {
+			// Malformed frame / doc-open failure: log + drop — never leak an
+			// unhandled rejection from the inbound hot path.
+			rlog().warn(
+				"crdt",
+				`handleFrame failed for note_id=${docId}: ${errMsg(e)} — frame dropped`,
+			);
+		});
 	};
 
 	// Vault-channel fan-out (P1): applies a server-pushed Yjs update to an IDLE

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -7314,6 +7314,19 @@ export class SyncEngine {
 					const replayNp = normalizePath(entry.path);
 					let replayId = this.noteIdMap?.get(replayNp) ?? null;
 					if (!replayId && this.noteIdMap) {
+						// MINT REFUSAL (#972/#217 parity) — see shouldDeferMint. Live
+						// pushes and batch genesis refuse to mint for an engine-flushed
+						// path whose id relocated away; the replay path must too, or a
+						// stale queued entry mints a FRESH id and duplicates the note
+						// server-side. Leave it queued — the next flush (after the echo
+						// window) re-resolves against the settled map.
+						if (this.shouldDeferMint(replayNp)) {
+							rlog().info(
+								"queue",
+								`Replay mint refused (engine-flushed, id relocated away): ${entry.path}`,
+							);
+							continue;
+						}
 						replayId = uuid7();
 						this.noteIdMap.set(replayNp, replayId);
 					}

--- a/tests/crdt/enrollment.test.ts
+++ b/tests/crdt/enrollment.test.ts
@@ -4,8 +4,9 @@
  * Task 7B: opening a note triggers exactly one startSync; reset on reconnect
  * allows a fresh startSync; multiple paths each get their own startSync.
  */
-import { describe, expect, mock, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
 import { CrdtEnrollment } from "../../src/crdt/enrollment";
+import { rlog } from "../../src/remote-log";
 
 function makeEnrollment() {
 	const startSyncCalls: string[] = [];
@@ -163,6 +164,41 @@ describe("CrdtEnrollment bounded concurrency", () => {
 		e.enroll("id-1");
 		for (let i = 0; i < 10; i++) await Promise.resolve();
 		expect(calls).toBe(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Failed handshake: a rejected startSync must not permanently latch the
+// once-per-session guard (the note would stay deaf all session, silently).
+// ---------------------------------------------------------------------------
+
+describe("CrdtEnrollment failed handshake", () => {
+	test("a rejected startSync logs a warn and un-marks enrollment so a later enroll retries", async () => {
+		let calls = 0;
+		const e = new CrdtEnrollment({
+			startSync: async () => {
+				calls++;
+				if (calls === 1) throw new Error("transport down");
+			},
+			resetSync: () => {},
+		});
+		const warnSpy = spyOn(rlog(), "warn");
+
+		e.enroll("id-1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(calls).toBe(1);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
+		const [category, message] = warnSpy.mock.calls[0] as unknown as [string, string];
+		expect(category).toBe("crdt");
+		expect(message).toContain("id-1");
+
+		// The failed handshake must be retryable — a permanent `enrolled` latch
+		// leaves the note deaf to remote CRDT state for the whole session.
+		e.enroll("id-1");
+		await new Promise((r) => setTimeout(r, 0));
+		expect(calls).toBe(2);
+
+		warnSpy.mockRestore();
 	});
 });
 

--- a/tests/crdt/enrollment.test.ts
+++ b/tests/crdt/enrollment.test.ts
@@ -175,12 +175,15 @@ describe("CrdtEnrollment bounded concurrency", () => {
 describe("CrdtEnrollment failed handshake", () => {
 	test("a rejected startSync logs a warn and un-marks enrollment so a later enroll retries", async () => {
 		let calls = 0;
+		const resetSyncCalls: string[] = [];
 		const e = new CrdtEnrollment({
 			startSync: async () => {
 				calls++;
 				if (calls === 1) throw new Error("transport down");
 			},
-			resetSync: () => {},
+			resetSync: (id) => {
+				resetSyncCalls.push(id);
+			},
 		});
 		const warnSpy = spyOn(rlog(), "warn");
 
@@ -191,6 +194,11 @@ describe("CrdtEnrollment failed handshake", () => {
 		const [category, message] = warnSpy.mock.calls[0] as unknown as [string, string];
 		expect(category).toBe("crdt");
 		expect(message).toContain("id-1");
+
+		// The channel's once-per-doc `initiated` latch is set BEFORE startSync's
+		// first await (channel.ts) — without resetSync the "retry" would early
+		// return there and never send a STEP1. The catch must clear BOTH latches.
+		expect(resetSyncCalls).toEqual(["id-1"]);
 
 		// The failed handshake must be retryable — a permanent `enrolled` latch
 		// leaves the note deaf to remote CRDT state for the whole session.

--- a/tests/crdt/wiring.test.ts
+++ b/tests/crdt/wiring.test.ts
@@ -23,10 +23,11 @@
  *   3. an inbound frame for an id the receiver's map doesn't know strands, then
  *      heals via reconcile + retry (the #187 on-strand self-heal).
  */
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import "fake-indexeddb/auto";
 import { NoteIdMap } from "../../src/crdt/note-id-map";
 import { type CrdtWiring, createCrdtWiring } from "../../src/crdt/wiring";
+import { rlog } from "../../src/remote-log";
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -54,17 +55,24 @@ interface Device {
 /** A device: real NoteIdMap + real CrdtManager (via the wiring) + a fake
  *  SyncEngine that records flushes to a path-keyed disk. `reconcile` models the
  *  server manifest — it mutates this device's map and returns the note count. */
-function makeDevice(id: string, reconcile: () => number): Device {
+function makeDevice(
+	id: string,
+	reconcile: () => number,
+	opts?: { flushFromCrdt?: (path: string, content: string) => Promise<boolean> },
+): Device {
 	const map = new NoteIdMap();
 	const disk = new Map<string, string>();
 	const flushedPaths: string[] = [];
 	const relayTo = { send: (_docId: string, _frame: string) => {} };
 
 	const syncEngine = {
-		flushFromCrdt: async (path: string, content: string) => {
-			disk.set(path, content);
-			flushedPaths.push(path);
-		},
+		flushFromCrdt:
+			opts?.flushFromCrdt ??
+			(async (path: string, content: string) => {
+				disk.set(path, content);
+				flushedPaths.push(path);
+				return true;
+			}),
 		isUnchangedSynced: () => false,
 		materializeEmptyDiscovered: async (path: string) => {
 			disk.set(path, "");
@@ -333,6 +341,65 @@ test("rename on A leaves B with exactly one file at the new path", async () => {
 	expect(a.map.pathForId(noteId)).toBe("A/original.md");
 	expect(b.map.pathForId(noteId)).toBe("B/renamed.md");
 
+	await destroy(a, b);
+});
+
+test("onCrdtMessage with a malformed frame logs a warn instead of an unhandled rejection", async () => {
+	const dev = makeDevice("GARBAGE", () => 0);
+	const warnSpy = spyOn(rlog(), "warn");
+
+	// Not valid base64 / not a valid yjs frame — handleFrame rejects. The wiring
+	// must catch it (log + drop the frame), never leak an unhandled rejection.
+	dev.wiring.onCrdtMessage("bad-frame-id", "!!!not-a-frame!!!");
+	await sleep(20);
+
+	expect(warnSpy).toHaveBeenCalled();
+	const [category, message] = warnSpy.mock.calls[warnSpy.mock.calls.length - 1] as unknown as [
+		string,
+		string,
+	];
+	expect(category).toBe("crdt");
+	expect(message).toContain("bad-frame-id");
+
+	warnSpy.mockRestore();
+	await destroy(dev);
+});
+
+test("a refused stranded-flush disk write is logged, not silently dropped", async () => {
+	// Same shape as the strand-heal scenario below, but the receiver's
+	// flushFromCrdt REFUSES the write (returns false — e.g. the empty-over-content
+	// gate). Pre-fix: `void syncEngine.flushFromCrdt(...)` discarded the result,
+	// so content stranded in the Y.Doc with zero observability.
+	const noteId = "note-failflush";
+	const a = makeDevice("FA", () => 0);
+	const b = makeDevice(
+		"FB",
+		() => {
+			b.map.set("FB/fail.md", noteId);
+			return 1;
+		},
+		{ flushFromCrdt: async () => false },
+	);
+	connect(a, b);
+
+	a.map.set("FA/new.md", noteId);
+	a.wiring.manager.markSynced(noteId);
+	await a.wiring.manager.applyLocalEdit(noteId, "refused body", false);
+
+	b.wiring.onCrdtDocReady(noteId);
+	await waitFor(
+		async () => (await b.wiring.manager.getText(noteId)) === "refused body",
+		"B integrates body into the Y.Doc",
+	);
+
+	const warnSpy = spyOn(rlog(), "warn");
+	await b.wiring.drainStrandedFlushes();
+	await sleep(20); // let the (un-awaited) flush promise settle
+
+	const warns = warnSpy.mock.calls as unknown as Array<[string, string]>;
+	expect(warns.some(([cat, msg]) => cat === "crdt" && msg.includes("FB/fail.md"))).toBe(true);
+
+	warnSpy.mockRestore();
 	await destroy(a, b);
 });
 

--- a/tests/sync-replay-cas-enroll.test.ts
+++ b/tests/sync-replay-cas-enroll.test.ts
@@ -196,3 +196,36 @@ describe("A6: first confirmation re-fires the CRDT handshake", () => {
 		expect(enroll).not.toHaveBeenCalled();
 	});
 });
+
+describe("replay mint refusal (#972/#217 guard parity)", () => {
+	test("replay of an engine-flushed path with no id does NOT mint — entry stays queued", async () => {
+		const engine = createEngine();
+		const map = new NoteIdMap();
+		engine.setNoteIdMap(map); // no id mapped for the path
+
+		// Engine-flushed window: flushFromCrdt just wrote this path after its id
+		// was relocated away (#972 class). Live pushes and batch genesis refuse to
+		// mint here (shouldDeferMint) — the replay path must too, or a stale
+		// queued entry mints a FRESH id and creates a duplicate server row.
+		(engine as unknown as { recentlyFlushed: Map<string, number> }).recentlyFlushed.set(
+			"flushed.md",
+			1,
+		);
+
+		engine.queue.load([
+			{
+				path: "flushed.md",
+				action: "upsert",
+				content: "stale offline edit",
+				mtime: 100,
+				timestamp: 1,
+			},
+		]);
+
+		await engine.flushQueue();
+
+		expect(mockApi.pushNote).not.toHaveBeenCalled(); // no push under a fresh id
+		expect(map.get("flushed.md")).toBeNull(); // no mint
+		expect(engine.queue.size).toBe(1); // left queued for after the echo window
+	});
+});


### PR DESCRIPTION
## Summary

Four swallowed-failure holes in the CRDT path, found by the post-migration audit (all TDD'd — each fix has a test that failed before it):

1. **Offline-queue replay minted without the `shouldDeferMint` guard** (`sync.ts` replay path). Live pushes and batch genesis refuse to mint a fresh note_id for an engine-flushed path whose id relocated away (#972/#217); the replay path didn't — a stale queued entry could mint a fresh id and duplicate the note server-side. Now refuses and leaves the entry queued; the next flush (after the 5s echo window) re-resolves against the settled map.

2. **`CrdtEnrollment.drain` swallowed a rejected `startSync`** — unhandled promise rejection AND the noteId stayed latched in `enrolled`, so the note never handshaked again all session, silently. Now logs a `crdt` warn and un-marks enrollment so the next `enroll()` retries.

3. **`wiring.onCrdtMessage` fired `handleFrame` uncaught** — a malformed frame was a silent drop + unhandled rejection. Now caught + rlog'd with the note_id.

4. **`wiring.drainStrandedFlushes` discarded a refused/failed `flushFromCrdt`** — the primary onFlushToDisk path throws on refusal, but the strand-healed path void-discarded the result. Now surfaces refusal and failure via rlog (content stays safe in the Y.Doc either way).

## Testing

- 4 new tests (RED before fix, GREEN after): `tests/crdt/enrollment.test.ts`, `tests/crdt/wiring.test.ts` ×2, `tests/sync-replay-cas-enroll.test.ts`
- Full suite: 2260 pass / 0 fail
- `biome ci` clean, `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj