### PR TITLE
fix: release the transient heal room after convergence commits (e2e fan-out flake root cause)

### DIFF
--- a/main.js
+++ b/main.js
@@ -17432,23 +17432,31 @@ var _CrdtManager = class _CrdtManager {
     if (cached)
       return await cached.ready, cached;
     let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), text2 = doc2.getText(CONTENT_KEY), ready = persistence.whenSynced.then(() => {
-    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0 };
+    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0, hadContent: !1 };
     return persistence.on("error", (err) => {
       var _a, _b;
       return (_b = (_a = this.opts).onPersistError) == null ? void 0 : _b.call(_a, noteId, err);
     }), doc2.on("update", (update, origin) => {
-      origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
+      text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
     }), doc2.on("update", (_u, origin) => {
-      if (origin !== REMOTE_ORIGIN) return;
+      if (text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN) return;
       entry.remoteSeq += 1;
-      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON(), flush = Promise.resolve(
+      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON();
+      if (body.length === 0 && !entry.hadContent) {
+        rlog().warn(
+          "crdt",
+          `remote-merge flush SKIPPED for ${noteId}: empty body on never-seeded doc (#288 genesis guard)`
+        );
+        return;
+      }
+      let flush = Promise.resolve(
         this.opts.onFlushToDisk(noteId, projectNote(order, values, body, raws))
       );
       this.pendingFlush.set(id2, flush), flush.catch(() => {
       }).finally(() => {
         this.pendingFlush.get(id2) === flush && this.pendingFlush.delete(id2);
       });
-    }), this.docs.set(id2, entry), await ready, entry;
+    }), this.docs.set(id2, entry), await ready, text2.length > 0 && (entry.hadContent = !0), entry;
   }
   /**
    * Returns true when the Y.Text already carries CRDT history (content
@@ -19958,7 +19966,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       }
     }
     let staged = this.pendingConvergence.get(noteId);
-    if (!staged) return;
+    if (!staged) {
+      queued && this.releaseHealRoom(noteId, queued.path);
+      return;
+    }
     if (staged.content !== null) {
       let matches = !1;
       if (this.crdt)
@@ -19985,19 +19996,37 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     }
     this.pendingConvergence.delete(noteId), this.crdtRehandshakeAttempts.delete(noteId);
     let path = (_f = this.noteIdMap) == null ? void 0 : _f.pathForId(noteId);
-    if (path)
-      try {
-        let boundFile = this.app.vault.getFileByPath(path), stored = this.syncState.get(path), localHash = (_g = stored == null ? void 0 : stored.hash) != null ? _g : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
-        this.syncState.set(path, {
-          ...(_h = this.syncState.get(path)) != null ? _h : {},
-          hash: localHash,
-          serverHash: staged.serverHash,
-          version: staged.version,
-          seq: staged.seq
-        }), rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
-      } catch (e) {
-        rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
-      }
+    if (!path) {
+      this.releaseHealRoom(noteId, null);
+      return;
+    }
+    try {
+      let boundFile = this.app.vault.getFileByPath(path), stored = this.syncState.get(path), localHash = (_g = stored == null ? void 0 : stored.hash) != null ? _g : boundFile ? fnv1a(await this.app.vault.cachedRead(boundFile)) : 0;
+      this.syncState.set(path, {
+        ...(_h = this.syncState.get(path)) != null ? _h : {},
+        hash: localHash,
+        serverHash: staged.serverHash,
+        version: staged.version,
+        seq: staged.seq
+      }), rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
+    } catch (e) {
+      rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
+    }
+    this.releaseHealRoom(noteId, path);
+  }
+  /** Release the TRANSIENT heal room once its job is done (fan-out idle
+   *  invariant: an idle note holds NO CRDT room). The diverged-cold-note heal
+   *  and the queued-delivery nudge open a room via reset+enroll; without this
+   *  release the once-per-session `enrolled` mark keeps that room (client doc
+   *  + server SharedDoc) alive for the rest of the session — on mass
+   *  divergence that recreates the connect-storm resource shape the fan-out
+   *  model exists to prevent (e2e canary:
+   *  test_cold_send_over_fanout_opens_no_room). `reset` also clears the
+   *  channel's once-per-doc STEP1 gate so a FUTURE heal can re-handshake.
+   *  A live-bound note keeps its room — the editor owns its lifecycle. */
+  releaseHealRoom(noteId, path) {
+    var _a;
+    path && this.isLiveBound((0, import_obsidian21.normalizePath)(path)) || ((_a = this.crdtEnrollment) == null || _a.reset(noteId), path && this.hibernateIfIdle(path, noteId));
   }
   /** Cheap mid-session divergence heal for the just-opened note (rework #6 —
    *  restores the coverage the removed `verifyConvergenceOnOpen` had, a note

--- a/main.js
+++ b/main.js
@@ -20025,8 +20025,18 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  channel's once-per-doc STEP1 gate so a FUTURE heal can re-handshake.
    *  A live-bound note keeps its room — the editor owns its lifecycle. */
   releaseHealRoom(noteId, path) {
-    var _a;
-    path && this.isLiveBound((0, import_obsidian21.normalizePath)(path)) || ((_a = this.crdtEnrollment) == null || _a.reset(noteId), path && this.hibernateIfIdle(path, noteId));
+    var _a, _b, _c;
+    let current = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.pathForId(noteId)) != null ? _b : path;
+    if (!(current && this.isLiveBound((0, import_obsidian21.normalizePath)(current)))) {
+      if ((_c = this.crdtEnrollment) == null || _c.reset(noteId), current)
+        this.hibernateIfIdle(current, noteId);
+      else if (this.crdt)
+        try {
+          this.crdt.closeDoc(noteId);
+        } catch (e) {
+          devLog().log("crdt", `releaseHealRoom: closeDoc ${noteId} failed \u2014 ${errMsg(e)}`);
+        }
+    }
   }
   /** Cheap mid-session divergence heal for the just-opened note (rework #6 —
    *  restores the coverage the removed `verifyConvergenceOnOpen` had, a note

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3888,9 +3888,24 @@ export class SyncEngine {
 	 *  channel's once-per-doc STEP1 gate so a FUTURE heal can re-handshake.
 	 *  A live-bound note keeps its room — the editor owns its lifecycle. */
 	private releaseHealRoom(noteId: string, path: string | null): void {
-		if (path && this.isLiveBound(normalizePath(path))) return;
+		// Re-resolve the CURRENT path — `path` may be the enqueue/staging-time
+		// path, and a rename in between would otherwise check liveness (and
+		// hibernate) against the stale path and closeDoc a doc the editor still
+		// owns at its NEW path (silent data loss, the bind-race class).
+		const current = this.noteIdMap?.pathForId(noteId) ?? path;
+		if (current && this.isLiveBound(normalizePath(current))) return;
 		this.crdtEnrollment?.reset(noteId);
-		if (path) this.hibernateIfIdle(path, noteId);
+		if (current) {
+			this.hibernateIfIdle(current, noteId);
+		} else if (this.crdt) {
+			// Id unmapped (deleted since staging) — cannot be live-bound; free the
+			// doc directly. Best-effort, mirrors hibernateIfIdle.
+			try {
+				this.crdt.closeDoc(noteId);
+			} catch (e) {
+				devLog().log("crdt", `releaseHealRoom: closeDoc ${noteId} failed — ${errMsg(e)}`);
+			}
+		}
 	}
 
 	/** Cheap mid-session divergence heal for the just-opened note (rework #6 —

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3801,7 +3801,13 @@ export class SyncEngine {
 			}
 		}
 		const staged = this.pendingConvergence.get(noteId);
-		if (!staged) return;
+		if (!staged) {
+			// A settled queue nudge with no staged convergence: the nudge's
+			// transient room is done — release it. A frame with NOTHING pending
+			// stays a pure no-op (commit fires on every inbound frame).
+			if (queued) this.releaseHealRoom(noteId, queued.path);
+			return;
+		}
 		if (staged.content !== null) {
 			let matches = false;
 			if (this.crdt) {
@@ -3846,7 +3852,12 @@ export class SyncEngine {
 		this.pendingConvergence.delete(noteId);
 		this.crdtRehandshakeAttempts.delete(noteId);
 		const path = this.noteIdMap?.pathForId(noteId);
-		if (!path) return; // id unmapped since staging (deleted) — nothing to record
+		if (!path) {
+			// Id unmapped since staging (deleted) — nothing to record, and a
+			// deleted note must not keep holding a room.
+			this.releaseHealRoom(noteId, null);
+			return;
+		}
 		try {
 			const boundFile = this.app.vault.getFileByPath(path);
 			const stored = this.syncState.get(path);
@@ -3863,6 +3874,23 @@ export class SyncEngine {
 		} catch (e) {
 			rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
 		}
+		this.releaseHealRoom(noteId, path);
+	}
+
+	/** Release the TRANSIENT heal room once its job is done (fan-out idle
+	 *  invariant: an idle note holds NO CRDT room). The diverged-cold-note heal
+	 *  and the queued-delivery nudge open a room via reset+enroll; without this
+	 *  release the once-per-session `enrolled` mark keeps that room (client doc
+	 *  + server SharedDoc) alive for the rest of the session — on mass
+	 *  divergence that recreates the connect-storm resource shape the fan-out
+	 *  model exists to prevent (e2e canary:
+	 *  test_cold_send_over_fanout_opens_no_room). `reset` also clears the
+	 *  channel's once-per-doc STEP1 gate so a FUTURE heal can re-handshake.
+	 *  A live-bound note keeps its room — the editor owns its lifecycle. */
+	private releaseHealRoom(noteId: string, path: string | null): void {
+		if (path && this.isLiveBound(normalizePath(path))) return;
+		this.crdtEnrollment?.reset(noteId);
+		if (path) this.hibernateIfIdle(path, noteId);
 	}
 
 	/** Cheap mid-session divergence heal for the just-opened note (rework #6 —

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -623,6 +623,58 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect((engine as any).queue.size).toBe(0); // the settle still dequeues
 	});
 
+	test("heal-room release: settle after a RENAME re-resolves the path — never closes the doc live-bound at its NEW path", async () => {
+		const { engine, reset, closeDoc, map } = crdtEngine();
+		// Entry enqueued under the OLD path; the note was renamed and is now
+		// OPEN in the editor at the NEW path.
+		map.set("renamed.md", "note-id-1"); // NoteIdMap: note-id-1 now lives at renamed.md
+		engine.setLiveBoundCheck((p: string) => p === "renamed.md");
+		await (engine as any).queue.enqueue({
+			path: "owned.md",
+			action: "upsert",
+			timestamp: 1,
+			crdt: true,
+			noteId: "note-id-1",
+		});
+		(engine as any).pendingQueueDeliveries.set("note-id-1", { path: "owned.md" });
+
+		await engine.commitCrdtConvergence("note-id-1");
+
+		// Live-bound at the CURRENT path: the room must survive — releasing on
+		// the stale enqueue-time path would closeDoc the editor's live doc.
+		expect(reset).not.toHaveBeenCalled();
+		expect(closeDoc).not.toHaveBeenCalled();
+	});
+
+	test("heal-room release: a DEFERRED commit (doc not at staged row) does NOT release the in-flight heal", async () => {
+		const { engine, enroll, reset, closeDoc, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		mockApp.vault.cachedRead.mockResolvedValue("old base");
+		engine.setLiveBoundCheck(() => false);
+		engine.importSyncState({
+			"owned.md": { hash: fnv1a("old base"), version: 1, serverHash: "old-hash" },
+		});
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "new server body",
+			content_hash: "new-hash",
+			version: 2,
+			mtime: 50,
+		} as any);
+		expect(enroll).toHaveBeenCalledTimes(1);
+
+		// Doc has NOT integrated the staged row yet — commit must defer AND
+		// leave the room alone (the next frame re-runs the check).
+		projectedText.mockResolvedValue("stale partial");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		expect(reset).toHaveBeenCalledTimes(1); // only the heal's own reset
+		expect(closeDoc).not.toHaveBeenCalled();
+	});
+
 	test("heal-room release: a frame with nothing staged and nothing queued stays a pure no-op", async () => {
 		const { engine, reset, closeDoc } = crdtEngine();
 		engine.setLiveBoundCheck(() => false);

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -135,12 +135,14 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 				await engine.flushFromCrdt(path, await projectedText());
 			}
 		});
+		const closeDoc = mock();
 		engine.setCrdtManager({
 			applyLocalEdit: mock().mockImplementation(async (_id: string, c: string) => c),
 			applyRemoteUpdate,
 			encodeStateVector,
 			hasPendingGap,
 			projectedText,
+			closeDoc,
 		} as any);
 		const enroll = mock();
 		const reset = mock();
@@ -154,6 +156,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 			encodeStateVector,
 			hasPendingGap,
 			projectedText,
+			closeDoc,
 		};
 	}
 
@@ -526,6 +529,108 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		// staged anymore) — does not throw, does not touch syncState again.
 		await engine.commitCrdtConvergence("note-id-1");
 		expect(engine.exportSyncState()["owned.md"]).toEqual(state);
+	});
+
+	// -----------------------------------------------------------------------
+	// Heal-room release (fan-out idle invariant): the diverged-cold-note heal
+	// and the queued-delivery nudge open a TRANSIENT room via reset+enroll.
+	// Once the convergence commits (or the delivery settles), the room must be
+	// RELEASED — enrollment un-marked (so a future heal can re-handshake) and
+	// the doc hibernated. Without the release every healed idle note holds a
+	// room for the rest of the session (the e2e fan-out precondition flake,
+	// test_cold_send_over_fanout_opens_no_room).
+	// -----------------------------------------------------------------------
+
+	test("heal-room release: verified commit for an IDLE note resets enrollment and hibernates the doc", async () => {
+		const { engine, enroll, reset, closeDoc, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		mockApp.vault.cachedRead.mockResolvedValue("old base");
+		engine.setLiveBoundCheck(() => false);
+		engine.importSyncState({
+			"owned.md": { hash: fnv1a("old base"), version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "new server body",
+			content_hash: "new-hash",
+			version: 2,
+			mtime: 50,
+		} as any);
+		// The cold heal opened the transient room (reset+enroll once).
+		expect(enroll).toHaveBeenCalledTimes(1);
+		expect(reset).toHaveBeenCalledTimes(1);
+
+		projectedText.mockResolvedValue("new server body");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		// Release: a SECOND reset (un-mark, so a future heal re-handshakes) and
+		// the doc hibernated — the idle note holds no room after convergence.
+		expect(reset).toHaveBeenCalledTimes(2);
+		expect(reset.mock.calls[1]?.[0]).toBe("note-id-1");
+		expect(closeDoc).toHaveBeenCalledWith("note-id-1");
+		// No re-enroll — released, not re-opened.
+		expect(enroll).toHaveBeenCalledTimes(1);
+	});
+
+	test("heal-room release: LIVE-BOUND note keeps its room after commit (editor owns it)", async () => {
+		const { engine, reset, closeDoc, projectedText } = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({
+			"owned.md": { hash: 1, version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "diverged body",
+			content_hash: "new-hash",
+			version: 2,
+			mtime: 50,
+		} as any);
+		expect(reset).toHaveBeenCalledTimes(1); // the heal's own reset+enroll
+
+		projectedText.mockResolvedValue("diverged body");
+		await engine.commitCrdtConvergence("note-id-1");
+
+		// Live-bound: the room stays — no release reset, no hibernate.
+		expect(reset).toHaveBeenCalledTimes(1);
+		expect(closeDoc).not.toHaveBeenCalled();
+	});
+
+	test("heal-room release: queued-delivery settle releases the nudge room for an idle note", async () => {
+		const { engine, reset, closeDoc } = crdtEngine();
+		engine.setLiveBoundCheck(() => false);
+		await (engine as any).queue.enqueue({
+			path: "owned.md",
+			action: "upsert",
+			timestamp: 1,
+			crdt: true,
+			noteId: "note-id-1",
+		});
+		(engine as any).pendingQueueDeliveries.set("note-id-1", { path: "owned.md" });
+
+		await engine.commitCrdtConvergence("note-id-1");
+
+		expect(reset).toHaveBeenCalledWith("note-id-1");
+		expect(closeDoc).toHaveBeenCalledWith("note-id-1");
+		expect((engine as any).queue.size).toBe(0); // the settle still dequeues
+	});
+
+	test("heal-room release: a frame with nothing staged and nothing queued stays a pure no-op", async () => {
+		const { engine, reset, closeDoc } = crdtEngine();
+		engine.setLiveBoundCheck(() => false);
+
+		await engine.commitCrdtConvergence("note-id-1");
+
+		expect(reset).not.toHaveBeenCalled();
+		expect(closeDoc).not.toHaveBeenCalled();
 	});
 
 	test("fix wave 1 (c): commit with nothing staged for the id is a no-op", async () => {


### PR DESCRIPTION
## Summary

Root-causes the pre-existing `test_cold_send_over_fanout_opens_no_room` e2e flake (failing on main since at least 01:48 UTC today, and currently red on #302/#303's gates).

**Mechanism:** the diverged-cold-note heal (`CRDT catch-up: diverged cold note, socket re-handshake`) and the queued-delivery nudge open a transient CRDT room via `reset+enroll` — but `commitCrdtConvergence` never released it. The once-per-session `enrolled` mark kept every healed idle note's room (client doc + server SharedDoc) open for the rest of the session, violating the fan-out idle invariant. The e2e precondition (`_confirm_room_free`) is the canary: it trips whenever a heal fires between establish and the assert. On mass divergence (account swap re-keying every row's HMAC) this is the connect-storm resource shape the fan-out model was built to prevent.

**Fix:** `releaseHealRoom(noteId, path)` — `enrollment.reset` (un-marks + clears the channel's once-per-doc STEP1 gate so a *future* heal can re-handshake) + `hibernateIfIdle`, called on all three commit exits: verified commit, queued-delivery settle, id-unmapped-since-staging. Live-bound notes keep their room (editor owns lifecycle); a frame with nothing pending stays a pure no-op.

## Testing (TDD)

- 2 RED→GREEN tests (idle release after verified commit; queued-settle release) + 2 behavior pins (live-bound keeps room; nothing-pending no-op) in `tests/sync-catchup.test.ts`
- Full suite: 2260 pass / 0 fail; `tsc` + esbuild + `biome ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj