### PR TITLE
chore: delete the enableCrdt flag-theater + CRDT-audit dead weight

### DIFF
--- a/main.js
+++ b/main.js
@@ -1504,7 +1504,7 @@ function topicUserIdIsStale(currentUserId, authenticatedUserId) {
   return authenticatedUserId ? currentUserId !== authenticatedUserId : !1;
 }
 var LARGE_FRAME_WARN_BYTES = 1e6, NoteChannel = class {
-  constructor(baseUrl, apiKey, userId, vaultId = null, enableCrdt = !1, deviceId = null) {
+  constructor(baseUrl, apiKey, userId, vaultId = null, deviceId = null) {
     this.ws = null;
     this.ref = 0;
     /** In-flight requests sent via `sendRequest`, keyed by the outbound frame's
@@ -1626,7 +1626,7 @@ var LARGE_FRAME_WARN_BYTES = 1e6, NoteChannel = class {
     // ---------------------------------------------------------------------------
     /** Guards openSocket against re-entry across its async token fetch. */
     this.opening = !1;
-    this.baseUrl = baseUrl.replace(/\/+$/, "").replace(/\/api$/, ""), this.apiKey = apiKey, this.userId = userId, this.vaultId = vaultId, this.enableCrdt = enableCrdt, this.deviceId = deviceId, rlog().info(
+    this.baseUrl = baseUrl.replace(/\/+$/, "").replace(/\/api$/, ""), this.apiKey = apiKey, this.userId = userId, this.vaultId = vaultId, this.deviceId = deviceId, rlog().info(
       "channel",
       `NoteChannel ctor \u2014 userId=${userId} vaultId=${vaultId != null ? vaultId : "null"} apiKeyLen=${apiKey.length} baseUrl=${this.baseUrl}`
     );
@@ -1654,7 +1654,7 @@ var LARGE_FRAME_WARN_BYTES = 1e6, NoteChannel = class {
     return `user:${this.userId}`;
   }
   get crdtTopic() {
-    return this.enableCrdt && this.vaultId ? `crdt:${this.userId}:${this.vaultId}` : null;
+    return this.vaultId ? `crdt:${this.userId}:${this.vaultId}` : null;
   }
   /** Send a CRDT update frame on the crdt topic.
    *  Returns false without sending until the crdt: join is server-acked —
@@ -24193,8 +24193,6 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         this.settings.apiKey,
         user.id,
         this.settings.vaultId,
-        !0,
-        // CRDT topic join — always on (the enableCrdt setting is gone; false survives only as a test seam)
         this.deviceId
       );
       if (channel.setAuthProbe(() => this.api.getMe()), channel.onEvent = (event) => {

--- a/main.js
+++ b/main.js
@@ -20995,7 +20995,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  mtime comparison short-circuits. */
   /** Persist a content-free, crdt-tagged upsert to the durable queue. Both of
    *  pushFile's channel-down seams must produce an IDENTICAL entry so
-   *  runFlushQueue's noteId-keyed /updates branch delivers them the same way —
+   *  runFlushQueue's socket-converge branch delivers them the same way —
    *  keep the producers in lockstep here rather than duplicating the object
    *  literal, so a new field can't be added to one seam and forgotten on the
    *  other. */

--- a/main.js
+++ b/main.js
@@ -24275,7 +24275,10 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           )));
         };
       } else
-        rlog().info("crdt", "vaultId is null \u2014 CRDT disabled; legacy pushNote path active");
+        rlog().info(
+          "crdt",
+          "vaultId is null \u2014 CRDT disabled; legacy pushNote path active"
+        );
       channel.connect();
     }).catch((e) => {
       console.error("Engram Sync: failed to fetch user id for channel", e), rlog().error("channel", `getMe() failed (attempt ${attempt + 1}): ${errMsg(e)}`), epoch === this.channelEpoch && window.setTimeout(

--- a/main.js
+++ b/main.js
@@ -3535,7 +3535,6 @@ var DEFAULT_SETTINGS = {
   conflictViewMode: "unified",
   diagnosticsEnabled: !1,
   conflictResolution: "auto",
-  enableCrdt: !0,
   vaultId: null,
   clientId: "",
   planState: null,
@@ -17432,23 +17431,31 @@ var _CrdtManager = class _CrdtManager {
     if (cached)
       return await cached.ready, cached;
     let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), text2 = doc2.getText(CONTENT_KEY), ready = persistence.whenSynced.then(() => {
-    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0 };
+    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0, hadContent: !1 };
     return persistence.on("error", (err) => {
       var _a, _b;
       return (_b = (_a = this.opts).onPersistError) == null ? void 0 : _b.call(_a, noteId, err);
     }), doc2.on("update", (update, origin) => {
-      origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
+      text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
     }), doc2.on("update", (_u, origin) => {
-      if (origin !== REMOTE_ORIGIN) return;
+      if (text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN) return;
       entry.remoteSeq += 1;
-      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON(), flush = Promise.resolve(
+      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON();
+      if (body.length === 0 && !entry.hadContent) {
+        rlog().warn(
+          "crdt",
+          `remote-merge flush SKIPPED for ${noteId}: empty body on never-seeded doc (#288 genesis guard)`
+        );
+        return;
+      }
+      let flush = Promise.resolve(
         this.opts.onFlushToDisk(noteId, projectNote(order, values, body, raws))
       );
       this.pendingFlush.set(id2, flush), flush.catch(() => {
       }).finally(() => {
         this.pendingFlush.get(id2) === flush && this.pendingFlush.delete(id2);
       });
-    }), this.docs.set(id2, entry), await ready, entry;
+    }), this.docs.set(id2, entry), await ready, text2.length > 0 && (entry.hadContent = !0), entry;
   }
   /**
    * Returns true when the Y.Text already carries CRDT history (content
@@ -18478,7 +18485,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  exists. Md + size gated exactly like the pre-push enroll (an oversized
    *  doc must never enroll — 8 MB WS frame limit). */
   refireEnrollmentOnFirstConfirm(noteId, path, content) {
-    !noteId || !this.crdtEnrollment || this.isNoteConfirmed(noteId) || path.endsWith(".md") && (new TextEncoder().encode(content).length > MAX_CRDT_NOTE_BYTES || this.isLiveBound((0, import_obsidian21.normalizePath)(path)) && (this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId)));
+    !noteId || !this.crdtEnrollment || this.isNoteConfirmed(noteId) || path.endsWith(".md") && (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) || this.isLiveBound((0, import_obsidian21.normalizePath)(path)) && (this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId)));
   }
   /** Drop a note_id's confirmed status when its server row is deleted, so a
    *  subsequent push of the same id (a rename's new-path push) takes the
@@ -18853,13 +18860,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   /** One-shot capability probe: a pre-Phase-1 backend 404s /vault/heads, so we
    *  latch ops off before the first edit and stay on the legacy whole-doc path. */
   async probeCrdtOps() {
-    if (this.settings.enableCrdt)
-      try {
-        await this.api.getVaultHeads(), this.crdtOpsProbed = !0;
-      } catch (e) {
-        let status = e == null ? void 0 : e.status;
-        (status === 404 || status === 405) && (this.markCrdtOpsUnsupported(status), this.crdtOpsProbed = !0);
-      }
+    try {
+      await this.api.getVaultHeads(), this.crdtOpsProbed = !0;
+    } catch (e) {
+      let status = e == null ? void 0 : e.status;
+      (status === 404 || status === 405) && (this.markCrdtOpsUnsupported(status), this.crdtOpsProbed = !0);
+    }
   }
   setSyncBlocked(blocked) {
     this.syncBlocked = blocked, devLog().log("lifecycle", `setSyncBlocked(${blocked})`);
@@ -19340,9 +19346,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           ), rlog().info(
             "push",
             `CRDT edit queued durably (channel down): ${file.path}`
-          ), !0)) : (file.extension === "md" && new TextEncoder().encode(content).length <= MAX_CRDT_NOTE_BYTES && this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), !0);
+          ), !0)) : (file.extension === "md" && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) && this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), !0);
         }
-        if (this.crdtCreate && this.crdt && noteId && file.extension === "md" && !this.hasServerNote(noteId) && ((_m = (_l = this.crdtLive) == null ? void 0 : _l.call(this)) == null || _m) && new TextEncoder().encode(content).length <= MAX_CRDT_NOTE_BYTES)
+        if (this.crdtCreate && this.crdt && noteId && file.extension === "md" && !this.hasServerNote(noteId) && ((_m = (_l = this.crdtLive) == null ? void 0 : _l.call(this)) == null || _m) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
           try {
             let serverId = await this.crdtCreate(noteId, pushedPath), effectiveId = noteId;
             try {
@@ -20013,7 +20019,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  idle note is still covered by reconnect catch-up (#5). Never throws. */
   async healNoteOnOpen(path) {
     var _a, _b;
-    if (!this.settings.enableCrdt || !this.crdt || !this.crdtOpsAvailable()) return;
+    if (!this.crdt || !this.crdtOpsAvailable()) return;
     let normalized = (0, import_obsidian21.normalizePath)(path), noteId = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(normalized)) != null ? _b : null;
     if (noteId)
       try {
@@ -21013,7 +21019,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     }), pushed > 0 && await this.saveData({ lastSync: this.lastSync }), devLog().log("lifecycle", `fullSync done \u2014 pulled=${pulled} pushed=${pushed}`), rlog().info("lifecycle", `FullSync done \u2014 pulled=${pulled} pushed=${pushed}`), { pulled, pushed };
   }
   crdtOpsAvailable() {
-    return this.settings.enableCrdt === !0 && this.crdtOpsProbed && !this.crdtOpsUnsupported;
+    return this.crdtOpsProbed && !this.crdtOpsUnsupported;
   }
   markCrdtOpsUnsupported(status) {
     (status === 404 || status === 405) && (this.crdtOpsUnsupported = !0);
@@ -21164,7 +21170,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         continue;
       }
       let content = await this.app.vault.read(file);
-      if (new TextEncoder().encode(content).length > MAX_CRDT_NOTE_BYTES) {
+      if (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)) {
         await this.pushFile(file, !0) ? pushed++ : failed++;
         continue;
       }
@@ -24187,7 +24193,8 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         this.settings.apiKey,
         user.id,
         this.settings.vaultId,
-        this.settings.enableCrdt,
+        !0,
+        // CRDT topic join — always on (the enableCrdt setting is gone; false survives only as a test seam)
         this.deviceId
       );
       if (channel.setAuthProbe(() => this.api.getMe()), channel.onEvent = (event) => {
@@ -24213,7 +24220,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         parsed && queueMicrotask(() => this.syncEngine.applyPlanState(parsed));
       }, this.noteStream = channel, this.authProvider && this.noteStream.setAuthProvider(this.authProvider), this.syncEngine.setCrdtCreate((id2, path) => channel.crdtCreate(id2, path)), this.syncEngine.setCrdtCreateBatch((creates) => channel.crdtCreateBatch(creates)), this.syncEngine.setCrdtDelete((id2) => channel.crdtDeleteAcked(id2)), this.syncEngine.setCrdtCatchupSince(
         (cursorSeq, limit) => channel.crdtCatchupSince(cursorSeq, limit)
-      ), this.settings.enableCrdt && this.settings.vaultId) {
+      ), this.settings.vaultId) {
         let dbPrefix = this.settings.vaultId;
         if (typeof indexedDB.databases == "function" ? await ensureDocSchema(dbPrefix, window.localStorage, {
           list: () => indexedDB.databases(),
@@ -24305,10 +24312,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           )));
         };
       } else
-        rlog().info(
-          "crdt",
-          this.settings.enableCrdt ? "vaultId is null \u2014 CRDT disabled; legacy pushNote path active" : "CRDT opt-in disabled \u2014 legacy pushNote path active"
-        );
+        rlog().info("crdt", "vaultId is null \u2014 CRDT disabled; legacy pushNote path active");
       channel.connect();
     }).catch((e) => {
       console.error("Engram Sync: failed to fetch user id for channel", e), rlog().error("channel", `getMe() failed (attempt ${attempt + 1}): ${errMsg(e)}`), epoch === this.channelEpoch && window.setTimeout(

--- a/main.js
+++ b/main.js
@@ -1255,13 +1255,9 @@ var EngramApi = class _EngramApi {
     let encoded = encodePath(path);
     return (await this.request("DELETE", `/notes/${encoded}`)).json;
   }
-  // --- CRDT ops transport: REST /updates DELETED (Phase E3) — the socket
-  // (crdt: channel sv-exchange) is the only Yjs delta path. ---
-  /** Capability probe + convergence check: current head per note across the
-   *  whole vault. */
-  async getVaultHeads() {
-    return { heads: (await this.request("GET", "/vault/heads")).json.heads };
-  }
+  // --- CRDT ops transport: fully socket-native — REST /updates deleted in
+  // Phase E3, the /vault/heads capability probe deleted with the pre-CRDT
+  // backend floor. The crdt: channel is the only Yjs path. ---
   // --- Attachment methods ---
   /** Push a binary attachment as base64. */
   async pushAttachment(path, contentBase64, mimeType, mtime) {
@@ -18307,21 +18303,6 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  two genuinely different relocations for the same id within one second
      *  can tie exactly. A tie can't be proven newer, so it must not win. */
     this.lastRelocationTs = /* @__PURE__ */ new Map();
-    /** Push all files that have been modified since last sync, plus any
-     *  syncable file that the engine has never seen (no syncState entry).
-     *  The untracked branch covers the first-sync case and the post
-     *  vault-change case where we cleared sync state — neither would
-     *  otherwise touch the push path because lastSync is empty and the
-     *  mtime comparison short-circuits. */
-    // Version gate: latched OFF the first time an /updates call 404/405s (a
-    // pre-Phase-1 backend). While off, CRDT notes fall back to the whole-doc
-    // base_hash push, exactly as before this feature.
-    this.crdtOpsUnsupported = !1;
-    // Capability comes SOLELY from the probe (Phase 2b remediation): ops are
-    // treated unavailable until getVaultHeads has actually confirmed them, so
-    // a channel-down edit that races the probe takes the durable legacy path
-    // instead of assuming ops work.
-    this.crdtOpsProbed = !1;
     this.parseIgnorePatterns();
   }
   setCrdtManager(mgr) {
@@ -18855,17 +18836,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   /** Mark the engine as ready to handle vault events.
    *  Called after layout is ready and initial sync completes. */
   setReady() {
-    this.ready = !0, devLog().log("lifecycle", "setReady \u2014 event handlers enabled"), rlog().info("lifecycle", "Engine ready \u2014 event handlers enabled"), this.probeCrdtOps();
-  }
-  /** One-shot capability probe: a pre-Phase-1 backend 404s /vault/heads, so we
-   *  latch ops off before the first edit and stay on the legacy whole-doc path. */
-  async probeCrdtOps() {
-    try {
-      await this.api.getVaultHeads(), this.crdtOpsProbed = !0;
-    } catch (e) {
-      let status = e == null ? void 0 : e.status;
-      (status === 404 || status === 405) && (this.markCrdtOpsUnsupported(status), this.crdtOpsProbed = !0);
-    }
+    this.ready = !0, devLog().log("lifecycle", "setReady \u2014 event handlers enabled"), rlog().info("lifecycle", "Engine ready \u2014 event handlers enabled");
   }
   setSyncBlocked(blocked) {
     this.syncBlocked = blocked, devLog().log("lifecycle", `setSyncBlocked(${blocked})`);
@@ -19266,7 +19237,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  pushModifiedFiles) pass force without this, so they stay quiet on
    *  plan-gated attachments. */
   async pushFile(file, force = !1, bypassPlanSkip = !1) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w;
     if (this.pushing.has(file.path)) return !1;
     if (!bypassPlanSkip && this.isBinaryFile(file) && this.hasInformationalIssue(file.path))
       return devLog().log("push", `skip (plan-informational): ${file.path}`), !1;
@@ -19319,12 +19290,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             ), !1;
           noteId = uuid7(), this.noteIdMap.set(file.path, noteId);
         }
-        file.extension === "md" && rlog().info(
+        if (file.extension === "md" && rlog().info(
           "push",
           `route: ${file.path} crdt=${!!this.crdt} server=${this.hasServerNote(noteId)} confirmed=${noteId ? this.isNoteConfirmed(noteId) : !1} live=${(_e = (_d = this.crdtLive) == null ? void 0 : _d.call(this)) != null ? _e : !0} id=${noteId != null ? noteId : "none"}`
-        );
-        let crdtLive = (_g = (_f = this.crdtLive) == null ? void 0 : _f.call(this)) != null ? _g : !0;
-        if (this.crdt && noteId && this.hasServerNote(noteId) && (crdtLive || this.crdtOpsAvailable())) {
+        ), this.crdt && noteId && this.hasServerNote(noteId)) {
           let consumed = await routeModify(
             {
               isMarkdown: file.extension === "md",
@@ -19340,21 +19309,21 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           return consumed !== null ? (this.syncState.set((0, import_obsidian21.normalizePath)(file.path), {
             ...existing,
             hash: fnv1a(consumed)
-          }), this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_h = this.crdtEnrollment) == null || _h.enroll(noteId)), success = !0, ((_j = (_i = this.crdtLive) == null ? void 0 : _i.call(this)) != null ? _j : !0) ? (devLog().log("push", `crdt ok: ${file.path}`), rlog().info("push", `CRDT push ok: ${file.path}`), !0) : (await this.enqueueCrdtEdit(file, noteId), this.flushQueue(), devLog().log(
+          }), this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_f = this.crdtEnrollment) == null || _f.enroll(noteId)), success = !0, ((_h = (_g = this.crdtLive) == null ? void 0 : _g.call(this)) != null ? _h : !0) ? (devLog().log("push", `crdt ok: ${file.path}`), rlog().info("push", `CRDT push ok: ${file.path}`), !0) : (await this.enqueueCrdtEdit(file, noteId), this.flushQueue(), devLog().log(
             "push",
             `crdt edit queued durably (channel down): ${file.path}`
           ), rlog().info(
             "push",
             `CRDT edit queued durably (channel down): ${file.path}`
-          ), !0)) : (file.extension === "md" && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) && this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), !0);
+          ), !0)) : (file.extension === "md" && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) && this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_i = this.crdtEnrollment) == null || _i.enroll(noteId)), !0);
         }
-        if (this.crdtCreate && this.crdt && noteId && file.extension === "md" && !this.hasServerNote(noteId) && ((_m = (_l = this.crdtLive) == null ? void 0 : _l.call(this)) == null || _m) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
+        if (this.crdtCreate && this.crdt && noteId && file.extension === "md" && !this.hasServerNote(noteId) && ((_k = (_j = this.crdtLive) == null ? void 0 : _j.call(this)) == null || _k) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
           try {
             let serverId = await this.crdtCreate(noteId, pushedPath), effectiveId = noteId;
             try {
               let consumed;
               if (serverId && serverId !== noteId && this.crdtEditorRebind && this.isLiveBound((0, import_obsidian21.normalizePath)(pushedPath))) {
-                (_n = this.noteIdMap) == null || _n.set((0, import_obsidian21.normalizePath)(pushedPath), serverId), effectiveId = serverId;
+                (_l = this.noteIdMap) == null || _l.set((0, import_obsidian21.normalizePath)(pushedPath), serverId), effectiveId = serverId;
                 let mintText = await this.crdt.projectedText(noteId), serverHadContent = typeof this.crdt.hasHistory == "function" && await this.crdt.hasHistory(serverId);
                 consumed = await this.crdt.applyLocalEdit(serverId, mintText), mintText.length > 0 && serverHadContent && rlog().warn(
                   "crdt",
@@ -19362,9 +19331,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
                 ), rlog().info(
                   "crdt",
                   `crdt_create ADOPT: remapped + rebound live editor ${pushedPath} ${noteId} -> ${serverId}`
-                ), this.crdtEditorRebind(pushedPath), await this.crdt.removeDoc(noteId), (_o = this.crdtEnrollment) == null || _o.reset(noteId);
+                ), this.crdtEditorRebind(pushedPath), await this.crdt.removeDoc(noteId), (_m = this.crdtEnrollment) == null || _m.reset(noteId);
               } else
-                serverId && serverId !== noteId && ((_p = this.noteIdMap) == null || _p.set((0, import_obsidian21.normalizePath)(pushedPath), serverId), rlog().info(
+                serverId && serverId !== noteId && ((_n = this.noteIdMap) == null || _n.set((0, import_obsidian21.normalizePath)(pushedPath), serverId), rlog().info(
                   "crdt",
                   `crdt_create ADOPT: remapped ${pushedPath} ${noteId} -> ${serverId}`
                 ), effectiveId = serverId), consumed = await routeModify(
@@ -19383,7 +19352,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               }) : rlog().warn(
                 "crdt",
                 `crdt_create ok but body seed declined (will deliver on next edit): ${pushedPath}`
-              ), this.isLiveBound((0, import_obsidian21.normalizePath)(pushedPath)) && ((_q = this.crdtEnrollment) == null || _q.enroll(effectiveId)), devLog().log(
+              ), this.isLiveBound((0, import_obsidian21.normalizePath)(pushedPath)) && ((_o = this.crdtEnrollment) == null || _o.enroll(effectiveId)), devLog().log(
                 "push",
                 `crdt_create ok: ${pushedPath} (id=${effectiveId})`
               ), rlog().info(
@@ -19417,11 +19386,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           let localFile = this.app.vault.getFileByPath(pushedPath);
           localFile && (await this.app.vault.rename(localFile, serverPath), new import_obsidian21.Notice(
             `Engram Sync: renamed "${pushedPath.split("/").pop()}" (unsupported characters)`
-          )), this.syncState.delete((0, import_obsidian21.normalizePath)(pushedPath)), this.syncState.set((0, import_obsidian21.normalizePath)(serverPath), { hash }), (_r = this.noteIdMap) == null || _r.delete((0, import_obsidian21.normalizePath)(pushedPath)), (_s = this.noteIdMap) == null || _s.set((0, import_obsidian21.normalizePath)(serverPath), resp.note.id);
+          )), this.syncState.delete((0, import_obsidian21.normalizePath)(pushedPath)), this.syncState.set((0, import_obsidian21.normalizePath)(serverPath), { hash }), (_p = this.noteIdMap) == null || _p.delete((0, import_obsidian21.normalizePath)(pushedPath)), (_q = this.noteIdMap) == null || _q.set((0, import_obsidian21.normalizePath)(serverPath), resp.note.id);
         } else
-          this.syncState.set((0, import_obsidian21.normalizePath)(file.path), { hash }), (_t2 = this.noteIdMap) == null || _t2.set((0, import_obsidian21.normalizePath)(file.path), resp.note.id);
+          this.syncState.set((0, import_obsidian21.normalizePath)(file.path), { hash }), (_r = this.noteIdMap) == null || _r.set((0, import_obsidian21.normalizePath)(file.path), resp.note.id);
         file.path === pushedPath && (pushedNoteParse = {
-          path: (_u = resp.note.path) != null ? _u : pushedPath,
+          path: (_s = resp.note.path) != null ? _s : pushedPath,
           parseStatus: resp.note.parse_status,
           parseReason: resp.note.parse_reason
         });
@@ -19450,8 +19419,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         lastFailedAt: now,
         attempts: 1
       });
-      let attempts = (_w = (_v = this.issues.get(file.path)) == null ? void 0 : _v.attempts) != null ? _w : 1;
-      issueDisposition(classified.category) === "informational" ? this.attachmentLimitedThisBatch += 1 : (this.failuresThisBatch += 1, (_x = this.firstFailureMessageThisBatch) != null || (this.firstFailureMessageThisBatch = classified.message)), devLog().log("error", `push failed: ${file.path} \u2014 ${msg} (${classified.category})`), rlog().error(
+      let attempts = (_u = (_t2 = this.issues.get(file.path)) == null ? void 0 : _t2.attempts) != null ? _u : 1;
+      issueDisposition(classified.category) === "informational" ? this.attachmentLimitedThisBatch += 1 : (this.failuresThisBatch += 1, (_v = this.firstFailureMessageThisBatch) != null || (this.firstFailureMessageThisBatch = classified.message)), devLog().log("error", `push failed: ${file.path} \u2014 ${msg} (${classified.category})`), rlog().error(
         "push",
         `Push failed: ${file.path} \u2014 ${msg} | category=${classified.category}`,
         e instanceof Error ? e.stack : void 0
@@ -19461,7 +19430,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         kind: isBinary ? "attachment" : "note",
         mtime: file.stat.mtime / 1e3,
         timestamp: Date.now(),
-        vaultId: (_y = this.settings.vaultId) != null ? _y : void 0
+        vaultId: (_w = this.settings.vaultId) != null ? _w : void 0
       }), this.maybeGoOffline(e);
     } finally {
       this.pushing.delete(pushedPath), this.releasePushSlot(), success && this.markRecentlyPushed(pushedPath), this.emitStatus();
@@ -20019,7 +19988,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  idle note is still covered by reconnect catch-up (#5). Never throws. */
   async healNoteOnOpen(path) {
     var _a, _b;
-    if (!this.crdt || !this.crdtOpsAvailable()) return;
+    if (!this.crdt) return;
     let normalized = (0, import_obsidian21.normalizePath)(path), noteId = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(normalized)) != null ? _b : null;
     if (noteId)
       try {
@@ -21018,12 +20987,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       skipped: this.lastBatchSkipped
     }), pushed > 0 && await this.saveData({ lastSync: this.lastSync }), devLog().log("lifecycle", `fullSync done \u2014 pulled=${pulled} pushed=${pushed}`), rlog().info("lifecycle", `FullSync done \u2014 pulled=${pulled} pushed=${pushed}`), { pulled, pushed };
   }
-  crdtOpsAvailable() {
-    return this.crdtOpsProbed && !this.crdtOpsUnsupported;
-  }
-  markCrdtOpsUnsupported(status) {
-    (status === 404 || status === 405) && (this.crdtOpsUnsupported = !0);
-  }
+  /** Push all files that have been modified since last sync, plus any
+   *  syncable file that the engine has never seen (no syncState entry).
+   *  The untracked branch covers the first-sync case and the post
+   *  vault-change case where we cleared sync state — neither would
+   *  otherwise touch the push path because lastSync is empty and the
+   *  mtime comparison short-circuits. */
   /** Persist a content-free, crdt-tagged upsert to the durable queue. Both of
    *  pushFile's channel-down seams must produce an IDENTICAL entry so
    *  runFlushQueue's noteId-keyed /updates branch delivers them the same way —
@@ -21714,16 +21683,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           }
           await this.api.pushAttachment(entry.path, base64, mimeType, mtime);
         } else {
-          if (entry.crdt && entry.noteId && this.crdt && this.crdtOpsAvailable()) {
-            (_d = (_c = this.crdtLive) == null ? void 0 : _c.call(this)) != null && _d && (this.pendingQueueDeliveries.set(entry.noteId, {
+          if (entry.crdt && entry.noteId) {
+            this.crdt && ((_d = (_c = this.crdtLive) == null ? void 0 : _c.call(this)) != null && _d) && (this.pendingQueueDeliveries.set(entry.noteId, {
               path: entry.path,
               vaultId: (_f = (_e = entry.vaultId) != null ? _e : this.settings.vaultId) != null ? _f : void 0
             }), this.socketConverge((0, import_obsidian21.normalizePath)(entry.path), entry.noteId));
             continue;
-          }
-          if (entry.crdt && !this.crdtOpsAvailable()) {
-            let key = (0, import_obsidian21.normalizePath)(entry.path), existing = this.syncState.get(key);
-            (existing == null ? void 0 : existing.serverHash) !== void 0 && this.syncState.set(key, { ...existing, serverHash: void 0 });
           }
           let content = entry.content, mtime = entry.mtime;
           if (content === void 0) {

--- a/main.js
+++ b/main.js
@@ -23849,7 +23849,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     this.settings = Object.assign({}, DEFAULT_SETTINGS, data == null ? void 0 : data.settings);
     let rawSettings = data == null ? void 0 : data.settings;
     this.settings.diagnosticsEnabled = migrateDiagnosticsEnabled(rawSettings);
-    for (let legacy of ["remoteLoggingEnabled", "diagnosticMode", "tracingEnabled"])
+    for (let legacy of [
+      "remoteLoggingEnabled",
+      "diagnosticMode",
+      "tracingEnabled",
+      "enableCrdt"
+    ])
       delete this.settings[legacy];
     this.syncGateAcceptedFor = (_a = data == null ? void 0 : data.syncGateAcceptedFor) != null ? _a : null, this.noteIdMap = NoteIdMap.fromJSON(data == null ? void 0 : data.noteIds);
     let dirty = !1, migratedUrl = migrateCloudApiUrl(this.settings.apiUrl, ENGRAM_CLOUD_URL);

--- a/src/api.ts
+++ b/src/api.ts
@@ -506,15 +506,9 @@ export class EngramApi {
 		return resp.json as DeleteResponse;
 	}
 
-	// --- CRDT ops transport: REST /updates DELETED (Phase E3) — the socket
-	// (crdt: channel sv-exchange) is the only Yjs delta path. ---
-
-	/** Capability probe + convergence check: current head per note across the
-	 *  whole vault. */
-	async getVaultHeads(): Promise<{ heads: Record<string, string> }> {
-		const resp = await this.request("GET", "/vault/heads");
-		return { heads: (resp.json as { heads: Record<string, string> }).heads };
-	}
+	// --- CRDT ops transport: fully socket-native — REST /updates deleted in
+	// Phase E3, the /vault/heads capability probe deleted with the pre-CRDT
+	// backend floor. The crdt: channel is the only Yjs path. ---
 
 	// --- Attachment methods ---
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -240,6 +240,9 @@ export class NoteChannel {
 		apiKey: string,
 		userId: string,
 		vaultId: string | null = null,
+		// Production always passes true (the enableCrdt SETTING was removed —
+		// CRDT is the sole md path). The param survives as a test seam: protocol
+		// tests pass false to isolate the note-topic frames from the crdt join.
 		enableCrdt = false,
 		deviceId: string | null = null,
 	) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -179,9 +179,6 @@ export class NoteChannel {
 	private deviceId: string | null;
 	/** Current connection id, minted fresh per physical socket. */
 	private connId: string | null = null;
-	/** Opt-in gate for the `crdt:` topic. When false the channel never joins the
-	 *  CRDT topic and behaves exactly like a non-CRDT build (legacy path only). */
-	private readonly enableCrdt: boolean;
 	private authProvider: AuthProvider | null = null;
 	/** Authenticated probe injected via `setAuthProbe` (e.g. GET /me). Fired on
 	 *  a fast pre-open close instead of guessing the token is stale. */
@@ -240,17 +237,12 @@ export class NoteChannel {
 		apiKey: string,
 		userId: string,
 		vaultId: string | null = null,
-		// Production always passes true (the enableCrdt SETTING was removed —
-		// CRDT is the sole md path). The param survives as a test seam: protocol
-		// tests pass false to isolate the note-topic frames from the crdt join.
-		enableCrdt = false,
 		deviceId: string | null = null,
 	) {
 		this.baseUrl = baseUrl.replace(/\/+$/, "").replace(/\/api$/, "");
 		this.apiKey = apiKey;
 		this.userId = userId;
 		this.vaultId = vaultId;
-		this.enableCrdt = enableCrdt;
 		this.deviceId = deviceId;
 		rlog().info(
 			"channel",
@@ -310,10 +302,7 @@ export class NoteChannel {
 	}
 
 	private get crdtTopic(): string | null {
-		// Gated on the opt-in flag: when CRDT is disabled the topic is null, so the
-		// channel never joins `crdt:`, never sends frames, and never surfaces an
-		// onCrdtJoined — identical to a non-CRDT build.
-		if (!this.enableCrdt) return null;
+		// Vault-scoped only: no vault bound yet → no crdt: room to join.
 		return this.vaultId ? `crdt:${this.userId}:${this.vaultId}` : null;
 	}
 

--- a/src/crdt/schema.ts
+++ b/src/crdt/schema.ts
@@ -72,30 +72,6 @@ export async function ensureDocSchema(
 	return true;
 }
 
-/**
- * Wire into main.ts before constructing CrdtManager:
- *
- * ```typescript
- * if (this.settings.enableCrdt && this.settings.vaultId) {
- *   const dbPrefix = this.settings.vaultId;
- *   if (typeof indexedDB.databases === "function") {
- *     await ensureDocSchema(dbPrefix, window.localStorage, {
- *       list: () => indexedDB.databases(),
- *       drop: (name) =>
- *         new Promise<void>((resolve) => {
- *           const req = indexedDB.deleteDatabase(name);
- *           req.onsuccess = req.onerror = req.onblocked = () => resolve();
- *         }),
- *     });
- *   } else {
- *     rlog().warn(
- *       "crdt",
- *       "indexedDB.databases() not available — skipping v1 schema wipe"
- *     );
- *   }
- *   this.crdtManager = new CrdtManager({
- *     // ...
- *   });
- * }
- * ```
- */
+// Wired in main.ts (connectChannel) before constructing CrdtManager — see the
+// ensureDocSchema call there for the real adapter. (A full code sample lived
+// here once and drifted from the real wiring; the call site is the reference.)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1733,7 +1733,7 @@ export default class EngramSyncPlugin extends Plugin {
 					this.settings.apiKey,
 					user.id,
 					this.settings.vaultId,
-					this.settings.enableCrdt,
+					true, // CRDT topic join — always on (the enableCrdt setting is gone; false survives only as a test seam)
 					this.deviceId,
 				);
 				channel.setAuthProbe(() => this.api.getMe());
@@ -1841,8 +1841,8 @@ export default class EngramSyncPlugin extends Plugin {
 
 				// Plan B1 Task 6: wire the socket-native create/delete/catchup senders
 				// into the engine. Harmless to wire unconditionally — each sender is
-				// only consulted once the engine's own crdt manager is set (enableCrdt
-				// && vaultId), so this is a no-op on a legacy/non-CRDT connection.
+				// only consulted once the engine's own crdt manager is set (vaultId
+				// bound), so this is a no-op on a legacy/non-CRDT connection.
 				this.syncEngine.setCrdtCreate((id, path) => channel.crdtCreate(id, path));
 				this.syncEngine.setCrdtCreateBatch((creates) => channel.crdtCreateBatch(creates));
 				// Direct AWAITED delete for handleRename's ordered tombstone->resurrect
@@ -1870,7 +1870,7 @@ export default class EngramSyncPlugin extends Plugin {
 				// server acknowledges the `crdt:` topic join. Against a non-CRDT
 				// backend the join errors out, onCrdtJoined never fires, and the
 				// SyncEngine's `this.crdt` stays null → legacy pushNote path active.
-				if (this.settings.enableCrdt && this.settings.vaultId) {
+				if (this.settings.vaultId) {
 					const dbPrefix = this.settings.vaultId;
 					// One-time schema upgrade: wipe v1 CRDT stores if needed.
 					if (typeof indexedDB.databases === "function") {
@@ -2037,12 +2037,7 @@ export default class EngramSyncPlugin extends Plugin {
 						}
 					};
 				} else {
-					rlog().info(
-						"crdt",
-						this.settings.enableCrdt
-							? "vaultId is null — CRDT disabled; legacy pushNote path active"
-							: "CRDT opt-in disabled — legacy pushNote path active",
-					);
+					rlog().info("crdt", "vaultId is null — CRDT disabled; legacy pushNote path active");
 				}
 
 				void channel.connect();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2036,7 +2036,10 @@ export default class EngramSyncPlugin extends Plugin {
 						}
 					};
 				} else {
-					rlog().info("crdt", "vaultId is null — CRDT disabled; legacy pushNote path active");
+					rlog().info(
+						"crdt",
+						"vaultId is null — CRDT disabled; legacy pushNote path active",
+					);
 				}
 
 				void channel.connect();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1079,7 +1079,14 @@ export default class EngramSyncPlugin extends Plugin {
 		// then drop the stale keys so the next save persists only the new shape.
 		const rawSettings = data?.settings as Record<string, unknown> | undefined;
 		this.settings.diagnosticsEnabled = migrateDiagnosticsEnabled(rawSettings);
-		for (const legacy of ["remoteLoggingEnabled", "diagnosticMode", "tracingEnabled"]) {
+		// enableCrdt: the setting was deleted (CRDT is the sole md path) — drop
+		// the stale key from persisted data.json on next save.
+		for (const legacy of [
+			"remoteLoggingEnabled",
+			"diagnosticMode",
+			"tracingEnabled",
+			"enableCrdt",
+		]) {
 			delete (this.settings as unknown as Record<string, unknown>)[legacy];
 		}
 		this.syncGateAcceptedFor = data?.syncGateAcceptedFor ?? null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1733,7 +1733,6 @@ export default class EngramSyncPlugin extends Plugin {
 					this.settings.apiKey,
 					user.id,
 					this.settings.vaultId,
-					true, // CRDT topic join — always on (the enableCrdt setting is gone; false survives only as a test seam)
 					this.deviceId,
 				);
 				channel.setAuthProbe(() => this.api.getMe());

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -6008,7 +6008,7 @@ export class SyncEngine {
 	 *  mtime comparison short-circuits. */
 	/** Persist a content-free, crdt-tagged upsert to the durable queue. Both of
 	 *  pushFile's channel-down seams must produce an IDENTICAL entry so
-	 *  runFlushQueue's noteId-keyed /updates branch delivers them the same way —
+	 *  runFlushQueue's socket-converge branch delivers them the same way —
 	 *  keep the producers in lockstep here rather than duplicating the object
 	 *  literal, so a new field can't be added to one seam and forgotten on the
 	 *  other. */

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1526,33 +1526,6 @@ export class SyncEngine {
 		this.ready = true;
 		devLog().log("lifecycle", "setReady — event handlers enabled");
 		rlog().info("lifecycle", "Engine ready — event handlers enabled");
-		// One-shot capability probe: latch ops off before the first edit if this
-		// is a pre-Phase-1 backend, so we stay on the legacy whole-doc path
-		// instead of 404ing on the first CRDT flush.
-		void this.probeCrdtOps();
-	}
-
-	/** One-shot capability probe: a pre-Phase-1 backend 404s /vault/heads, so we
-	 *  latch ops off before the first edit and stay on the legacy whole-doc path. */
-	async probeCrdtOps(): Promise<void> {
-		try {
-			await this.api.getVaultHeads();
-			// Conclusive: the route answered, ops are supported.
-			this.crdtOpsProbed = true;
-		} catch (e) {
-			const status = (e as { status?: number })?.status;
-			// Only a definitive 404/405 conclusively proves the route is absent.
-			// Any other failure (5xx, or a status-less network error) is
-			// INCONCLUSIVE: leaving crdtOpsProbed=false keeps ops unavailable this
-			// session so channel-down edits take the legacy whole-doc path. Marking
-			// probed here would make a later /updates 404 (against a route-less
-			// backend) look like "note gone" in runFlushQueue and silently drop the
-			// edit.
-			if (status === 404 || status === 405) {
-				this.markCrdtOpsUnsupported(status);
-				this.crdtOpsProbed = true;
-			}
-		}
 	}
 
 	setSyncBlocked(blocked: boolean): void {
@@ -2487,27 +2460,14 @@ export class SyncEngine {
 				// noteId) — no full-document POST, no version field, no base_hash.
 				// When the channel is NOT joined (crdtLive() false — a stale manager
 				// latch, e.g. dead-but-set after an auth swap, or a genuine
-				// disconnect) but the backend supports CRDT ops
-				// (crdtOpsAvailable()), the edit is still durable in the local
-				// Y.Doc — persist a durable crdt-tagged queue entry (delivered by
-				// runFlushQueue's noteId-keyed /updates branch) instead of falling
+				// disconnect), the edit is still durable in the local Y.Doc —
+				// persist a durable crdt-tagged queue entry (delivered by
+				// runFlushQueue's socket-converge branch) instead of falling
 				// through to the whole-doc base_hash push (#203, e2e test_83/test_85).
-				// Only when ops are unsupported (pre-Phase-1 backend) does a down
-				// channel fall through to the legacy REST path, exactly as before
-				// this feature.
-				//
-				// `crdtLive` here is a PRE-AWAIT snapshot, used ONLY to decide
-				// whether this branch is even entered (below). It can go stale
-				// during the awaited `routeModify` seed if the channel drops
-				// mid-seed — see the post-await `crdtLiveNow` re-check (Task 5)
-				// that actually decides live-vs-durable-queue.
-				const crdtLive = this.crdtLive?.() ?? true;
-				if (
-					this.crdt &&
-					noteId &&
-					this.hasServerNote(noteId) &&
-					(crdtLive || this.crdtOpsAvailable())
-				) {
+				// Live-vs-durable-queue is decided by the post-await `crdtLiveNow`
+				// re-check below (Task 5) — the channel can drop during the awaited
+				// `routeModify` seed.
+				if (this.crdt && noteId && this.hasServerNote(noteId)) {
 					const consumed = await routeModify(
 						{
 							isMarkdown: file.extension === "md",
@@ -3877,7 +3837,7 @@ export class SyncEngine {
 	 *  covers the real case without a vault-wide heads fetch on every open; an
 	 *  idle note is still covered by reconnect catch-up (#5). Never throws. */
 	async healNoteOnOpen(path: string): Promise<void> {
-		if (!this.crdt || !this.crdtOpsAvailable()) return;
+		if (!this.crdt) return;
 		const normalized = normalizePath(path);
 		const noteId = this.noteIdMap?.get(normalized) ?? null;
 		if (!noteId) return; // truly unknown — reconnect catch-up discovers it (#5)
@@ -6046,27 +6006,6 @@ export class SyncEngine {
 	 *  vault-change case where we cleared sync state — neither would
 	 *  otherwise touch the push path because lastSync is empty and the
 	 *  mtime comparison short-circuits. */
-	// Version gate: latched OFF the first time an /updates call 404/405s (a
-	// pre-Phase-1 backend). While off, CRDT notes fall back to the whole-doc
-	// base_hash push, exactly as before this feature.
-	private crdtOpsUnsupported = false;
-
-	// Capability comes SOLELY from the probe (Phase 2b remediation): ops are
-	// treated unavailable until getVaultHeads has actually confirmed them, so
-	// a channel-down edit that races the probe takes the durable legacy path
-	// instead of assuming ops work.
-	private crdtOpsProbed = false;
-
-	private crdtOpsAvailable(): boolean {
-		return this.crdtOpsProbed && !this.crdtOpsUnsupported;
-	}
-
-	private markCrdtOpsUnsupported(status: number): void {
-		if (status === 404 || status === 405) {
-			this.crdtOpsUnsupported = true;
-		}
-	}
-
 	/** Persist a content-free, crdt-tagged upsert to the durable queue. Both of
 	 *  pushFile's channel-down seams must produce an IDENTICAL entry so
 	 *  runFlushQueue's noteId-keyed /updates branch delivers them the same way —
@@ -7258,8 +7197,14 @@ export class SyncEngine {
 					// no delivery path at all: leave the entry queued (not a
 					// failure, no retry-count bump) until a later flush finds the
 					// channel up.
-					if (entry.crdt && entry.noteId && this.crdt && this.crdtOpsAvailable()) {
-						if (this.crdtLive?.() ?? false) {
+					if (entry.crdt && entry.noteId) {
+						// The socket is the ONLY delivery path for a crdt entry — the
+						// edit lives durably in the Y.Doc, so a whole-doc REST replay
+						// could only stomp newer server state. Channel live → converge
+						// now; down → leave the entry queued until a later flush finds
+						// it up. (A noteId-less crdt entry — ancient plugin versions —
+						// still falls through to the one-shot content replay below.)
+						if (this.crdt && (this.crdtLive?.() ?? false)) {
 							this.pendingQueueDeliveries.set(entry.noteId, {
 								path: entry.path,
 								vaultId: entry.vaultId ?? this.settings.vaultId ?? undefined,
@@ -7267,19 +7212,6 @@ export class SyncEngine {
 							this.socketConverge(normalizePath(entry.path), entry.noteId);
 						}
 						continue;
-					}
-
-					if (entry.crdt && !this.crdtOpsAvailable()) {
-						// Ops unavailable (old backend / probe latched off): fall
-						// through to the legacy whole-doc push below. Clear the stale
-						// serverHash first — prior CRDT-ops flushes advanced the
-						// server body without recording a new serverHash, so the old
-						// CAS base would 409. A no-base push overwrites deliberately.
-						const key = normalizePath(entry.path);
-						const existing = this.syncState.get(key);
-						if (existing?.serverHash !== undefined) {
-							this.syncState.set(key, { ...existing, serverHash: undefined });
-						}
 					}
 
 					// Note upsert — legacy entries have content; new entries are content-free

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -826,7 +826,7 @@ export class SyncEngine {
 		if (!noteId || !this.crdtEnrollment) return;
 		if (this.isNoteConfirmed(noteId)) return; // not a create — already live
 		if (!path.endsWith(".md")) return;
-		if (new TextEncoder().encode(content).length > MAX_CRDT_NOTE_BYTES) return;
+		if (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)) return;
 		// Vault-channel fan-out: a cold (not-open-in-editor) send stays room-free —
 		// its edits ship over /updates and it RECEIVES future updates over the
 		// note_yjs_update broadcast, no room needed. Enroll (STEP1) only for a
@@ -1535,7 +1535,6 @@ export class SyncEngine {
 	/** One-shot capability probe: a pre-Phase-1 backend 404s /vault/heads, so we
 	 *  latch ops off before the first edit and stay on the legacy whole-doc path. */
 	async probeCrdtOps(): Promise<void> {
-		if (!this.settings.enableCrdt) return;
 		try {
 			await this.api.getVaultHeads();
 			// Conclusive: the route answered, ops are supported.
@@ -2598,7 +2597,7 @@ export class SyncEngine {
 					// gone); acceptable because the gate makes this path unreachable.
 					if (
 						file.extension === "md" &&
-						new TextEncoder().encode(content).length <= MAX_CRDT_NOTE_BYTES &&
+						!exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) &&
 						this.isLiveBound(normalizePath(file.path))
 					) {
 						this.crdtEnrollment?.enroll(noteId);
@@ -2627,7 +2626,7 @@ export class SyncEngine {
 					file.extension === "md" &&
 					!this.hasServerNote(noteId) &&
 					(this.crdtLive?.() ?? true) &&
-					new TextEncoder().encode(content).length <= MAX_CRDT_NOTE_BYTES
+					!exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)
 				) {
 					try {
 						// Only the crdtCreate call itself is covered by this catch — once
@@ -3047,12 +3046,12 @@ export class SyncEngine {
 
 	/** Test hook: how many attachments were marked needs_pro since the last
 	 *  flush. Drained when the toast fires. */
-	getAttachmentLimitedCount(): number {
+	private getAttachmentLimitedCount(): number {
 		return this.attachmentLimitedThisBatch;
 	}
 
 	/** Test hook: whether the session has already shown the batched toast. */
-	hasShownAttachmentLimitToast(): boolean {
+	private hasShownAttachmentLimitToast(): boolean {
 		return this.attachmentLimitToastShown;
 	}
 
@@ -3131,7 +3130,7 @@ export class SyncEngine {
 	}
 
 	/** Check if a path was recently pushed (for echo suppression). */
-	isRecentlyPushed(path: string): boolean {
+	private isRecentlyPushed(path: string): boolean {
 		return this.recentlyPushed.has(path);
 	}
 
@@ -3878,7 +3877,7 @@ export class SyncEngine {
 	 *  covers the real case without a vault-wide heads fetch on every open; an
 	 *  idle note is still covered by reconnect catch-up (#5). Never throws. */
 	async healNoteOnOpen(path: string): Promise<void> {
-		if (!this.settings.enableCrdt || !this.crdt || !this.crdtOpsAvailable()) return;
+		if (!this.crdt || !this.crdtOpsAvailable()) return;
 		const normalized = normalizePath(path);
 		const noteId = this.noteIdMap?.get(normalized) ?? null;
 		if (!noteId) return; // truly unknown — reconnect catch-up discovers it (#5)
@@ -6059,7 +6058,7 @@ export class SyncEngine {
 	private crdtOpsProbed = false;
 
 	private crdtOpsAvailable(): boolean {
-		return this.settings.enableCrdt === true && this.crdtOpsProbed && !this.crdtOpsUnsupported;
+		return this.crdtOpsProbed && !this.crdtOpsUnsupported;
 	}
 
 	private markCrdtOpsUnsupported(status: number): void {
@@ -6296,7 +6295,7 @@ export class SyncEngine {
 			// L739, sync.ts L2475/L2504/L2680), leaving a server-held CRDT room
 			// that the client's own edits then bypass via legacy REST: split-brain.
 			// Gate on content BEFORE minting/encoding so it never gets a doc_id.
-			if (new TextEncoder().encode(content).length > MAX_CRDT_NOTE_BYTES) {
+			if (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)) {
 				if (await this.pushFile(file, true)) pushed++;
 				else failed++;
 				continue;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,6 @@ export interface EngramSyncSettings {
 	 *  "auto" creates a conflict copy file (non-blocking).
 	 *  "modal" shows the interactive diff modal. */
 	conflictResolution: "auto" | "modal";
-	/** Opt-in to CRDT (Yjs) file sync. OFF by default: v1 CRDT is not yet a
-	 *  drop-in replacement for the legacy push/pull path (it changes offline-queue,
-	 *  versioning, and conflict-file semantics), so it ships dormant. When false the
-	 *  plugin never joins the `crdt:` topic and routes every save through the legacy
-	 *  path — behaving exactly like a non-CRDT build. */
-	enableCrdt: boolean;
 	/** Server-assigned vault ID. Populated after registration. Null until first sync. */
 	vaultId: string | null;
 	/** Server-side name for the selected vault, mirrored from the registration
@@ -67,14 +61,6 @@ export interface EngramSyncSettings {
 /** Which search backend the panel uses. */
 export type SearchMode = "semantic" | "keyword" | "hybrid";
 
-/** Metadata for a CRDT-managed note doc. */
-export interface CrdtDocMeta {
-	/** Vault-scoped doc id used for the IndexedDB store name and the channel topic key. */
-	docId: string;
-	/** Vault path (key the SyncEngine uses). */
-	path: string;
-}
-
 /** A normalized, note-level search result shared across all modes. */
 export interface UnifiedSearchResult {
 	source_path: string;
@@ -96,7 +82,6 @@ export const DEFAULT_SETTINGS: EngramSyncSettings = {
 	conflictViewMode: "unified",
 	diagnosticsEnabled: false,
 	conflictResolution: "auto",
-	enableCrdt: true,
 	vaultId: null,
 	clientId: "",
 	planState: null,

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -943,20 +943,6 @@ describe("EngramApi", () => {
 			expect(invalidate).toHaveBeenCalledTimes(1);
 		});
 	});
-
-	describe("crdt ops transport (socket-only after Phase E3 — only the heads probe remains)", () => {
-		test("getVaultHeads returns the note->head map", async () => {
-			mockRequestUrl.mockResolvedValueOnce({
-				status: 200,
-				json: { heads: { a: "h1", b: "h2" } },
-			} as any);
-			const res = await api.getVaultHeads();
-			expect(res.heads).toEqual({ a: "h1", b: "h2" });
-			const opts = mockRequestUrl.mock.calls[0]![0] as any;
-			expect(opts.method).toBe("GET");
-			expect(opts.url).toContain("/vault/heads");
-		});
-	});
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/channel-conn-id.test.ts
+++ b/tests/channel-conn-id.test.ts
@@ -22,7 +22,7 @@ beforeAll(() => {
 });
 
 test("mints a fresh conn_id per openSocket and puts it in the URL", async () => {
-	const ch = new NoteChannel("http://x", "key-123", "user-1", "vault-9", false, "dev-1");
+	const ch = new NoteChannel("http://x", "key-123", "user-1", "vault-9", "dev-1");
 	await ch.connect();
 	const first = ch.getConnId();
 	expect(first).toBeTruthy();

--- a/tests/channel-crdt.test.ts
+++ b/tests/channel-crdt.test.ts
@@ -49,7 +49,7 @@ function simulateMessage(ws: any, msg: unknown[]): void {
  *  sendRequest tests. Mirrors the [0]=sync join, [1]=user join,
  *  [2]=crdt join setup used across this file. */
 async function joinedCrdtChannel(): Promise<{ channel: NoteChannel; ws: any }> {
-	const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+	const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 	await channel.connect();
 	const ws = lastWsInstance;
 	simulateOpen(ws);
@@ -66,7 +66,7 @@ beforeEach(() => {
 
 describe("NoteChannel CRDT topic join", () => {
 	test("joins crdt:{userId}:{vaultId} topic when vaultId is set", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -83,7 +83,7 @@ describe("NoteChannel CRDT topic join", () => {
 	});
 
 	test("crdt topic join payload includes crdt_proto: 2", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -111,26 +111,8 @@ describe("NoteChannel CRDT topic join", () => {
 		channel.disconnect();
 	});
 
-	test("does NOT join crdt topic when CRDT is disabled (default), even with vaultId", async () => {
-		// enableCrdt defaults to false → the plugin must behave exactly like a
-		// non-CRDT build: no crdt: join, isCrdtConnected stays false, every save
-		// goes through the legacy push path.
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
-		await channel.connect();
-		simulateOpen(lastWsInstance);
-
-		const crdtJoin = lastWsInstance.sent
-			.map((s: string) => JSON.parse(s) as unknown[])
-			.find((m: unknown[]) => (m[2] as string).startsWith("crdt:"));
-
-		expect(crdtJoin).toBeUndefined();
-		expect(channel.isCrdtConnected()).toBe(false);
-
-		channel.disconnect();
-	});
-
 	test("crdt topic join error is graceful and does not flip connected", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -167,7 +149,7 @@ describe("NoteChannel.sendCrdt", () => {
 	// join_ref is silently dropped server-side). Flipped below: pre-join must
 	// drop, not send.
 	test("drops (returns false) before the crdt: join is acked", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 		// NO join ack delivered for the crdt: topic.
@@ -185,7 +167,7 @@ describe("NoteChannel.sendCrdt", () => {
 	});
 
 	test("emits (returns true) a crdt_msg event with doc_id and b64 after the crdt: join is acked", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 		ackCrdtJoin();
@@ -232,7 +214,7 @@ describe("NoteChannel.sendCrdt", () => {
 
 describe("NoteChannel inbound crdt_msg", () => {
 	test("routes inbound crdt_msg to onCrdtMessage callback", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const received: { docId: string; b64: string }[] = [];
 		channel.onCrdtMessage = (docId, b64) => received.push({ docId, b64 });
 		await channel.connect();
@@ -254,7 +236,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	});
 
 	test("crdt_msg without onCrdtMessage is a no-op (no crash)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -272,7 +254,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	});
 
 	test("routes inbound note_yjs_update to onNoteYjsUpdate callback, carrying seq", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const received: { noteId: string; b64: string; head: string; seq?: number | null }[] = [];
 		channel.onNoteYjsUpdate = (noteId, b64, head, seq) =>
 			received.push({ noteId, b64, head, seq });
@@ -297,7 +279,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	// at all — back-compat must thread through undefined, not crash or coerce
 	// to 0 (0 is a valid gap-heal cursor value, not "absent").
 	test("note_yjs_update without a seq field passes seq=undefined (old-backend back-compat)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const received: { noteId: string; b64: string; head: string; seq?: number | null }[] = [];
 		channel.onNoteYjsUpdate = (noteId, b64, head, seq) =>
 			received.push({ noteId, b64, head, seq });
@@ -323,7 +305,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	// malformed/foreign frame from carrying a non-integer at runtime — the
 	// frame boundary must guard it, not just trust the cast (final review).
 	test("note_yjs_update with a non-integer seq (string) is normalized to undefined", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const received: { noteId: string; b64: string; head: string; seq?: number | null }[] = [];
 		channel.onNoteYjsUpdate = (noteId, b64, head, seq) =>
 			received.push({ noteId, b64, head, seq });
@@ -346,7 +328,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	});
 
 	test("note_yjs_update with a non-integer seq (float) is normalized to undefined", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const received: { noteId: string; b64: string; head: string; seq?: number | null }[] = [];
 		channel.onNoteYjsUpdate = (noteId, b64, head, seq) =>
 			received.push({ noteId, b64, head, seq });
@@ -369,7 +351,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	});
 
 	test("note_yjs_update without onNoteYjsUpdate is a no-op (no crash)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -390,7 +372,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 	// field must be dropped silently — never delivered as a partial event that
 	// would apply undefined bytes / persist an undefined head.
 	test("note_yjs_update with a missing field does NOT invoke the callback", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const received: unknown[] = [];
 		channel.onNoteYjsUpdate = (noteId, b64, head) => received.push({ noteId, b64, head });
 		await channel.connect();
@@ -433,7 +415,7 @@ describe("NoteChannel inbound crdt_msg", () => {
 
 describe("NoteChannel inbound crdt_doc_ready", () => {
 	test("routes inbound crdt_doc_ready to onCrdtDocReady callback", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const ready: string[] = [];
 		channel.onCrdtDocReady = (docId) => ready.push(docId);
 		await channel.connect();
@@ -455,7 +437,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 	test("forwards the announce path to onCrdtDocReady (empty-note discovery, test_27)", async () => {
 		// The backend now carries the note's path on the announce so an empty note
 		// (zero Y.Doc ops → no note_yjs_update) can be discovered immediately.
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const calls: Array<[string, string | undefined]> = [];
 		channel.onCrdtDocReady = (docId, path) => calls.push([docId, path]);
 		await channel.connect();
@@ -479,7 +461,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 		// crdt_msg names an id it has no row for — the create-race cross-wire
 		// signature. The plugin must surface it so the sync engine can run its
 		// live id-map reconcile immediately instead of waiting for an announce.
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const missing: string[] = [];
 		channel.onCrdtNoteNotFound = (docId) => missing.push(docId);
 		await channel.connect();
@@ -499,7 +481,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 	});
 
 	test("note_not_found on a NON-crdt topic does not fire the heal callback", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const missing: string[] = [];
 		channel.onCrdtNoteNotFound = (docId) => missing.push(docId);
 		await channel.connect();
@@ -518,7 +500,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 	});
 
 	test("note_not_found without doc_id falls through (no crash, no callback)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const missing: string[] = [];
 		channel.onCrdtNoteNotFound = (docId) => missing.push(docId);
 		await channel.connect();
@@ -539,7 +521,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 	});
 
 	test("crdt_doc_ready without onCrdtDocReady is a no-op (no crash)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -557,7 +539,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 	});
 
 	test("crdt_doc_ready without doc_id does not fire callback", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		let fired = false;
 		channel.onCrdtDocReady = () => {
 			fired = true;
@@ -579,7 +561,7 @@ describe("NoteChannel inbound crdt_doc_ready", () => {
 
 describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 	test("isCrdtConnected() is false before the crdt: topic join is acknowledged", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -590,7 +572,7 @@ describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 	});
 
 	test("isCrdtConnected() is true after crdt: topic join ok", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -608,7 +590,7 @@ describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 	});
 
 	test("isCrdtConnected() stays false when the crdt: topic join errors (non-CRDT backend)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -626,7 +608,7 @@ describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 	});
 
 	test("onCrdtJoined fires exactly once when crdt: topic join ok", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const joined = mock();
 		channel.onCrdtJoined = joined;
 		await channel.connect();
@@ -646,7 +628,7 @@ describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 	});
 
 	test("onCrdtJoined does NOT fire when the crdt: topic join errors", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const joined = mock();
 		channel.onCrdtJoined = joined;
 		await channel.connect();
@@ -678,7 +660,7 @@ describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 	});
 
 	test("isCrdtConnected() resets to false after disconnect", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -711,7 +693,7 @@ describe("NoteChannel.isCrdtConnected and onCrdtJoined", () => {
 describe("Graceful degradation: setCrdtManager deferred to onCrdtJoined", () => {
 	test("onCrdtJoined wires setCrdtManager; before join, manager is not wired", async () => {
 		// Simulate the pattern from main.ts: wire onCrdtJoined to call setCrdtManager
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -741,7 +723,7 @@ describe("Graceful degradation: setCrdtManager deferred to onCrdtJoined", () => 
 	});
 
 	test("crdt: join error → onCrdtJoined never fires → manager stays null (non-CRDT backend)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -788,7 +770,7 @@ describe("onCrdtJoinError: crdt join error fires callback with reason", () => {
 	// behavior (any error on the crdt topic fires) is intentionally updated here.
 
 	test("fires onCrdtJoinError with the reason string when crdt: topic errors (join ref matches)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -818,7 +800,7 @@ describe("onCrdtJoinError: crdt join error fires callback with reason", () => {
 	});
 
 	test("fires onCrdtJoinError with undefined reason when no reason in payload (join ref matches)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -849,7 +831,7 @@ describe("onCrdtJoinError: crdt join error fires callback with reason", () => {
 		// Backend #846 adds per-message error replies on crdt_msg frames (e.g. "rate_limited",
 		// "frame_too_large"). These carry a DIFFERENT ref than the join frame. A single
 		// rate-limit trip must NOT tear down the CRDT session.
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -874,7 +856,7 @@ describe("onCrdtJoinError: crdt join error fires callback with reason", () => {
 	});
 
 	test("does NOT fire onCrdtJoinError for a user topic join error", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -898,7 +880,7 @@ describe("onCrdtJoinError: crdt join error fires callback with reason", () => {
 	});
 
 	test("does NOT fire onCrdtJoinError for the sync topic join error", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -930,7 +912,7 @@ describe("onCrdtJoinError: crdt join error fires callback with reason", () => {
 
 describe("onCrdtJoinError: crdt_proto_too_old surfaces min proto version", () => {
 	test("fires onCrdtJoinError with reason and min when crdt_proto_too_old (join ref matches)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -958,7 +940,7 @@ describe("onCrdtJoinError: crdt_proto_too_old surfaces min proto version", () =>
 	});
 
 	test("fires onCrdtJoinError with min undefined when crdt_proto_too_old but no min field (join ref matches)", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -995,7 +977,7 @@ describe("onCrdtJoinError: crdt_proto_too_old surfaces min proto version", () =>
 
 describe("crdtJoined resets on unclean close (#191)", () => {
 	test("crdt ack without sync ack, then unclean close: crdt gate closes", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		simulateOpen(lastWsInstance);
 
@@ -1023,7 +1005,7 @@ describe("crdtJoined resets on unclean close (#191)", () => {
 	});
 
 	test("onCrdtJoined re-fires after an unclean close and rejoin", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		const joined = mock();
 		channel.onCrdtJoined = joined;
 		await channel.connect();

--- a/tests/channel-frame-size.test.ts
+++ b/tests/channel-frame-size.test.ts
@@ -56,7 +56,7 @@ function joinAndAckCrdt(): void {
 
 describe("outbound oversize frame warning", () => {
 	test("a frame over the threshold triggers a channel warn naming the event and size", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "42", "vault-1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "42", "vault-1");
 		await channel.connect();
 		joinAndAckCrdt();
 
@@ -81,7 +81,7 @@ describe("outbound oversize frame warning", () => {
 	});
 
 	test("a small frame does NOT trigger a warn", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "42", "vault-1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "42", "vault-1");
 		await channel.connect();
 		joinAndAckCrdt();
 

--- a/tests/channel-join-backoff.test.ts
+++ b/tests/channel-join-backoff.test.ts
@@ -113,7 +113,7 @@ function failCycle(channel: NoteChannel, reason: string, topic = "crdt:u1:v1"): 
 
 describe("NoteChannel join-failure reconnect backoff", () => {
 	test("a graceful drop with NO join failure keeps the flat full-jitter delay", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		lastWsInstance.onopen?.();
 		const ref = crdtJoinRef(lastWsInstance);
@@ -128,7 +128,7 @@ describe("NoteChannel join-failure reconnect backoff", () => {
 	});
 
 	test("a rejected crdt join backs off (non-zero delay) instead of the flat jitter", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 		const delay = failCycle(channel, "some_error");
 		expect(delay).toBeGreaterThan(0);
@@ -136,7 +136,7 @@ describe("NoteChannel join-failure reconnect backoff", () => {
 	});
 
 	test("consecutive join rejections grow the backoff, capped at 60s", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 
 		const delays: number[] = [];
@@ -160,12 +160,12 @@ describe("NoteChannel join-failure reconnect backoff", () => {
 	});
 
 	test("an explicit rate_limited reason gets a higher floor than a generic join error", async () => {
-		const channelA = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channelA = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channelA.connect();
 		const genericDelay = failCycle(channelA, "some_error");
 		channelA.disconnect();
 
-		const channelB = new NoteChannel("http://localhost:4000", "key", "u2", "v1", true);
+		const channelB = new NoteChannel("http://localhost:4000", "key", "u2", "v1");
 		await channelB.connect();
 		const rateLimitedDelay = failCycle(channelB, "rate_limited", "crdt:u2:v1");
 		channelB.disconnect();
@@ -174,7 +174,7 @@ describe("NoteChannel join-failure reconnect backoff", () => {
 	});
 
 	test("a successful crdt join resets the backoff back to the floor", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		await channel.connect();
 
 		// First failure grows the backoff.

--- a/tests/channel-unauthorized-rejoin.test.ts
+++ b/tests/channel-unauthorized-rejoin.test.ts
@@ -106,7 +106,7 @@ async function rejectedCycleThenReconnect(reason: string, staleTopic: string): P
 describe("NoteChannel unauthorized-join identity self-heal", () => {
 	test("an unauthorized crdt join re-derives the userId on the next reconnect", async () => {
 		// Channel frozen under stale-user; the socket authenticates as fresh-user.
-		const channel = new NoteChannel("http://localhost:4000", "key", "stale-user", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "stale-user", "v1");
 		let probes = 0;
 		channel.setAuthProbe(async () => {
 			probes++;
@@ -134,7 +134,7 @@ describe("NoteChannel unauthorized-join identity self-heal", () => {
 		// never fires and CRDT routing stays degraded until an unrelated blip.
 		// The channel must cycle the socket itself; the onclose backoff
 		// (crdtJoinFailedReason set) keeps it bounded.
-		const channel = new NoteChannel("http://localhost:4000", "key", "stale-user", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "stale-user", "v1");
 		channel.setAuthProbe(async () => ({ id: "fresh-user" }));
 		await channel.connect();
 		lastWsInstance.onopen?.();
@@ -149,7 +149,7 @@ describe("NoteChannel unauthorized-join identity self-heal", () => {
 	});
 
 	test("a generic join rejection does NOT cycle the socket", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		channel.setAuthProbe(async () => ({ id: "u1" }));
 		await channel.connect();
 		lastWsInstance.onopen?.();
@@ -159,7 +159,7 @@ describe("NoteChannel unauthorized-join identity self-heal", () => {
 	});
 
 	test("a generic join rejection does NOT trigger the identity probe", async () => {
-		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1", true);
+		const channel = new NoteChannel("http://localhost:4000", "key", "u1", "v1");
 		let probes = 0;
 		channel.setAuthProbe(async () => {
 			probes++;

--- a/tests/crdt-create-ack-gate.test.ts
+++ b/tests/crdt-create-ack-gate.test.ts
@@ -22,7 +22,7 @@ function makeEngine(): SyncEngine {
 	return new SyncEngine(
 		{} as any,
 		{} as any,
-		{ ...DEFAULT_SETTINGS, enableCrdt: false },
+		{ ...DEFAULT_SETTINGS },
 		mock().mockResolvedValue(undefined),
 	);
 }

--- a/tests/crdt/note-yjs-update.test.ts
+++ b/tests/crdt/note-yjs-update.test.ts
@@ -45,7 +45,7 @@ function engine(opts?: { crdt?: Partial<CrdtManager> }): SyncEngine {
 	const e = new SyncEngine(
 		mockApp,
 		mockApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	if (opts?.crdt) e.setCrdtManager(opts.crdt as unknown as CrdtManager);
@@ -229,7 +229,7 @@ describe("applyPushedNoteUpdate — gap heal (missed-open reconnect)", () => {
 		const e = new SyncEngine(
 			mockApp,
 			mockApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
 		e.setCrdtManager(crdt as unknown as CrdtManager);

--- a/tests/main-catchup-wiring.test.ts
+++ b/tests/main-catchup-wiring.test.ts
@@ -14,8 +14,8 @@
  * This exercises the REAL connectChannel() (not a reimplementation) via an
  * `Object.create(EngramSyncPlugin.prototype)` fake `this`: real prototype
  * methods (connectChannel, onCrdtTopicJoined, reEnrollOpenCrdtNotes) run with
- * fake data fields, so the actual wiring is under test. enableCrdt:true so the
- * crdt: block wires channel.onCrdtJoined; the heavy CRDT-room objects
+ * fake data fields, so the actual wiring is under test. The crdt: block wires
+ * channel.onCrdtJoined; the heavy CRDT-room objects
  * (createCrdtWiring, CrdtLiveViews) construct against light fakes and are never
  * exercised (syncEngine is stubbed). connectChannel is `private` (genuinely
  * internal), so the cast bypasses the compile-time visibility check without
@@ -39,7 +39,7 @@ class MockWebSocket {
 }
 (globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
 
-// The enableCrdt block probes indexedDB.databases; a bare object makes the probe
+// The CRDT wiring block probes indexedDB.databases; a bare object makes the probe
 // read "not a function" and take the skip-schema-wipe branch (no IDB / localStorage
 // needed). Force it per-test: a prior test file in the same run may have set
 // indexedDB.databases to a real function, which would otherwise route into
@@ -71,7 +71,6 @@ function makeFakeThis(catchup: () => Promise<void>, pull: () => Promise<number>,
 			apiKey: "key",
 			refreshToken: "",
 			vaultId: "vault-1",
-			enableCrdt: true,
 			userEmail: "a@example.com",
 		},
 		deviceId: "device-1",

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -407,7 +407,7 @@ export class Replica {
 			apiUrl: "http://sim.local/api",
 			apiKey: `token-${id}`,
 			vaultId: VAULT_ID,
-			enableCrdt: true,
+
 			userEmail: "sim@example.com",
 			// Small but non-zero: keeps handleModify's debounce a real (virtual) timer
 			// that drain() fires after the network settles, mirroring production timing.
@@ -484,7 +484,7 @@ export class Replica {
 			settings.apiKey,
 			SIM_USER_ID,
 			settings.vaultId,
-			settings.enableCrdt,
+			true, // CRDT topic join — always on (setting removed; ctor param is a test seam)
 			id, // deviceId -> the WebSocket adapter's routing key (device_id param)
 		);
 		noteStream = channel;

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -407,7 +407,6 @@ export class Replica {
 			apiUrl: "http://sim.local/api",
 			apiKey: `token-${id}`,
 			vaultId: VAULT_ID,
-
 			userEmail: "sim@example.com",
 			// Small but non-zero: keeps handleModify's debounce a real (virtual) timer
 			// that drain() fires after the network settles, mirroring production timing.
@@ -484,7 +483,6 @@ export class Replica {
 			settings.apiKey,
 			SIM_USER_ID,
 			settings.vaultId,
-
 			id, // deviceId -> the WebSocket adapter's routing key (device_id param)
 		);
 		noteStream = channel;

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -484,7 +484,7 @@ export class Replica {
 			settings.apiKey,
 			SIM_USER_ID,
 			settings.vaultId,
-			true, // CRDT topic join — always on (setting removed; ctor param is a test seam)
+
 			id, // deviceId -> the WebSocket adapter's routing key (device_id param)
 		);
 		noteStream = channel;

--- a/tests/sync-crdt-drift-merge.test.ts
+++ b/tests/sync-crdt-drift-merge.test.ts
@@ -80,7 +80,7 @@ async function scenario(dbPrefix: string) {
 	const e = new SyncEngine(
 		mockApp,
 		{} as unknown as EngramApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	e.setCrdtManager(mgr as unknown as CrdtManager);
@@ -159,7 +159,7 @@ async function historyLessScenario(opts: {
 	const e = new SyncEngine(
 		mockApp,
 		api,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	box.e = e;

--- a/tests/sync-crdt-drift-merge.test.ts
+++ b/tests/sync-crdt-drift-merge.test.ts
@@ -32,10 +32,6 @@ function markConfirmed(engine: SyncEngine, noteId: string): void {
 	const p = e.noteIdMap?.pathForId(noteId);
 	if (p) e.setCrdtHead(p, "server-head");
 }
-function markProbed(engine: SyncEngine): void {
-	(engine as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
-}
-
 /** Build a shared-base local doc + a remote delta that adds " REMOTE" on that
  *  same base, plus the disk drift "BASE local" and its recorded baseline. */
 async function scenario(dbPrefix: string) {
@@ -152,9 +148,7 @@ async function historyLessScenario(opts: {
 		workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
 	} as any;
 
-	const api = {
-		getVaultHeads: async () => ({ heads: { "id-a": "SRV" } }),
-	} as unknown as EngramApi;
+	const api = {} as unknown as EngramApi;
 
 	const e = new SyncEngine(
 		mockApp,
@@ -165,7 +159,6 @@ async function historyLessScenario(opts: {
 	box.e = e;
 	e.setCrdtManager(mgr as unknown as CrdtManager);
 	e.setReady();
-	markProbed(e);
 	const map = new NoteIdMap();
 	map.set("a.md", "id-a");
 	e.setNoteIdMap(map);

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests: crdtOpsAvailable capability latch on SyncEngine (mirrors
  * batchPushUnsupported). Latches OFF on a 404/405 from an /updates call;
- * stays on for other statuses; requires settings.enableCrdt.
+ * stays on for other statuses.
  */
 import { describe, expect, mock, test } from "bun:test";
 import "fake-indexeddb/auto";
@@ -103,14 +103,14 @@ const mockApp = {
 } as any;
 
 function engine(opts?: {
-	enableCrdt?: boolean;
+
 	api?: Partial<EngramApi>;
 	crdt?: Partial<CrdtManager>;
 }): SyncEngine {
 	const e = new SyncEngine(
 		mockApp,
 		(opts?.api ?? mockApi) as unknown as EngramApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: opts?.enableCrdt ?? true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	if (opts?.crdt) e.setCrdtManager(opts.crdt as unknown as CrdtManager);
@@ -145,7 +145,7 @@ describe("applyCrdtCreateAck seeds the body on peers (not a 0-byte row)", () => 
 		const e = new SyncEngine(
 			localApp as any,
 			mockApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
 		e.setCrdtManager(crdt as unknown as CrdtManager);
@@ -195,7 +195,7 @@ describe("applyCrdtCreateAck seeds the body on peers (not a 0-byte row)", () => 
 });
 
 describe("crdtOpsAvailable latch", () => {
-	test("is available when enableCrdt, probed, and not latched", () => {
+	test("is available when probed and not latched", () => {
 		const e = engine();
 		markProbed(e);
 		expect((e as any).crdtOpsAvailable()).toBe(true);
@@ -222,17 +222,6 @@ describe("crdtOpsAvailable latch", () => {
 		expect((e as any).crdtOpsAvailable()).toBe(false);
 	});
 
-	test("unavailable when enableCrdt is false, even unlatched and probed", () => {
-		const e = new SyncEngine(
-			mockApp,
-			mockApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: false },
-			mock().mockResolvedValue(undefined),
-		);
-		e.setReady();
-		markProbed(e);
-		expect((e as any).crdtOpsAvailable()).toBe(false);
-	});
 });
 
 describe("probeCrdtOps — one-shot capability probe", () => {
@@ -244,29 +233,16 @@ describe("probeCrdtOps — one-shot capability probe", () => {
 				throw err;
 			},
 		};
-		const e = engine({ enableCrdt: true, api });
+		const e = engine({ api });
 		await (e as any).probeCrdtOps();
 		expect((e as any).crdtOpsAvailable()).toBe(false);
 	});
 
 	test("a getVaultHeads success leaves ops available", async () => {
 		const api = { getVaultHeads: async () => ({ heads: {} }) };
-		const e = engine({ enableCrdt: true, api });
+		const e = engine({ api });
 		await (e as any).probeCrdtOps();
 		expect((e as any).crdtOpsAvailable()).toBe(true);
-	});
-
-	test("no-op when enableCrdt is false", async () => {
-		let called = false;
-		const api = {
-			getVaultHeads: async () => {
-				called = true;
-				return { heads: {} };
-			},
-		};
-		const e = engine({ enableCrdt: false, api });
-		await (e as any).probeCrdtOps();
-		expect(called).toBe(false);
 	});
 
 	// Phase 2b remediation: capability comes SOLELY from the probe. Ops must
@@ -279,7 +255,7 @@ describe("probeCrdtOps — one-shot capability probe", () => {
 					resolveHeads = r;
 				}),
 		};
-		const e = engine({ enableCrdt: true, api });
+		const e = engine({ api });
 		expect((e as any).crdtOpsAvailable()).toBe(false); // not probed yet
 		const p = e.probeCrdtOps();
 		resolveHeads({ heads: {} });
@@ -306,7 +282,7 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 		const crdt = {
 			applyLocalEdit: async () => true,
 		};
-		const e = engine({ enableCrdt: true, api, crdt });
+		const e = engine({ api, crdt });
 		markProbed(e);
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("p.md", "id-1");
@@ -338,7 +314,7 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 		const crdt = { applyLocalEdit: async () => true };
 		const enroll = mock();
 		const reset = mock();
-		const e = engine({ enableCrdt: true, api, crdt });
+		const e = engine({ api, crdt });
 		markProbed(e);
 		e.setCrdtEnrollment({ enroll, reset } as any);
 		e.setCrdtLiveCheck(() => true); // channel live now
@@ -402,7 +378,7 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 		const e = new SyncEngine(
 			localApp as any,
 			api as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
 		e.setCrdtManager(crdt as unknown as CrdtManager);
@@ -459,7 +435,7 @@ describe("Task 5: crdtLive is re-checked AFTER the awaited seed (TOCTOU)", () =>
 				return true;
 			},
 		};
-		const e = engine({ enableCrdt: true, api, crdt });
+		const e = engine({ api, crdt });
 		markProbed(e);
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("T.md", "id-1");
@@ -499,7 +475,7 @@ describe("CRDT notes never whole-doc push (channel down → durable queue)", () 
 		const crdt = {
 			applyLocalEdit: async () => true,
 		};
-		const e = engine({ enableCrdt: true, api, crdt });
+		const e = engine({ api, crdt });
 		markProbed(e);
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("p.md", "id-1");
@@ -537,7 +513,7 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 			onUpdate: () => {},
 			onFlushToDisk: async () => {},
 		});
-		const e = engine({ enableCrdt: true, api, crdt: realCrdt });
+		const e = engine({ api, crdt: realCrdt });
 		markProbed(e);
 		const enroll = mock();
 		const reset = mock();
@@ -579,7 +555,7 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 		};
 		const crdt = { applyLocalEdit: async () => true };
 		const enroll = mock();
-		const e = engine({ enableCrdt: true, api, crdt });
+		const e = engine({ api, crdt });
 		markProbed(e);
 		e.setCrdtEnrollment({ enroll, reset: mock() } as any);
 		e.setCrdtLiveCheck(() => false);
@@ -621,7 +597,7 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 		const e = new SyncEngine(
 			localApp as any,
 			api as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
 		e.setReady();
@@ -659,7 +635,7 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 		const e = new SyncEngine(
 			localApp as any,
 			api as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
 		e.setReady();

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -1,7 +1,6 @@
 /**
- * Tests: crdtOpsAvailable capability latch on SyncEngine (mirrors
- * batchPushUnsupported). Latches OFF on a 404/405 from an /updates call;
- * stays on for other statuses.
+ * Tests: socket-native CRDT op delivery on SyncEngine — create-ack body
+ * seeding, the channel-down durable queue chain, and TOCTOU liveness.
  */
 import { describe, expect, mock, test } from "bun:test";
 import "fake-indexeddb/auto";
@@ -25,14 +24,6 @@ function markConfirmed(engine: SyncEngine, noteId: string): void {
 	};
 	const p = e.noteIdMap?.pathForId(noteId);
 	if (p) e.setCrdtHead(p, "server-head");
-}
-
-/** Mark the one-shot capability probe as already complete, for tests that
- *  exercise post-probe latch behavior directly without driving a real
- *  getVaultHeads round-trip (Phase 2b: crdtOpsAvailable() now requires
- *  crdtOpsProbed, not just an unlatched crdtOpsUnsupported). */
-function markProbed(engine: SyncEngine): void {
-	(engine as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
 }
 
 // Minimal mock api/app — mirrors tests/sync-crdt-route.test.ts's harness.
@@ -103,7 +94,6 @@ const mockApp = {
 } as any;
 
 function engine(opts?: {
-
 	api?: Partial<EngramApi>;
 	crdt?: Partial<CrdtManager>;
 }): SyncEngine {
@@ -194,76 +184,6 @@ describe("applyCrdtCreateAck seeds the body on peers (not a 0-byte row)", () => 
 	});
 });
 
-describe("crdtOpsAvailable latch", () => {
-	test("is available when probed and not latched", () => {
-		const e = engine();
-		markProbed(e);
-		expect((e as any).crdtOpsAvailable()).toBe(true);
-	});
-
-	test("latches off on a 404/405 from an updates call", () => {
-		const e = engine();
-		markProbed(e);
-		(e as any).markCrdtOpsUnsupported(404);
-		expect((e as any).crdtOpsAvailable()).toBe(false);
-	});
-
-	test("stays available on other statuses", () => {
-		const e = engine();
-		markProbed(e);
-		(e as any).markCrdtOpsUnsupported(500);
-		expect((e as any).crdtOpsAvailable()).toBe(true);
-	});
-
-	test("405 also latches off", () => {
-		const e = engine();
-		markProbed(e);
-		(e as any).markCrdtOpsUnsupported(405);
-		expect((e as any).crdtOpsAvailable()).toBe(false);
-	});
-
-});
-
-describe("probeCrdtOps — one-shot capability probe", () => {
-	test("a getVaultHeads 404 pre-latches ops-unsupported", async () => {
-		const api = {
-			getVaultHeads: async () => {
-				const err: any = new Error("nf");
-				err.status = 404;
-				throw err;
-			},
-		};
-		const e = engine({ api });
-		await (e as any).probeCrdtOps();
-		expect((e as any).crdtOpsAvailable()).toBe(false);
-	});
-
-	test("a getVaultHeads success leaves ops available", async () => {
-		const api = { getVaultHeads: async () => ({ heads: {} }) };
-		const e = engine({ api });
-		await (e as any).probeCrdtOps();
-		expect((e as any).crdtOpsAvailable()).toBe(true);
-	});
-
-	// Phase 2b remediation: capability comes SOLELY from the probe. Ops must
-	// read unavailable while the probe is in flight, not just after a failure.
-	test("ops are unavailable until the probe completes, then available on success", async () => {
-		let resolveHeads: (v: unknown) => void = () => {};
-		const api = {
-			getVaultHeads: () =>
-				new Promise((r) => {
-					resolveHeads = r;
-				}),
-		};
-		const e = engine({ api });
-		expect((e as any).crdtOpsAvailable()).toBe(false); // not probed yet
-		const p = e.probeCrdtOps();
-		resolveHeads({ heads: {} });
-		await p;
-		expect((e as any).crdtOpsAvailable()).toBe(true);
-	});
-});
-
 // The in-memory `scheduleCrdtFlush`/`flushCrdtState`/`crdtFlushTimers` debounce
 // was retired (Task 3, Phase 2b remediation) in favor of routing every
 // channel-down CRDT edit through the DURABLE offline queue: pushFile seeds the
@@ -283,7 +203,6 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 			applyLocalEdit: async () => true,
 		};
 		const e = engine({ api, crdt });
-		markProbed(e);
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("p.md", "id-1");
 		e.setNoteIdMap(noteIdMap);
@@ -315,7 +234,6 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 		const enroll = mock();
 		const reset = mock();
 		const e = engine({ api, crdt });
-		markProbed(e);
 		e.setCrdtEnrollment({ enroll, reset } as any);
 		e.setCrdtLiveCheck(() => true); // channel live now
 
@@ -342,70 +260,6 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 		// An inbound frame fires commitCrdtConvergence — the round-trip is
 		// proven and the entry settles out of the durable queue.
 		await e.commitCrdtConvergence("id-1");
-		expect(e.queue.size).toBe(0);
-	});
-
-	// Probe-race stranding (final review Minor-1, carried over from the retired
-	// scheduleCrdtFlush test): a CRDT note edited while the channel is down is
-	// durably queued while ops still look available. If the capability probe
-	// latches crdtOpsUnsupported AFTER the entry is queued but BEFORE it is
-	// delivered, the next flush must NOT strand it — it must re-drive delivery
-	// via the legacy whole-doc push (runFlushQueue's ops-unavailable fallback).
-	test("ops latch off after a channel-down edit is durably queued: the next flush delivers via legacy push, not silently stranded", async () => {
-		let pushNoteCalled = false;
-		let pushNoteArgs: any[] = [];
-		const testFile = new TFile("p.md");
-		const localApp = {
-			...mockApp,
-			vault: {
-				...mockApp.vault,
-				getFileByPath: mock().mockImplementation((p: string) =>
-					p === "p.md" ? testFile : null,
-				),
-				cachedRead: mock().mockResolvedValue("body"),
-			},
-		};
-		const api = {
-			pushNote: async (...args: any[]) => {
-				pushNoteCalled = true;
-				pushNoteArgs = args;
-				return { note: {}, chunks_indexed: 1 };
-			},
-		};
-		const crdt = {
-			applyLocalEdit: async () => true,
-		};
-		const e = new SyncEngine(
-			localApp as any,
-			api as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
-			mock().mockResolvedValue(undefined),
-		);
-		e.setCrdtManager(crdt as unknown as CrdtManager);
-		e.setReady();
-		markProbed(e);
-		const noteIdMap = new NoteIdMap();
-		noteIdMap.set("p.md", "id-1");
-		e.setNoteIdMap(noteIdMap);
-		markConfirmed(e, "id-1");
-		e.setCrdtLiveCheck(() => false); // channel down
-
-		const result = await (e as any).pushFile(testFile);
-		expect(result).toBe(true);
-		await new Promise((r) => setTimeout(r, 20)); // auto-flush: channel down → stays queued
-
-		expect(pushNoteCalled).toBe(false); // still queued, not stranded to legacy yet
-		expect(e.queue.size).toBe(1);
-
-		// Capability probe latches ops-unsupported (e.g. a pre-Phase-1 backend
-		// discovered mid-session) AFTER the edit was already durably queued.
-		(e as any).markCrdtOpsUnsupported(404);
-
-		const flushed = await e.flushQueue();
-
-		expect(flushed).toBe(1);
-		expect(pushNoteCalled).toBe(true); // delivered via legacy path, not dropped
-		expect(pushNoteArgs[1]).toBe("body");
 		expect(e.queue.size).toBe(0);
 	});
 });
@@ -436,7 +290,6 @@ describe("Task 5: crdtLive is re-checked AFTER the awaited seed (TOCTOU)", () =>
 			},
 		};
 		const e = engine({ api, crdt });
-		markProbed(e);
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("T.md", "id-1");
 		e.setNoteIdMap(noteIdMap);
@@ -476,7 +329,6 @@ describe("CRDT notes never whole-doc push (channel down → durable queue)", () 
 			applyLocalEdit: async () => true,
 		};
 		const e = engine({ api, crdt });
-		markProbed(e);
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("p.md", "id-1");
 		e.setNoteIdMap(noteIdMap);
@@ -514,7 +366,6 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 			onFlushToDisk: async () => {},
 		});
 		const e = engine({ api, crdt: realCrdt });
-		markProbed(e);
 		const enroll = mock();
 		const reset = mock();
 		e.setCrdtEnrollment({ enroll, reset } as any);
@@ -556,7 +407,6 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 		const crdt = { applyLocalEdit: async () => true };
 		const enroll = mock();
 		const e = engine({ api, crdt });
-		markProbed(e);
 		e.setCrdtEnrollment({ enroll, reset: mock() } as any);
 		e.setCrdtLiveCheck(() => false);
 
@@ -573,86 +423,5 @@ describe("runFlushQueue: durable crdt queue entry delivery over the socket", () 
 		expect(flushed).toBe(0);
 		expect(e.queue.size).toBe(1); // waits for the channel — not dropped, not parked
 		expect(enroll).not.toHaveBeenCalled();
-	});
-
-	test("crdt entry with ops unavailable clears the stale serverHash then falls through to the legacy push", async () => {
-		let pushNoteArgs: any[] = [];
-		const testFile = new TFile("T.md");
-		const localApp = {
-			...mockApp,
-			vault: {
-				...mockApp.vault,
-				getFileByPath: mock().mockImplementation((p: string) =>
-					p === "T.md" ? testFile : null,
-				),
-				cachedRead: mock().mockResolvedValue("legacy content"),
-			},
-		};
-		const api = {
-			pushNote: async (...args: any[]) => {
-				pushNoteArgs = args;
-				return { note: {}, chunks_indexed: 1 };
-			},
-		};
-		const e = new SyncEngine(
-			localApp as any,
-			api as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
-			mock().mockResolvedValue(undefined),
-		);
-		e.setReady();
-		(e as any).markCrdtOpsUnsupported(404); // ops unavailable (old backend)
-		e.importSyncState({ "T.md": { hash: 1, version: 1, serverHash: "stale-hash" } });
-
-		await e.queue.enqueue({
-			path: "T.md",
-			action: "upsert",
-			noteId: "id-1",
-			crdt: true,
-			timestamp: 1,
-		});
-		const flushed = await e.flushQueue();
-
-		expect(flushed).toBe(1);
-		// The stale serverHash was cleared before the legacy push — a no-base
-		// push overwrites deliberately instead of 409ing against the CAS base
-		// that CRDT-ops delivery already advanced past.
-		expect(pushNoteArgs[5]).toBeUndefined();
-		expect(pushNoteArgs[1]).toBe("legacy content");
-	});
-
-	test("a crdt entry whose file was renamed away (ops unavailable, legacy fallback) re-enrolls for channel convergence instead of silently dropping", async () => {
-		const api = {
-			pushNote: async () => {
-				throw new Error("must not legacy-push a vanished file");
-			},
-		};
-		const localApp = {
-			...mockApp,
-			vault: { ...mockApp.vault, getFileByPath: mock().mockReturnValue(null) },
-		};
-		const enroll = mock();
-		const e = new SyncEngine(
-			localApp as any,
-			api as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
-			mock().mockResolvedValue(undefined),
-		);
-		e.setReady();
-		(e as any).markCrdtOpsUnsupported(404); // ops unavailable: legacy fallback path
-		e.setCrdtEnrollment({ enroll, reset: mock() } as any);
-		// Content-free crdt entry; its file is no longer on disk (renamed away).
-		await e.queue.enqueue({
-			path: "T.md",
-			action: "upsert",
-			noteId: "id-1",
-			crdt: true,
-			timestamp: 1,
-		});
-		const flushed = await e.flushQueue();
-
-		expect(enroll).toHaveBeenCalledWith("id-1"); // Y.Doc retained: channel delivers
-		expect(e.queue.size).toBe(0); // dequeued (not looping)
-		expect(flushed).toBe(1);
 	});
 });

--- a/tests/sync-crdt-route.test.ts
+++ b/tests/sync-crdt-route.test.ts
@@ -262,14 +262,6 @@ function markServerKnown(engine: SyncEngine, path: string, noteId: string): void
 	e.setCrdtHead(path, "server-head");
 }
 
-/** Mark the one-shot capability probe as already complete, for tests that
- *  exercise post-probe latch behavior directly without driving a real
- *  getVaultHeads round-trip (Phase 2b: crdtOpsAvailable() now requires
- *  crdtOpsProbed, not just an unlatched crdtOpsUnsupported). */
-function markProbed(engine: SyncEngine): void {
-	(engine as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
-}
-
 beforeEach(() => {
 	(mockApi.pushNote as ReturnType<typeof mock>)
 		.mockReset()

--- a/tests/sync-delete-guard.test.ts
+++ b/tests/sync-delete-guard.test.ts
@@ -40,7 +40,7 @@ function makeEngine(crdt: Partial<CrdtManager>, applied: string[]): SyncEngine {
 	const e = new SyncEngine(
 		mockApp,
 		mockApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	e.setCrdtManager(crdt as unknown as CrdtManager);

--- a/tests/sync-gap-heal.test.ts
+++ b/tests/sync-gap-heal.test.ts
@@ -29,7 +29,7 @@ function makeEngine(): SyncEngine {
 	return new SyncEngine(
 		{} as any,
 		{} as any,
-		{ ...DEFAULT_SETTINGS, enableCrdt: false },
+		{ ...DEFAULT_SETTINGS },
 		mock().mockResolvedValue(undefined),
 	);
 }
@@ -191,7 +191,7 @@ function wiredNote(noteId: string, path: string) {
 			workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
 		} as any,
 		{} as any,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	engine.setCrdtManager(crdt as unknown as CrdtManager);

--- a/tests/sync-genesis-batch-echo.test.ts
+++ b/tests/sync-genesis-batch-echo.test.ts
@@ -57,7 +57,7 @@ function makeGenesisEngine(dbPrefix: string) {
 	const e = new SyncEngine(
 		app,
 		api,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	e.setCrdtManager(mgr as unknown as CrdtManager);

--- a/tests/sync-heal-on-open.test.ts
+++ b/tests/sync-heal-on-open.test.ts
@@ -57,7 +57,7 @@ function makeEngine(
 	const e = new SyncEngine(
 		mockApp,
 		mockApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	(e as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
@@ -151,7 +151,7 @@ describe("healNoteOnOpen", () => {
 		const e = new SyncEngine(
 			mockApp,
 			{ getUpdates: mock() } as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
 		(e as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
@@ -187,20 +187,6 @@ describe("healNoteOnOpen", () => {
 		expect(replayed).toBe(true); // seq-replay catch-up ran
 		expect(getUpdates).not.toHaveBeenCalled(); // NOT the REST heal path
 		expect(reset).not.toHaveBeenCalled(); // NOT the socket re-handshake path
-	});
-
-	test("crdt disabled: no-op", async () => {
-		const applyRemoteUpdate = mock().mockResolvedValue(undefined);
-		const e = new SyncEngine(
-			mockApp,
-			{ getUpdates: mock() } as unknown as EngramApi,
-			{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: false },
-			mock().mockResolvedValue(undefined),
-		);
-		e.setCrdtManager({ applyRemoteUpdate } as unknown as CrdtManager);
-		e.setReady();
-		await e.healNoteOnOpen("Notes/a.md");
-		expect(applyRemoteUpdate).not.toHaveBeenCalled();
 	});
 
 	test("never throws — a failure inside the socket re-handshake is caught and swallowed", async () => {

--- a/tests/sync-heal-on-open.test.ts
+++ b/tests/sync-heal-on-open.test.ts
@@ -60,7 +60,6 @@ function makeEngine(
 		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
-	(e as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
 	e.setCrdtManager(crdt as unknown as CrdtManager);
 	e.setReady();
 	e.setLiveBoundCheck(() => opts?.liveBound ?? true);
@@ -154,7 +153,6 @@ describe("healNoteOnOpen", () => {
 			{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 			mock().mockResolvedValue(undefined),
 		);
-		(e as unknown as { crdtOpsProbed: boolean }).crdtOpsProbed = true;
 		e.setCrdtManager({ applyRemoteUpdate } as unknown as CrdtManager);
 		e.setReady();
 		e.setLiveBoundCheck(() => true);

--- a/tests/sync-parse-status.test.ts
+++ b/tests/sync-parse-status.test.ts
@@ -98,7 +98,7 @@ function makeEngine(): SyncEngine {
 	const e = new SyncEngine(
 		mockApp,
 		mockApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: false },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	e.setReady();

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -98,7 +98,7 @@ function makeEngine(
 	const engine = new SyncEngine(
 		app,
 		api,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	engine.setCrdtManager(crdt as unknown as CrdtManagerType);

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -83,7 +83,7 @@ function makeEngineWithCrdt(crdt: Partial<CrdtManager>): SyncEngine {
 	const e = new SyncEngine(
 		mockApp,
 		mockApi,
-		{ ...DEFAULT_SETTINGS, debounceMs: 1, enableCrdt: true },
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
 	e.setCrdtManager(crdt as unknown as CrdtManager);

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -565,7 +565,7 @@ describe("SyncEngine.applySyncChange (apply behavior)", () => {
 	// (e2e test_47). Legacy notes (no id) keep the skip-and-resurrect guard.
 	function makeCrdtDeleteEngine(): { engine: SyncEngine; removed: string[] } {
 		const removed: string[] = [];
-		const engine = createEngine({ enableCrdt: true });
+		const engine = createEngine();
 		engine.setCrdtManager({
 			removeDoc: (id: string) => {
 				removed.push(id);
@@ -891,7 +891,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 		// doc the new-path upsert just materialized (received=yes materialized=no).
 		const removed: string[] = [];
 		const resets: string[] = [];
-		const engine = createEngine({ enableCrdt: true });
+		const engine = createEngine();
 		engine.setCrdtManager({
 			removeDoc: (id: string) => {
 				removed.push(id);
@@ -930,7 +930,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 		// A genuine delete: the id maps to THIS path (no upsert relocated it), so
 		// the authoritative teardown must still fire — removeDoc is called.
 		const removed: string[] = [];
-		const engine = createEngine({ enableCrdt: true });
+		const engine = createEngine();
 		engine.setCrdtManager({
 			removeDoc: (id: string) => {
 				removed.push(id);
@@ -964,7 +964,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 		// pull (received=yes materialized=no). The upsert carries the note's
 		// AUTHORITATIVE content inline, so it must materialize LIVE from event.content.
 		const removed: string[] = [];
-		const engine = createEngine({ enableCrdt: true });
+		const engine = createEngine();
 		engine.setCrdtManager({
 			removeDoc: (id: string) => {
 				removed.push(id);
@@ -1010,7 +1010,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 		// stay (it now belongs to the new path) AND the old file must be trashed.
 		const removed: string[] = [];
 		const resets: string[] = [];
-		const engine = createEngine({ enableCrdt: true });
+		const engine = createEngine();
 		engine.setCrdtManager({
 			removeDoc: (id: string) => {
 				removed.push(id);
@@ -1057,7 +1057,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 		// then flips (as if a relocation landed) before the write — the new path
 		// must NOT be written.
 		let flipped = false;
-		const engine = createEngine({ enableCrdt: true });
+		const engine = createEngine();
 		engine.setCrdtManager({
 			removeDoc: () => Promise.resolve(),
 			closeDoc: () => {},
@@ -1153,7 +1153,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 
 		// Push is complete — path is no longer in pushing set
 		// But should still be in recentlyPushed cooldown
-		expect(engine.isRecentlyPushed("Notes/Cooldown.canvas")).toBe(true);
+		expect((engine as any).isRecentlyPushed("Notes/Cooldown.canvas")).toBe(true);
 
 		// WebSocket event arriving after push should still be suppressed
 		await engine.handleStreamEvent({
@@ -3088,7 +3088,7 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 			}),
 		);
 
-		expect(engine.isRecentlyPushed(path)).toBe(false);
+		expect((engine as any).isRecentlyPushed(path)).toBe(false);
 
 		// Local content matches what was just pulled — pushFile takes the
 		// echo-skip no-op branch.
@@ -3099,7 +3099,7 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 		expect(pushed).toBe(false);
 		expect(mockApi.pushNote).not.toHaveBeenCalled();
 		// The no-op must NOT have opened the suppression window.
-		expect(engine.isRecentlyPushed(path)).toBe(false);
+		expect((engine as any).isRecentlyPushed(path)).toBe(false);
 
 		// A real remote update arriving right after must be applied, not
 		// echo-skipped.
@@ -3701,7 +3701,7 @@ describe("SyncEngine attachment pre-gate (client-side plan limits)", () => {
 		expect(mockApi.pushAttachment).not.toHaveBeenCalled();
 		expect(engine.issues.get("photo.png")?.category).toBe("needs_pro");
 		// Informational skip is tallied for the batched toast.
-		expect(engine.getAttachmentLimitedCount()).toBe(1);
+		expect((engine as any).getAttachmentLimitedCount()).toBe(1);
 	});
 
 	test("free text-only: a known text ext (.txt) attachment is NOT pre-skipped", async () => {


### PR DESCRIPTION
## Summary

"Lean machine" purge wave from the CRDT-migration audit (companion to #302). Three commits, escalating scope per review feedback:

### 1. `enableCrdt` fully deleted (setting + ctor param + join gate)
The setting defaulted `true`, had no settings-UI toggle, and its doc comment still said "OFF by default … ships dormant." Gone entirely: the field, its 5 plugin gates, the `NoteChannel` ctor param, the `crdtTopic` opt-in gate, and all flag-behavior tests. `crdt:` join is now gated solely on a vault being bound.

### 2. Pre-CRDT backend floor dropped
CRDT sockets are the only Yjs path; a backend without them is no longer supported:
- `probeCrdtOps` + `crdtOpsProbed`/`crdtOpsUnsupported` latch deleted — capability now IS the `crdt:` join ack (`this.crdt` set on join)
- `api.getVaultHeads` deleted (existed only to answer the probe; the backend route just lost its last plugin caller)
- A server-known md note always routes CRDT: live channel carries it, down channel queues durably — **never** a whole-doc REST push
- `runFlushQueue`'s ops-unavailable legacy replay for crdt entries deleted; a `crdt`+`noteId` entry converges over the socket or stays queued (REST replay survives only for noteId-less entries from ancient plugin versions)

### 3. Misc dead weight
- `CrdtDocMeta` interface (zero usages)
- 4 inline `TextEncoder` size checks → the existing `exceedsCrdtNoteLimit` helper
- 3 test-hook accessors made `private` (tests keep coverage via casts)
- schema.ts's drifted 25-line JSDoc wiring sample → pointer to the real call site

### Audit items deliberately NOT taken
- `reconcile()` + check-sync command: audit claimed the command was the sole caller — wrong, `pushAll` post-push verification uses it. Both stay.
- `pushFile` DECLINED / seed-decline branches: documented defensive fallbacks, not dead code.

## Backend follow-up
`GET /vault/heads` (router + `CrdtSyncController.vault_heads`) now has zero plugin callers — removable if web/MCP don't use it.

## Testing
- `tsc` + esbuild clean, `biome ci` clean
- Full suite: 2241 pass / 0 fail (probe/latch/flag suites deleted with their subjects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj