### PR TITLE
feat: sync preview on the op-log socket feed (redo of #311, startup + vault-switch fixed)

### DIFF
--- a/main.js
+++ b/main.js
@@ -18176,6 +18176,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  binding. Set from the plugin layer; defaults to "never bound" so non-CRDT
      *  and headless contexts behave exactly as before. */
     this.isLiveBound = () => !1;
+    /** How long enumerateServerState waits for the op-log socket to become
+     *  enumerable (catch-up wired + manager set + channel live) before failing
+     *  the preview. Covers the startup join race and the vault-switch rebuild.
+     *  A field so tests can shrink it. */
+    this.enumerateWaitMs = 8e3;
     /** Persistent record of files that failed to sync, with reason. Surfaced
      *  in the Sync Center "Issues" panel and used to short-circuit the offline
      *  queue for terminal failures (e.g. 413 Payload Too Large). */
@@ -19646,8 +19651,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  preview was their last caller). Throws when the channel is not live: the
    *  preview must error visibly, never render a wrong empty plan. */
   async enumerateServerState() {
-    var _a, _b;
-    if (!this.crdtCatchupSince || !this.crdt || !((_b = (_a = this.crdtLive) == null ? void 0 : _a.call(this)) != null && _b))
+    var _a, _b, _c, _d;
+    let deadline = Date.now() + this.enumerateWaitMs;
+    for (; (!this.crdtCatchupSince || !this.crdt || !((_b = (_a = this.crdtLive) == null ? void 0 : _a.call(this)) != null && _b)) && Date.now() < deadline; )
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    if (!this.crdtCatchupSince || !this.crdt || !((_d = (_c = this.crdtLive) == null ? void 0 : _c.call(this)) != null && _d))
       throw new Error("Sync preview needs the live socket (op-log enumeration)");
     let byId = /* @__PURE__ */ new Map(), attachments = /* @__PURE__ */ new Map(), cursor = 0;
     for (let page = 0; page < 1e5; page++) {
@@ -24474,7 +24482,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           createVault: (name) => this.api.createVault(name),
           applyVaultChange: async (id2, name) => {
             var _a2, _b2;
-            return this.settings.vaultId = id2, this.settings.remoteVaultName = name, this.api.setVaultId(id2), this.syncEngine.updateSettings(this.settings), await this.syncEngine.resetForVaultChange(), this.syncGateAcceptedFor = null, this.lastMapReconcileAt = 0, (_a2 = this.crdtWiring) == null || _a2.clearStrandHealAttempts(), this.syncEngine.setSyncBlocked(!0), await this.savePluginData(this.syncEngine.getLastSync()), (_b2 = this.settingTab) == null || _b2.rerender(), this.syncEngine.computeSyncPlan("full");
+            return this.settings.vaultId = id2, this.settings.remoteVaultName = name, this.api.setVaultId(id2), this.syncEngine.updateSettings(this.settings), await this.syncEngine.resetForVaultChange(), this.syncGateAcceptedFor = null, this.lastMapReconcileAt = 0, (_a2 = this.crdtWiring) == null || _a2.clearStrandHealAttempts(), this.syncEngine.setSyncBlocked(!0), await this.savePluginData(this.syncEngine.getLastSync()), (_b2 = this.settingTab) == null || _b2.rerender(), this.setupNoteStream(), this.syncEngine.computeSyncPlan("full");
           }
         });
         this.syncEngine.computeSyncPlan("full").then((plan) => modal.setPlan(plan)).catch((e) => {

--- a/main.js
+++ b/main.js
@@ -997,9 +997,6 @@ var EngramApi = class _EngramApi {
      *  a slow link legitimately outlives the note deadline. */
     this.requestTimeoutMs = 15e3;
     this.attachmentTimeoutMs = 12e4;
-    /** Bulk pages (batch push, change feeds) can carry many full note bodies —
-     *  15s starves a slow link, 120s is a transfer budget they don't need. */
-    this.bulkTimeoutMs = 6e4;
     /** In-flight sendRequest calls, so a channel-disconnect signal can probe
      *  for wedged connections and fail them early (see failWedgedRequests). */
     this.inflight = /* @__PURE__ */ new Set();
@@ -1101,7 +1098,7 @@ var EngramApi = class _EngramApi {
       ...extraHeaders
     }, activeVaultId = this.getActiveVaultId();
     activeVaultId && (headers["X-Vault-ID"] = activeVaultId), this.deviceId && (headers["X-Device-Id"] = this.deviceId), body !== void 0 && (headers["Content-Type"] = "application/json");
-    let attachmentMeta = path === "/attachments/changes" || path.startsWith("/attachments/changes?"), attachmentTransfer = path.startsWith("/attachments") && !attachmentMeta && (method === "POST" || method === "GET"), bulk = path === "/notes/batch" || path.startsWith("/notes/changes?") || path === "/sync/changes" || path.startsWith("/sync/changes?"), timeoutMs = attachmentTransfer ? this.attachmentTimeoutMs : bulk ? this.bulkTimeoutMs : this.requestTimeoutMs, raw = (0, import_obsidian.requestUrl)({
+    let attachmentTransfer = path.startsWith("/attachments") && (method === "POST" || method === "GET"), timeoutMs = attachmentTransfer ? this.attachmentTimeoutMs : this.requestTimeoutMs, raw = (0, import_obsidian.requestUrl)({
       url: `${this.baseUrl}${path}`,
       method,
       headers,
@@ -1237,14 +1234,6 @@ var EngramApi = class _EngramApi {
       throw e;
     }
   }
-  /** Get changes since a timestamp.
-   *  Protocol rev: pass limit/cursor to page through large vaults and
-   *  fields:"meta" to receive content_hash instead of content. Pre-rev
-   *  backends ignore the extra params and return the legacy full response. */
-  async getChanges(since, opts) {
-    let params2 = new URLSearchParams({ since });
-    return (opts == null ? void 0 : opts.limit) !== void 0 && params2.set("limit", String(opts.limit)), opts != null && opts.cursor && params2.set("cursor", opts.cursor), opts != null && opts.fields && params2.set("fields", opts.fields), (await this.request("GET", `/notes/changes?${params2.toString()}`)).json;
-  }
   /** Get full note by path. */
   async getNote(path) {
     let encoded = encodePath(path);
@@ -1298,11 +1287,6 @@ var EngramApi = class _EngramApi {
   /** Push batched log entries to the server for remote debugging. */
   async pushLogs(entries) {
     await this.request("POST", "/logs", { logs: entries });
-  }
-  /** Get attachment changes since a timestamp. */
-  async getAttachmentChanges(since) {
-    let encoded = encodeURIComponent(since);
-    return (await this.request("GET", `/attachments/changes?since=${encoded}`)).json;
   }
   // --- Explicit folder markers (kind='folder' rows) ---
   /** Create an explicit empty folder marker. Server is idempotent — repeated
@@ -1648,6 +1632,13 @@ var LARGE_FRAME_WARN_BYTES = 1e6, NoteChannel = class {
   }
   get userTopic() {
     return `user:${this.userId}`;
+  }
+  /** The server vault this channel is joined to (`crdt:{userId}:{vaultId}`),
+   *  or null before a vault is bound. Callers reading vault-scoped state off
+   *  the socket must confirm this matches their intended vault — a vault
+   *  switch that skips setupNoteStream leaves this channel on the old vault. */
+  getVaultId() {
+    return this.vaultId;
   }
   get crdtTopic() {
     return this.vaultId ? `crdt:${this.userId}:${this.vaultId}` : null;
@@ -19608,19 +19599,6 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     return !!this.noteIdMap && !this.noteIdMap.get(path) && this.recentlyFlushed.has((0, import_obsidian21.normalizePath)(path));
   }
   // --- Pull: Engram → local vault ---
-  /** Pull remote changes and apply to vault. */
-  /** Page through GET /notes/changes until has_more=false (protocol rev).
-   *  Pre-rev backends return no has_more — the loop exits after one page,
-   *  preserving legacy behavior. fields:"meta" requests hash-only pages. */
-  async fetchAllNoteChanges(since, fields) {
-    let all2 = [], cursor, serverTime = "";
-    for (let page = 0; page < 1e4; page++) {
-      let resp = await this.api.getChanges(since, { limit: 500, cursor, fields });
-      if (all2.push(...resp.changes), serverTime = resp.server_time, !resp.has_more || !resp.next_cursor) break;
-      cursor = resp.next_cursor;
-    }
-    return { changes: all2, server_time: serverTime };
-  }
   /** Free `noteId`'s Y.Doc after a remote update has been applied and its head
    *  durably recorded (P3, plugin #232-series). Idle notes are not
    *  channel-enrolled under the fan-out model (P2 removed lazyEnrollment) —
@@ -19657,6 +19635,37 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  cursor — a "replace remote with local" must download nothing (that would
    *  materialize remote extras as local orphans, which then resurrect on the
    *  next sync), and mustn't steal seq progress from a later genuine catch-up. */
+  /** Enumerate the FULL current server state from the seq-ordered op-log
+   *  (`crdt_catchup_since` from seq 0). Nothing is applied and the real
+   *  catch-up cursor is untouched — this is a pure read. Ops fold per note_id
+   *  with last-seq-wins, so a rename collapses to its FINAL path (no ghost
+   *  old-path row — better than the retired REST delta, which listed both)
+   *  and a tombstone folds to `deleted: true`. Attachments ride the same feed
+   *  and fold by path. Replaced GET /notes/changes + GET /attachments/changes
+   *  as `computeSyncPlan`'s inventory (#304, REST-purge Bucket C — the
+   *  preview was their last caller). Throws when the channel is not live: the
+   *  preview must error visibly, never render a wrong empty plan. */
+  async enumerateServerState() {
+    var _a, _b;
+    if (!this.crdtCatchupSince || !this.crdt || !((_b = (_a = this.crdtLive) == null ? void 0 : _a.call(this)) != null && _b))
+      throw new Error("Sync preview needs the live socket (op-log enumeration)");
+    let byId = /* @__PURE__ */ new Map(), attachments = /* @__PURE__ */ new Map(), cursor = 0;
+    for (let page = 0; page < 1e5; page++) {
+      let resp = await this.crdtCatchupSince(cursor, 500);
+      for (let c of resp.changes)
+        typeof c.seq == "number" && c.seq > cursor && (cursor = c.seq), c.type === "attachment" ? c.path && attachments.set(c.path, { deleted: c.deleted }) : c.id && c.path && byId.set(c.id, c);
+      if (!resp.has_more) break;
+      typeof resp.next_seq == "number" && resp.next_seq > cursor && (cursor = resp.next_seq);
+    }
+    let notes = /* @__PURE__ */ new Map();
+    for (let c of byId.values())
+      notes.set(c.path, {
+        deleted: c.deleted,
+        content: c.content,
+        contentHash: c.content_hash
+      });
+    return { notes, attachments };
+  }
   async catchupViaSeqReplay(opts = {}) {
     var _a, _b, _c;
     let serverIds = /* @__PURE__ */ new Set(), serverAttachmentPaths = /* @__PURE__ */ new Set();
@@ -21281,44 +21290,43 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  - "full"     — bidirectional: compute toPush, toPull, conflicts, deletions
    *  - "push-all" — push only: compute toPush, skip toPull
    *  - "pull-all" — pull only: compute toPull, skip toPush
+   *
+   *  Server state comes from ONE from-genesis op-log enumeration
+   *  (`enumerateServerState`) — delta and inventory in a single walk. The
+   *  REST-era split (manifest for inventory, GET /notes/changes for the
+   *  delta, epoch-widening when the manifest was missing) died with those
+   *  endpoints (#304). Per-path classification:
+   *  - identical bytes (row carries content)            → clean, skip
+   *  - server unchanged (row hash == recorded serverHash):
+   *      local unchanged → clean · local changed → toPush
+   *  - server changed: local unchanged → toPull · both changed → conflict
    */
   async computeSyncPlan(mode) {
-    let epoch = "1970-01-01T00:00:00Z", manifestNotePaths = null, manifestAttachPaths = null, manifestNoteCount = null, manifestAttachCount = null;
-    if (mode === "full" && this.lastSync) {
-      let manifest = await this.api.getManifest();
-      manifest && (manifestNotePaths = new Set(manifest.notes.map((n) => n.path)), manifestAttachPaths = new Set(manifest.attachments.map((a) => a.path)), manifestNoteCount = manifest.notes.length, manifestAttachCount = manifest.attachments.length);
-    }
-    let needsDeltaAsInventory = mode === "full" && this.lastSync !== "" && manifestNotePaths === null, since = mode !== "full" || needsDeltaAsInventory ? epoch : this.lastSync || epoch, [noteResp, attachResp] = await Promise.all([
-      this.fetchAllNoteChanges(since),
-      this.api.getAttachmentChanges(since)
-    ]), serverNotes = /* @__PURE__ */ new Map();
-    for (let c of noteResp.changes)
-      serverNotes.set(c.path, { deleted: c.deleted });
-    let serverAttachments = /* @__PURE__ */ new Map();
-    for (let c of attachResp.changes)
-      serverAttachments.set(c.path, { deleted: c.deleted });
-    let serverHasNote = (path) => manifestNotePaths ? manifestNotePaths.has(path) : serverNotes.has(path), serverHasAttach = (path) => manifestAttachPaths ? manifestAttachPaths.has(path) : serverAttachments.has(path), syncable = this.app.vault.getFiles().filter((f) => this.isSyncable(f) && !this.shouldIgnore(f.path)), localNotes = [], localAttachments = [];
+    let server = await this.enumerateServerState(), serverNotes = server.notes, serverAttachments = server.attachments, syncable = this.app.vault.getFiles().filter((f) => this.isSyncable(f) && !this.shouldIgnore(f.path)), localNotes = [], localAttachments = [];
     for (let f of syncable)
       this.isBinaryFile(f) ? localAttachments.push(f.path) : localNotes.push(f.path);
-    let localNoteSet = new Set(localNotes), localAttachSet = new Set(localAttachments), toPullNotes = [], conflictNotes = [], toDeleteLocal = [];
-    for (let [path, { deleted }] of serverNotes) {
-      if (deleted) {
+    let localNoteSet = new Set(localNotes), localAttachSet = new Set(localAttachments), toPullNotes = [], conflictNotes = [], toDeleteLocal = [], toPushNotes = [];
+    for (let [path, row] of serverNotes) {
+      if (row.deleted) {
         localNoteSet.has(path) && toDeleteLocal.push(path);
         continue;
       }
-      if (localNoteSet.has(path)) {
-        let file = this.app.vault.getFileByPath(path);
-        if (file) {
-          let content = await this.app.vault.cachedRead(file), localHash = fnv1a(content), serverChange = noteResp.changes.find((c) => c.path === path), serverHash = (serverChange == null ? void 0 : serverChange.content) !== void 0 ? fnv1a(serverChange.content) : void 0;
-          if (serverHash !== void 0 && localHash === serverHash)
-            continue;
-          let synced = this.syncState.get(path);
-          (synced == null ? void 0 : synced.hash) !== void 0 && localHash !== synced.hash ? conflictNotes.push(path) : toPullNotes.push(path);
-        } else
-          toPullNotes.push(path);
-      } else
+      if (!localNoteSet.has(path)) {
         toPullNotes.push(path);
+        continue;
+      }
+      let file = this.app.vault.getFileByPath(path);
+      if (!file) {
+        toPullNotes.push(path);
+        continue;
+      }
+      let content = await this.app.vault.cachedRead(file), localHash = fnv1a(content);
+      if (row.content !== void 0 && localHash === fnv1a(row.content)) continue;
+      let synced = this.syncState.get(path), localChanged = (synced == null ? void 0 : synced.hash) !== void 0 && localHash !== synced.hash;
+      row.contentHash !== void 0 && (synced == null ? void 0 : synced.serverHash) !== void 0 && row.contentHash === synced.serverHash ? localChanged && toPushNotes.push(path) : localChanged ? conflictNotes.push(path) : toPullNotes.push(path);
     }
+    for (let path of localNotes)
+      serverNotes.has(path) || toPushNotes.push(path);
     let toPullAttachments = [], toDeleteLocalAttach = [];
     for (let [path, { deleted }] of serverAttachments) {
       if (deleted) {
@@ -21327,29 +21335,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       }
       localAttachSet.has(path) || toPullAttachments.push(path);
     }
-    let toPushNotes = [];
-    for (let path of localNotes) {
-      if (!serverHasNote(path)) {
-        toPushNotes.push(path);
-        continue;
-      }
-      if (serverNotes.has(path)) continue;
-      let file = this.app.vault.getFileByPath(path);
-      if (!file) continue;
-      let content = await this.app.vault.cachedRead(file), localHash = fnv1a(content), synced = this.syncState.get(path);
-      (synced == null ? void 0 : synced.hash) !== void 0 && synced.hash !== localHash && toPushNotes.push(path);
-    }
     let toPushAttachments = [];
     for (let path of localAttachments)
-      serverHasAttach(path) || toPushAttachments.push(path);
-    let localFolderCount = countFolders([...localNotes, ...localAttachments]), serverPaths = manifestNotePaths ? [...manifestNotePaths, ...manifestAttachPaths != null ? manifestAttachPaths : /* @__PURE__ */ new Set()] : [
-      ...[...serverNotes.entries()].filter(([, v]) => !v.deleted).map(([k]) => k),
-      ...[...serverAttachments.entries()].filter(([, v]) => !v.deleted).map(([k]) => k)
-    ], serverFolderCount = countFolders(serverPaths);
+      serverAttachments.has(path) || toPushAttachments.push(path);
+    let liveNotePaths = [...serverNotes.entries()].filter(([, v]) => !v.deleted).map(([k]) => k), liveAttachPaths = [...serverAttachments.entries()].filter(([, v]) => !v.deleted).map(([k]) => k), serverPaths = [...liveNotePaths, ...liveAttachPaths], localFolderCount = countFolders([...localNotes, ...localAttachments]), serverFolderCount = countFolders(serverPaths);
     return {
       vaultName: this.app.vault.getName(),
-      serverNoteCount: manifestNoteCount != null ? manifestNoteCount : [...serverNotes.values()].filter((v) => !v.deleted).length,
-      serverAttachmentCount: manifestAttachCount != null ? manifestAttachCount : [...serverAttachments.values()].filter((v) => !v.deleted).length,
+      serverNoteCount: liveNotePaths.length,
+      serverAttachmentCount: liveAttachPaths.length,
       serverFolderCount,
       localNoteCount: localNotes.length,
       localAttachmentCount: localAttachments.length,
@@ -24253,9 +24246,11 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       }, channel.onPlanState = (raw) => {
         let parsed = parsePlanState(raw, Date.now());
         parsed && queueMicrotask(() => this.syncEngine.applyPlanState(parsed));
-      }, this.noteStream = channel, this.authProvider && this.noteStream.setAuthProvider(this.authProvider), this.syncEngine.setCrdtCreate((id2, path) => channel.crdtCreate(id2, path)), this.syncEngine.setCrdtCreateBatch((creates) => channel.crdtCreateBatch(creates)), this.syncEngine.setCrdtDelete((id2) => channel.crdtDeleteAcked(id2)), this.syncEngine.setCrdtCatchupSince(
-        (cursorSeq, limit) => channel.crdtCatchupSince(cursorSeq, limit)
-      ), this.settings.vaultId) {
+      }, this.noteStream = channel, this.authProvider && this.noteStream.setAuthProvider(this.authProvider), this.syncEngine.setCrdtCreate((id2, path) => channel.crdtCreate(id2, path)), this.syncEngine.setCrdtCreateBatch((creates) => channel.crdtCreateBatch(creates)), this.syncEngine.setCrdtDelete((id2) => channel.crdtDeleteAcked(id2)), this.syncEngine.setCrdtCatchupSince((cursorSeq, limit) => {
+        if (channel.getVaultId() !== this.settings.vaultId)
+          throw new Error("Sync preview needs the live socket (vault switching)");
+        return channel.crdtCatchupSince(cursorSeq, limit);
+      }), this.settings.vaultId) {
         let dbPrefix = this.settings.vaultId;
         if (typeof indexedDB.databases == "function" ? await ensureDocSchema(dbPrefix, window.localStorage, {
           list: () => indexedDB.databases(),

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,10 +11,8 @@ import { BeaconBuffer } from "./observability/beacon";
 import { newTraceContext } from "./observability/traceGen";
 import { rlog } from "./remote-log";
 import type {
-	AttachmentChangesResponse,
 	AttachmentDetail,
 	AttachmentResponse,
-	ChangesResponse,
 	DeleteResponse,
 	ManifestResponse,
 	NoteDetail,
@@ -64,9 +62,6 @@ export class EngramApi {
 	 *  a slow link legitimately outlives the note deadline. */
 	requestTimeoutMs = 15_000;
 	attachmentTimeoutMs = 120_000;
-	/** Bulk pages (batch push, change feeds) can carry many full note bodies —
-	 *  15s starves a slow link, 120s is a transfer budget they don't need. */
-	bulkTimeoutMs = 60_000;
 
 	/** In-flight sendRequest calls, so a channel-disconnect signal can probe
 	 *  for wedged connections and fail them early (see failWedgedRequests). */
@@ -250,29 +245,12 @@ export class EngramApi {
 		}
 		// Deadline classes. Only actual attachment byte transfers earn 120s:
 		// upload (POST /attachments) and download (GET /attachments/<path>).
-		// The EXACT-endpoint check matters — "/attachments/changes" is the
-		// metadata feed, but "/attachments/changes.pdf" is a real file download
-		// (a prefix match starved any attachment literally named changes*).
-		// Bulk pages that legitimately carry many full note bodies (batch push,
-		// bootstrap/cursor change pages) get a middle deadline: 15s is too
-		// tight for a slow link, but they stay wedge-abortable (below) so a
-		// wedged pull still recovers in probe time, not 60s.
-		const attachmentMeta =
-			path === "/attachments/changes" || path.startsWith("/attachments/changes?");
+		// Everything else is note/metadata traffic on the short deadline —
+		// the REST bulk-page class (batch push, change feeds) died with the
+		// socket-only migration (#304).
 		const attachmentTransfer =
-			path.startsWith("/attachments") &&
-			!attachmentMeta &&
-			(method === "POST" || method === "GET");
-		const bulk =
-			path === "/notes/batch" ||
-			path.startsWith("/notes/changes?") ||
-			path === "/sync/changes" ||
-			path.startsWith("/sync/changes?");
-		const timeoutMs = attachmentTransfer
-			? this.attachmentTimeoutMs
-			: bulk
-				? this.bulkTimeoutMs
-				: this.requestTimeoutMs;
+			path.startsWith("/attachments") && (method === "POST" || method === "GET");
+		const timeoutMs = attachmentTransfer ? this.attachmentTimeoutMs : this.requestTimeoutMs;
 		const raw = requestUrl({
 			url: `${this.baseUrl}${path}`,
 			method,
@@ -476,22 +454,6 @@ export class EngramApi {
 		}
 	}
 
-	/** Get changes since a timestamp.
-	 *  Protocol rev: pass limit/cursor to page through large vaults and
-	 *  fields:"meta" to receive content_hash instead of content. Pre-rev
-	 *  backends ignore the extra params and return the legacy full response. */
-	async getChanges(
-		since: string,
-		opts?: { limit?: number; cursor?: string; fields?: "meta" },
-	): Promise<ChangesResponse> {
-		const params = new URLSearchParams({ since });
-		if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
-		if (opts?.cursor) params.set("cursor", opts.cursor);
-		if (opts?.fields) params.set("fields", opts.fields);
-		const resp = await this.request("GET", `/notes/changes?${params.toString()}`);
-		return resp.json as ChangesResponse;
-	}
-
 	/** Get full note by path. */
 	async getNote(path: string): Promise<NoteDetail> {
 		const encoded = encodePath(path);
@@ -588,13 +550,6 @@ export class EngramApi {
 		}[],
 	): Promise<void> {
 		await this.request("POST", "/logs", { logs: entries });
-	}
-
-	/** Get attachment changes since a timestamp. */
-	async getAttachmentChanges(since: string): Promise<AttachmentChangesResponse> {
-		const encoded = encodeURIComponent(since);
-		const resp = await this.request("GET", `/attachments/changes?since=${encoded}`);
-		return resp.json as AttachmentChangesResponse;
 	}
 
 	// --- Explicit folder markers (kind='folder' rows) ---

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -301,6 +301,14 @@ export class NoteChannel {
 		return `user:${this.userId}`;
 	}
 
+	/** The server vault this channel is joined to (`crdt:{userId}:{vaultId}`),
+	 *  or null before a vault is bound. Callers reading vault-scoped state off
+	 *  the socket must confirm this matches their intended vault — a vault
+	 *  switch that skips setupNoteStream leaves this channel on the old vault. */
+	getVaultId(): string | null {
+		return this.vaultId;
+	}
+
 	private get crdtTopic(): string | null {
 		// Vault-scoped only: no vault bound yet → no crdt: room to join.
 		return this.vaultId ? `crdt:${this.userId}:${this.vaultId}` : null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1858,9 +1858,18 @@ export default class EngramSyncPlugin extends Plugin {
 				// Delete (and durable create genesis) now route through the plugin-
 				// lifetime crdtOpQueue, wired once in onload, not per-channel here.
 				// Single-path convergence: seq-ordered op-log replayed over the socket.
-				this.syncEngine.setCrdtCatchupSince((cursorSeq, limit) =>
-					channel.crdtCatchupSince(cursorSeq, limit),
-				);
+				this.syncEngine.setCrdtCatchupSince((cursorSeq, limit) => {
+					// The op-log feed is vault-scoped. A vault switch that skips
+					// setupNoteStream (applyVaultChange, to avoid stacking a modal)
+					// leaves this channel joined to the OLD vault while
+					// settings.vaultId already points at the new one — enumerating
+					// here would render the old vault's state as the new vault's
+					// plan. Refuse rather than mislead; the caller surfaces it.
+					if (channel.getVaultId() !== this.settings.vaultId) {
+						throw new Error("Sync preview needs the live socket (vault switching)");
+					}
+					return channel.crdtCatchupSince(cursorSeq, limit);
+				});
 
 				// Wire CRDT transport through this channel.
 				// Only wire when vaultId is known: the crdt: topic is keyed by

--- a/src/main.ts
+++ b/src/main.ts
@@ -1859,12 +1859,15 @@ export default class EngramSyncPlugin extends Plugin {
 				// lifetime crdtOpQueue, wired once in onload, not per-channel here.
 				// Single-path convergence: seq-ordered op-log replayed over the socket.
 				this.syncEngine.setCrdtCatchupSince((cursorSeq, limit) => {
-					// The op-log feed is vault-scoped. A vault switch that skips
-					// setupNoteStream (applyVaultChange, to avoid stacking a modal)
-					// leaves this channel joined to the OLD vault while
-					// settings.vaultId already points at the new one — enumerating
-					// here would render the old vault's state as the new vault's
-					// plan. Refuse rather than mislead; the caller surfaces it.
+					// The op-log feed is vault-scoped. applyVaultChange rebuilds the
+					// stream for the new vault before computing the plan, so this
+					// closure normally captures the current vault's channel. This
+					// guard is defense against any future path that flips
+					// settings.vaultId without rebuilding: a stale channel would
+					// enumerate the OLD vault and render it as the new vault's plan.
+					// Refuse rather than mislead (enumerateServerState waits for the
+					// rebuilt channel to go live, so this fires only on a true stale
+					// mismatch, not the rebuild window).
 					if (channel.getVaultId() !== this.settings.vaultId) {
 						throw new Error("Sync preview needs the live socket (vault switching)");
 					}
@@ -2276,15 +2279,23 @@ export default class EngramSyncPlugin extends Plugin {
 						// Strand-heal retry counts are scoped to the previous vault's
 						// note_ids (final review MINOR-6) — stale counts here could
 						// prematurely give up on a note_id that happens to be reused
-						// in the new vault. (The wiring is also rebuilt on the next
-						// setupNoteStream, but clear defensively — the rebuild is not
-						// this handler's contract.)
+						// in the new vault.
 						this.crdtWiring?.clearStrandHealAttempts();
 						this.syncEngine.setSyncBlocked(true);
 						await this.savePluginData(this.syncEngine.getLastSync());
 						// Re-render the settings tab so the vault name span and
 						// any other vault-derived UI pick up the switch.
 						this.settingTab?.rerender();
+						// Rebuild the stream for the NEW vault before computing the
+						// plan: the preview enumerates server state off the crdt:
+						// op-log socket, which is vault-scoped. The connection key
+						// includes the vault, so this tears down the old vault's
+						// channel and rejoins crdt: for the new one. setupNoteStream
+						// (unlike saveSettings) does NOT re-fire doSyncWithFirstSyncCheck,
+						// so it won't stack a second modal. computeSyncPlan's
+						// enumerateServerState waits for the new join to land before
+						// enumerating (SyncEngine.enumerateWaitMs).
+						this.setupNoteStream();
 						return this.syncEngine.computeSyncPlan("full");
 					},
 				});

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1062,6 +1062,12 @@ export class SyncEngine {
 		this.isLiveBound = fn;
 	}
 
+	/** How long enumerateServerState waits for the op-log socket to become
+	 *  enumerable (catch-up wired + manager set + channel live) before failing
+	 *  the preview. Covers the startup join race and the vault-switch rebuild.
+	 *  A field so tests can shrink it. */
+	private enumerateWaitMs = 8000;
+
 	/** Adopt-first seed gate input (CrdtManager.isUnchangedSynced): true when
 	 *  `content` hashes to exactly what this engine last synced for `path` —
 	 *  i.e. the server already holds this content, so a history-less Y.Doc must
@@ -3226,6 +3232,20 @@ export class SyncEngine {
 		notes: Map<string, { deleted: boolean; content?: string; contentHash?: string }>;
 		attachments: Map<string, { deleted: boolean }>;
 	}> {
+		// The preview reads server state off the live op-log socket. On startup
+		// the plan is computed the moment the user channel joins — often before
+		// the crdt: topic join lands (onCrdtJoined) — and on a vault switch the
+		// stream is torn down and rebuilt underneath us. Both leave the socket
+		// briefly non-enumerable; wait for it rather than failing the preview
+		// outright (a vault-switch/startup false-negative is worse than a short
+		// spinner). Falls through to the offline error only after the budget.
+		const deadline = Date.now() + this.enumerateWaitMs;
+		while (
+			(!this.crdtCatchupSince || !this.crdt || !(this.crdtLive?.() ?? false)) &&
+			Date.now() < deadline
+		) {
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
 		if (!this.crdtCatchupSince || !this.crdt || !(this.crdtLive?.() ?? false)) {
 			throw new Error("Sync preview needs the live socket (op-log enumeration)");
 		}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3244,7 +3244,7 @@ export class SyncEngine {
 			(!this.crdtCatchupSince || !this.crdt || !(this.crdtLive?.() ?? false)) &&
 			Date.now() < deadline
 		) {
-			await new Promise((resolve) => setTimeout(resolve, 100));
+			await new Promise((resolve) => window.setTimeout(resolve, 100));
 		}
 		if (!this.crdtCatchupSince || !this.crdt || !(this.crdtLive?.() ?? false)) {
 			throw new Error("Sync preview needs the live socket (op-log enumeration)");

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3134,29 +3134,6 @@ export class SyncEngine {
 
 	// --- Pull: Engram → local vault ---
 
-	/** Pull remote changes and apply to vault. */
-	/** Page through GET /notes/changes until has_more=false (protocol rev).
-	 *  Pre-rev backends return no has_more — the loop exits after one page,
-	 *  preserving legacy behavior. fields:"meta" requests hash-only pages. */
-	private async fetchAllNoteChanges(
-		since: string,
-		fields?: "meta",
-	): Promise<{ changes: NoteChange[]; server_time: string }> {
-		const all: NoteChange[] = [];
-		let cursor: string | undefined;
-		let serverTime = "";
-		// Loop ceiling is corruption protection (cursor not advancing), not a
-		// real limit: 10k pages × 500 = 5M notes.
-		for (let page = 0; page < 10_000; page++) {
-			const resp = await this.api.getChanges(since, { limit: 500, cursor, fields });
-			all.push(...resp.changes);
-			serverTime = resp.server_time;
-			if (!resp.has_more || !resp.next_cursor) break;
-			cursor = resp.next_cursor;
-		}
-		return { changes: all, server_time: serverTime };
-	}
-
 	/** Free `noteId`'s Y.Doc after a remote update has been applied and its head
 	 *  durably recorded (P3, plugin #232-series). Idle notes are not
 	 *  channel-enrolled under the fan-out model (P2 removed lazyEnrollment) —
@@ -3235,6 +3212,60 @@ export class SyncEngine {
 	 *  cursor — a "replace remote with local" must download nothing (that would
 	 *  materialize remote extras as local orphans, which then resurrect on the
 	 *  next sync), and mustn't steal seq progress from a later genuine catch-up. */
+	/** Enumerate the FULL current server state from the seq-ordered op-log
+	 *  (`crdt_catchup_since` from seq 0). Nothing is applied and the real
+	 *  catch-up cursor is untouched — this is a pure read. Ops fold per note_id
+	 *  with last-seq-wins, so a rename collapses to its FINAL path (no ghost
+	 *  old-path row — better than the retired REST delta, which listed both)
+	 *  and a tombstone folds to `deleted: true`. Attachments ride the same feed
+	 *  and fold by path. Replaced GET /notes/changes + GET /attachments/changes
+	 *  as `computeSyncPlan`'s inventory (#304, REST-purge Bucket C — the
+	 *  preview was their last caller). Throws when the channel is not live: the
+	 *  preview must error visibly, never render a wrong empty plan. */
+	private async enumerateServerState(): Promise<{
+		notes: Map<string, { deleted: boolean; content?: string; contentHash?: string }>;
+		attachments: Map<string, { deleted: boolean }>;
+	}> {
+		if (!this.crdtCatchupSince || !this.crdt || !(this.crdtLive?.() ?? false)) {
+			throw new Error("Sync preview needs the live socket (op-log enumeration)");
+		}
+		const byId = new Map<string, Extract<SyncChange, { type: "note" }>>();
+		const attachments = new Map<string, { deleted: boolean }>();
+		let cursor = 0;
+		// Loop ceiling is corruption protection, not a real limit (mirrors
+		// runSeqReplayOnce): 100k pages x 500 rows.
+		for (let page = 0; page < 100_000; page++) {
+			const resp = await this.crdtCatchupSince(cursor, 500);
+			for (const c of resp.changes) {
+				if (typeof c.seq === "number" && c.seq > cursor) cursor = c.seq;
+				if (c.type === "attachment") {
+					if (c.path) attachments.set(c.path, { deleted: c.deleted });
+				} else if (c.id && c.path) {
+					// Both guards: an id-less or path-less row (a folder-marker op
+					// leaking into the note feed, mirrored from applyOp) would key
+					// the fold on null and surface as a bogus toPull in the plan.
+					byId.set(c.id, c);
+				}
+			}
+			if (!resp.has_more) break;
+			if (typeof resp.next_seq === "number" && resp.next_seq > cursor) {
+				cursor = resp.next_seq;
+			}
+		}
+		const notes = new Map<
+			string,
+			{ deleted: boolean; content?: string; contentHash?: string }
+		>();
+		for (const c of byId.values()) {
+			notes.set(c.path, {
+				deleted: c.deleted,
+				content: c.content,
+				contentHash: c.content_hash,
+			});
+		}
+		return { notes, attachments };
+	}
+
 	async catchupViaSeqReplay(opts: { fromZero?: boolean; enumerateOnly?: boolean } = {}): Promise<{
 		applied: number;
 		serverIds: Set<string>;
@@ -6455,60 +6486,21 @@ export class SyncEngine {
 	 *  - "full"     — bidirectional: compute toPush, toPull, conflicts, deletions
 	 *  - "push-all" — push only: compute toPush, skip toPull
 	 *  - "pull-all" — pull only: compute toPull, skip toPush
+	 *
+	 *  Server state comes from ONE from-genesis op-log enumeration
+	 *  (`enumerateServerState`) — delta and inventory in a single walk. The
+	 *  REST-era split (manifest for inventory, GET /notes/changes for the
+	 *  delta, epoch-widening when the manifest was missing) died with those
+	 *  endpoints (#304). Per-path classification:
+	 *  - identical bytes (row carries content)            → clean, skip
+	 *  - server unchanged (row hash == recorded serverHash):
+	 *      local unchanged → clean · local changed → toPush
+	 *  - server changed: local unchanged → toPull · both changed → conflict
 	 */
 	async computeSyncPlan(mode: "push-all" | "pull-all" | "full"): Promise<SyncPlan> {
-		const epoch = "1970-01-01T00:00:00Z";
-
-		// Authoritative server inventory for "is this path on the server?" comparisons.
-		// In incremental "full" mode the changes-since-lastSync delta is NOT a valid
-		// inventory — long-synced files don't appear in the delta and were falsely
-		// flagged for push. Prefer /sync/manifest for inventory; fall back to a full
-		// changes-since-epoch query when the server doesn't expose the manifest.
-		let manifestNotePaths: Set<string> | null = null;
-		let manifestAttachPaths: Set<string> | null = null;
-		let manifestNoteCount: number | null = null;
-		let manifestAttachCount: number | null = null;
-
-		if (mode === "full" && this.lastSync) {
-			const manifest = await this.api.getManifest();
-			if (manifest) {
-				manifestNotePaths = new Set(manifest.notes.map((n) => n.path));
-				manifestAttachPaths = new Set(manifest.attachments.map((a) => a.path));
-				manifestNoteCount = manifest.notes.length;
-				manifestAttachCount = manifest.attachments.length;
-			}
-		}
-
-		// Delta query: changes-since-lastSync for content/pull/conflict computation.
-		// When manifest is unavailable (older self-host backend) AND we're in
-		// incremental mode, widen the query to since=epoch so the delta also serves
-		// as a (slower) inventory. This trades a one-off slow query for correctness.
-		const needsDeltaAsInventory =
-			mode === "full" && this.lastSync !== "" && manifestNotePaths === null;
-		const since = mode !== "full" || needsDeltaAsInventory ? epoch : this.lastSync || epoch;
-
-		const [noteResp, attachResp] = await Promise.all([
-			this.fetchAllNoteChanges(since),
-			this.api.getAttachmentChanges(since),
-		]);
-
-		// Build lookup sets from server state
-		const serverNotes = new Map<string, { deleted: boolean }>();
-		for (const c of noteResp.changes) {
-			serverNotes.set(c.path, { deleted: c.deleted });
-		}
-
-		const serverAttachments = new Map<string, { deleted: boolean }>();
-		for (const c of attachResp.changes) {
-			serverAttachments.set(c.path, { deleted: c.deleted });
-		}
-
-		// `serverHasNote/serverHasAttach` returns the authoritative answer:
-		// manifest when present, else the (epoch-widened) delta as fallback.
-		const serverHasNote = (path: string) =>
-			manifestNotePaths ? manifestNotePaths.has(path) : serverNotes.has(path);
-		const serverHasAttach = (path: string) =>
-			manifestAttachPaths ? manifestAttachPaths.has(path) : serverAttachments.has(path);
+		const server = await this.enumerateServerState();
+		const serverNotes = server.notes;
+		const serverAttachments = server.attachments;
 
 		// Enumerate local files
 		const allFiles = this.app.vault.getFiles();
@@ -6527,121 +6519,87 @@ export class SyncEngine {
 		const localNoteSet = new Set(localNotes);
 		const localAttachSet = new Set(localAttachments);
 
-		// Categorise server note changes
+		// Categorise server note rows — each path classified exactly once.
 		const toPullNotes: string[] = [];
 		const conflictNotes: string[] = [];
 		const toDeleteLocal: string[] = [];
+		const toPushNotes: string[] = [];
 
-		for (const [path, { deleted }] of serverNotes) {
-			if (deleted) {
-				// Server deleted — mark for local deletion if present
-				if (localNoteSet.has(path)) {
-					toDeleteLocal.push(path);
-				}
+		for (const [path, row] of serverNotes) {
+			if (row.deleted) {
+				// Server tombstone — mark for local deletion if present.
+				if (localNoteSet.has(path)) toDeleteLocal.push(path);
 				continue;
 			}
-			if (localNoteSet.has(path)) {
-				// Both sides have it — compare content to see if pull is needed
-				const file = this.app.vault.getFileByPath(path);
-				if (file) {
-					const content = await this.app.vault.cachedRead(file);
-					const localHash = fnv1a(content);
-
-					// Check if server content actually differs from local
-					const serverChange = noteResp.changes.find((c) => c.path === path);
-					const serverHash =
-						serverChange?.content !== undefined
-							? fnv1a(serverChange.content)
-							: undefined;
-
-					if (serverHash !== undefined && localHash === serverHash) {
-						// Content identical — nothing to do, skip entirely
-						continue;
-					}
-
-					const synced = this.syncState.get(path);
-					if (synced?.hash !== undefined && localHash !== synced.hash) {
-						// Local changed since last sync AND server changed — conflict
-						conflictNotes.push(path);
-					} else {
-						// Local unchanged or never synced — server has new content
-						toPullNotes.push(path);
-					}
-				} else {
-					toPullNotes.push(path);
-				}
+			if (!localNoteSet.has(path)) {
+				toPullNotes.push(path);
+				continue;
+			}
+			const file = this.app.vault.getFileByPath(path);
+			if (!file) {
+				toPullNotes.push(path);
+				continue;
+			}
+			const content = await this.app.vault.cachedRead(file);
+			const localHash = fnv1a(content);
+			// Identical bytes — nothing to do, regardless of bookkeeping.
+			if (row.content !== undefined && localHash === fnv1a(row.content)) continue;
+			const synced = this.syncState.get(path);
+			const localChanged = synced?.hash !== undefined && localHash !== synced.hash;
+			// The row's content_hash is the server-side HMAC — uncomputable
+			// locally, but recorded as serverHash on every commit, so equality
+			// proves the server hasn't moved since our last converge.
+			const serverUnchanged =
+				row.contentHash !== undefined &&
+				synced?.serverHash !== undefined &&
+				row.contentHash === synced.serverHash;
+			if (serverUnchanged) {
+				if (localChanged) toPushNotes.push(path);
+				// else: neither side moved (row content just wasn't compared) — clean.
+			} else if (localChanged) {
+				conflictNotes.push(path);
 			} else {
-				// Only on server — need to pull
 				toPullNotes.push(path);
 			}
 		}
 
-		// Categorise server attachment changes
-		const toPullAttachments: string[] = [];
-		const toDeleteLocalAttach: string[] = [];
-
-		for (const [path, { deleted }] of serverAttachments) {
-			if (deleted) {
-				if (localAttachSet.has(path)) {
-					toDeleteLocalAttach.push(path);
-				}
-				continue;
-			}
-			if (!localAttachSet.has(path)) {
-				toPullAttachments.push(path);
-			}
+		// Local-only notes → push. A path with ANY server row (even a tombstone)
+		// is not "new" — the tombstone branch owns it (delete-wins; pushing would
+		// fight the <60s recreate refusal).
+		for (const path of localNotes) {
+			if (!serverNotes.has(path)) toPushNotes.push(path);
 		}
 
-		// Files only local → need to push (not on server at all).
-		// Then for files that ARE on the server but absent from the delta,
-		// compare current local hash against the last-synced hash so a
-		// locally-edited note shows up as toPush. Skip paths the delta
-		// already owns (pull/conflict branches handle those) to avoid
-		// double-counting. A missing syncState entry is treated as clean —
-		// a true content cross-check needs a plugin-computable server hash
-		// (separate backend work).
-		const toPushNotes: string[] = [];
-		for (const path of localNotes) {
-			if (!serverHasNote(path)) {
-				toPushNotes.push(path);
+		// Categorise server attachment rows
+		const toPullAttachments: string[] = [];
+		const toDeleteLocalAttach: string[] = [];
+		for (const [path, { deleted }] of serverAttachments) {
+			if (deleted) {
+				if (localAttachSet.has(path)) toDeleteLocalAttach.push(path);
 				continue;
 			}
-			if (serverNotes.has(path)) continue;
-			const file = this.app.vault.getFileByPath(path);
-			if (!file) continue;
-			const content = await this.app.vault.cachedRead(file);
-			const localHash = fnv1a(content);
-			const synced = this.syncState.get(path);
-			if (synced?.hash !== undefined && synced.hash !== localHash) {
-				toPushNotes.push(path);
-			}
+			if (!localAttachSet.has(path)) toPullAttachments.push(path);
 		}
 
 		const toPushAttachments: string[] = [];
 		for (const path of localAttachments) {
-			if (!serverHasAttach(path)) {
-				toPushAttachments.push(path);
-			}
+			if (!serverAttachments.has(path)) toPushAttachments.push(path);
 		}
 
+		const liveNotePaths = [...serverNotes.entries()]
+			.filter(([, v]) => !v.deleted)
+			.map(([k]) => k);
+		const liveAttachPaths = [...serverAttachments.entries()]
+			.filter(([, v]) => !v.deleted)
+			.map(([k]) => k);
+		const serverPaths = [...liveNotePaths, ...liveAttachPaths];
 		const localFolderCount = countFolders([...localNotes, ...localAttachments]);
-		const serverPaths = manifestNotePaths
-			? [...manifestNotePaths, ...(manifestAttachPaths ?? new Set<string>())]
-			: [
-					...[...serverNotes.entries()].filter(([, v]) => !v.deleted).map(([k]) => k),
-					...[...serverAttachments.entries()]
-						.filter(([, v]) => !v.deleted)
-						.map(([k]) => k),
-				];
 		const serverFolderCount = countFolders(serverPaths);
 
 		return {
 			vaultName: this.app.vault.getName(),
-			serverNoteCount:
-				manifestNoteCount ?? [...serverNotes.values()].filter((v) => !v.deleted).length,
-			serverAttachmentCount:
-				manifestAttachCount ??
-				[...serverAttachments.values()].filter((v) => !v.deleted).length,
+			serverNoteCount: liveNotePaths.length,
+			serverAttachmentCount: liveAttachPaths.length,
 			serverFolderCount,
 			localNoteCount: localNotes.length,
 			localAttachmentCount: localAttachments.length,

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,8 +124,9 @@ export interface NoteResponse {
 	chunks_indexed: number;
 }
 
-/** A change entry from GET /notes/changes.
- *  `content` is absent on `fields=meta` pages (protocol rev) — callers must
+/** A note change row applied by `applyChange`. Sourced from the op-log feed
+ *  (`crdt_catchup_since` → `applyOp`) after the REST changes endpoints were
+ *  removed (#304). `content` may be absent on meta-only rows — callers must
  *  resolve the body before applying a non-deleted change. `content_hash` is
  *  the server's opaque hash; compare it to the stored per-path serverHash. */
 export interface NoteChange {
@@ -145,18 +146,10 @@ export interface NoteChange {
 	seq?: number;
 }
 
-/** Response from GET /notes/changes */
-export interface ChangesResponse {
-	changes: NoteChange[];
-	server_time: string;
-	/** Protocol rev pagination — absent on pre-rev backends. */
-	has_more?: boolean;
-	next_cursor?: string | null;
-}
-
-/** A note entry from the MERGED ordered feed GET /sync/changes (PR B2).
- *  `content` is absent on meta-only pages; `content_hash` is the server's
- *  opaque hash. `seq` is the per-vault monotonic change sequence. */
+/** A note row on the op-log feed (`crdt_catchup_since`, folded by
+ *  `enumerateServerState` / replayed by `applySyncChange`). `content` is absent
+ *  on meta-only rows; `content_hash` is the server's opaque hash. `seq` is the
+ *  per-vault monotonic change sequence. */
 export interface SyncNoteChange {
 	type: "note";
 	id: string;
@@ -197,7 +190,7 @@ export interface SyncOp {
 	parse_reason?: ParseReason | null;
 }
 
-/** An attachment entry from GET /sync/changes — metadata only, no bytes. */
+/** An attachment row on the op-log feed — metadata only, no bytes. */
 export interface SyncAttachmentChange {
 	type: "attachment";
 	id: string;
@@ -397,7 +390,8 @@ export interface AttachmentDetail {
 	updated_at: string;
 }
 
-/** A change entry from GET /attachments/changes */
+/** An attachment change row applied by `applyAttachmentChange`, sourced from
+ *  the op-log feed (`crdt_catchup_since` → `applyOp`). */
 export interface AttachmentChange {
 	path: string;
 	mime_type: string;
@@ -405,12 +399,6 @@ export interface AttachmentChange {
 	mtime: number;
 	updated_at: string;
 	deleted: boolean;
-}
-
-/** Response from GET /attachments/changes */
-export interface AttachmentChangesResponse {
-	changes: AttachmentChange[];
-	server_time: string;
 }
 
 /** A single entry in the sync manifest (path + content hash). */

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -275,10 +275,10 @@ describe("EngramApi", () => {
 				enqueueSpy;
 			mockRequestUrl.mockResolvedValueOnce({
 				status: 200,
-				json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+				json: { notes: [], attachments: [] },
 			} as any);
 
-			await api.getChanges("2026-01-01T00:00:00Z");
+			await api.getManifest();
 
 			const opts = mockRequestUrl.mock.calls[0]?.[0] as any;
 			expect(opts.headers?.traceparent).toBeUndefined();
@@ -346,18 +346,6 @@ describe("EngramApi", () => {
 			const opts = mockRequestUrl.mock.calls[0]?.[0] as any;
 			expect(opts.headers?.traceparent).toBeUndefined();
 			expect(enqueueSpy).not.toHaveBeenCalled();
-		});
-	});
-
-	describe("getChanges", () => {
-		test("URL-encodes the since parameter", async () => {
-			mockRequestUrl.mockResolvedValueOnce({
-				status: 200,
-				json: { changes: [], deleted: [] },
-			} as any);
-			await api.getChanges("2024-01-01T00:00:00+00:00");
-			const opts = mockRequestUrl.mock.calls[0][0] as any;
-			expect(opts.url).toContain(encodeURIComponent("2024-01-01T00:00:00+00:00"));
 		});
 	});
 
@@ -452,9 +440,9 @@ describe("EngramApi", () => {
 			api.setVaultId("42");
 			mockRequestUrl.mockResolvedValueOnce({
 				status: 200,
-				json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+				json: { notes: [], attachments: [] },
 			} as any);
-			await api.getChanges("2026-01-01T00:00:00Z");
+			await api.getManifest();
 			expect(mockRequestUrl).toHaveBeenCalledWith(
 				expect.objectContaining({
 					headers: expect.objectContaining({
@@ -467,9 +455,9 @@ describe("EngramApi", () => {
 		test("omits X-Vault-ID when vaultId is null", async () => {
 			mockRequestUrl.mockResolvedValueOnce({
 				status: 200,
-				json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+				json: { notes: [], attachments: [] },
 			} as any);
-			await api.getChanges("2026-01-01T00:00:00Z");
+			await api.getManifest();
 			const headers = mockRequestUrl.mock.calls[0][0].headers;
 			expect(headers["X-Vault-ID"]).toBeUndefined();
 		});
@@ -488,9 +476,9 @@ describe("EngramApi", () => {
 			api.setVaultId(null);
 			mockRequestUrl.mockResolvedValueOnce({
 				status: 200,
-				json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+				json: { notes: [], attachments: [] },
 			} as any);
-			await api.getChanges("2026-01-01T00:00:00Z");
+			await api.getManifest();
 			expect(mockRequestUrl.mock.calls[0][0].headers["X-Vault-ID"]).toBe("engram-vault-id");
 		});
 
@@ -498,17 +486,17 @@ describe("EngramApi", () => {
 			api.setVaultId("10");
 			mockRequestUrl.mockResolvedValueOnce({
 				status: 200,
-				json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+				json: { notes: [], attachments: [] },
 			} as any);
-			await api.getChanges("2026-01-01T00:00:00Z");
+			await api.getManifest();
 			expect(mockRequestUrl.mock.calls[0][0].headers["X-Vault-ID"]).toBe("10");
 
 			api.setVaultId("20");
 			mockRequestUrl.mockResolvedValueOnce({
 				status: 200,
-				json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+				json: { notes: [], attachments: [] },
 			} as any);
-			await api.getChanges("2026-01-01T00:00:00Z");
+			await api.getManifest();
 			expect(mockRequestUrl.mock.calls[1][0].headers["X-Vault-ID"]).toBe("20");
 		});
 	});
@@ -809,19 +797,6 @@ describe("EngramApi", () => {
 			expect(opts.url).toBe(`${TEST_API_BASE}/logs`);
 			const body = JSON.parse(opts.body);
 			expect(body.logs).toEqual(entries);
-		});
-	});
-
-	describe("getAttachmentChanges", () => {
-		test("sends GET /attachments/changes with URL-encoded since", async () => {
-			mockRequestUrl.mockResolvedValueOnce({
-				status: 200,
-				json: { changes: [], deleted: [] },
-			} as any);
-			await api.getAttachmentChanges("2026-04-01T00:00:00+00:00");
-			const opts = mockRequestUrl.mock.calls[0][0] as any;
-			expect(opts.method).toBe("GET");
-			expect(opts.url).toContain(encodeURIComponent("2026-04-01T00:00:00+00:00"));
 		});
 	});
 
@@ -1168,41 +1143,22 @@ describe("deadline classification", () => {
 		mockRequestUrl.mockImplementation(() => new Promise<never>(() => {}));
 		const a = new EngramApi("http://host", "key");
 		a.requestTimeoutMs = 20;
-		a.bulkTimeoutMs = 20;
 		a.attachmentTimeoutMs = 300;
 		let settledAt: number | null = null;
 		const p = a.getAttachment("changes.pdf").catch(() => {
 			settledAt = Date.now();
 		});
-		await Bun.sleep(80); // past note+bulk deadlines, well short of transfer
+		await Bun.sleep(80); // past the note deadline, well short of transfer
 		expect(settledAt).toBeNull();
 		await p;
 		expect(settledAt).not.toBeNull();
 	});
 
-	test("the /attachments/changes metadata feed keeps the short deadline", async () => {
+	test("metadata GETs keep the short deadline", async () => {
 		mockRequestUrl.mockImplementation(() => new Promise<never>(() => {}));
 		const a = new EngramApi("http://host", "key");
 		a.requestTimeoutMs = 20;
 		a.attachmentTimeoutMs = 100_000;
-		await expect(a.getAttachmentChanges("2026-01-01T00:00:00Z")).rejects.toThrow(
-			RequestTimeoutError,
-		);
-	});
-
-	test("bulk change pages use the middle deadline", async () => {
-		mockRequestUrl.mockImplementation(() => new Promise<never>(() => {}));
-		const a = new EngramApi("http://host", "key");
-		a.requestTimeoutMs = 20;
-		a.bulkTimeoutMs = 300;
-		let settledAt: number | null = null;
-		// /notes/changes is a bulk feed (advanced-sync pullAll).
-		const p = a.getChanges("2026-01-01T00:00:00Z").catch(() => {
-			settledAt = Date.now();
-		});
-		await Bun.sleep(80); // past the note deadline, short of the bulk one
-		expect(settledAt).toBeNull();
-		await p;
-		expect(settledAt).not.toBeNull();
+		await expect(a.getManifest()).rejects.toThrow(RequestTimeoutError);
 	});
 });

--- a/tests/crdt-cross-wire-overwrite.test.ts
+++ b/tests/crdt-cross-wire-overwrite.test.ts
@@ -27,7 +27,6 @@ import { DEFAULT_SETTINGS } from "../src/types";
 
 const getManifest = mock().mockResolvedValue(null);
 const mockApi = {
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	getManifest,
 } as unknown as EngramApi;
 

--- a/tests/note-id-map-hygiene.test.ts
+++ b/tests/note-id-map-hygiene.test.ts
@@ -24,15 +24,10 @@ import { DEFAULT_SETTINGS } from "../src/types";
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "sid" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	health: mock().mockResolvedValue(true),
 	ping: mock().mockResolvedValue({ ok: true }),
 	getRateLimit: mock().mockResolvedValue(0),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getManifest: mock().mockResolvedValue(null),
 } as unknown as EngramApi;
 

--- a/tests/protocol-rev.test.ts
+++ b/tests/protocol-rev.test.ts
@@ -4,13 +4,12 @@ import type { EngramApi } from "../src/api";
 import { SyncEngine, fnv1a } from "../src/sync";
 import { DEFAULT_SETTINGS } from "../src/types";
 
-// Protocol rev: bulk push via POST /notes/batch, paginated /notes/changes
-// with fields=meta, hash-compare live sync, serverHash-based reconcile.
+// Protocol rev: hash-compare live sync + serverHash-based reconcile over the
+// op-log feed (the REST batch/changes endpoints were removed in #304).
 
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockResolvedValue({ results: [] }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "Notes/Remote.md",
@@ -37,9 +36,6 @@ const mockApi = {
 		updated_at: "2026-03-01T12:00:00Z",
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: jest
-		.fn()
-		.mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: jest
@@ -94,21 +90,6 @@ function createEngine(overrides = {}): SyncEngine {
 	return engine;
 }
 
-function metaChange(path: string, hash: string, version: number, extra = {}) {
-	return {
-		path,
-		title: path,
-		folder: "",
-		tags: [],
-		mtime: 100,
-		updated_at: "2026-06-12T00:00:00Z",
-		deleted: false,
-		version,
-		content_hash: hash,
-		...extra,
-	};
-}
-
 beforeEach(() => {
 	jest.clearAllMocks();
 	mockApp.vault.getFileByPath.mockReset().mockReturnValue(null);
@@ -116,9 +97,6 @@ beforeEach(() => {
 	mockApp.vault.cachedRead.mockReset().mockResolvedValue("# Test");
 	(mockApi.pushNote as jest.Mock).mockReset().mockResolvedValue({ note: {}, chunks_indexed: 1 });
 	(mockApi.pushNotesBatch as jest.Mock).mockReset().mockResolvedValue({ results: [] });
-	(mockApi.getChanges as jest.Mock)
-		.mockReset()
-		.mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" });
 	(mockApi.getNote as jest.Mock).mockReset().mockResolvedValue({
 		path: "Notes/Remote.md",
 		title: "Remote Note",
@@ -139,14 +117,9 @@ afterEach(() => {
 	activeEngines.length = 0;
 });
 
-// REST-purge Bucket B (Task 5) — REMOVED: "paginated pull (legacy meta feed
-// via pullAll)" (3 tests: page-loop cursor threading, serverHash body-skip,
-// body-fetch-on-hash-diff). pullAll() no longer calls fetchAllNoteChanges /
-// resolveChangeBody at all — it replays the note op-log from cursor 0 via
-// catchupViaSeqReplay({fromZero:true}) (tests/sync-push-consolidation.test.ts,
-// "SyncEngine.pullAll — replay-from-0"). fetchAllNoteChanges/resolveChangeBody
-// still exist (another caller in the pushAll/wipeRemote reconcile path,
-// untouched by this task), just no longer reachable through pullAll.
+// pullAll() replays the note op-log from cursor 0 via
+// catchupViaSeqReplay({fromZero:true}); the legacy paginated meta-feed pull
+// (fetchAllNoteChanges) and the REST changes endpoints it rode are gone (#304).
 
 describe("hash-compare live sync", () => {
 	test("skips events whose content_hash matches the stored serverHash", async () => {

--- a/tests/sim/model-server.test.ts
+++ b/tests/sim/model-server.test.ts
@@ -102,32 +102,6 @@ test("HTTP GET /notes/:id/updates returns {update, head} and update reconstructs
 	expect(doc.getText("content").toString()).toBe("hello");
 });
 
-test("HTTP GET /vault/heads returns per-note heads", () => {
-	const { server } = boot();
-	server.http({
-		method: "POST",
-		url: "/api/notes",
-		body: JSON.stringify({ path: "a.md", content: "hi", mtime: 1, id: "n1" }),
-	});
-	const j = server.http({ method: "GET", url: "/api/vault/heads" }).json as {
-		heads: Record<string, string>;
-	};
-	expect(typeof j.heads.n1).toBe("string");
-});
-
-test("HTTP GET /notes/changes returns ChangesResponse shape", () => {
-	const { server } = boot();
-	server.http({
-		method: "POST",
-		url: "/api/notes",
-		body: JSON.stringify({ path: "a.md", content: "hi", mtime: 1, id: "n1" }),
-	});
-	const j = server.http({ method: "GET", url: "/api/notes/changes?since=1970-01-01T00:00:00Z" })
-		.json as { changes: unknown[]; server_time: string };
-	expect(Array.isArray(j.changes)).toBe(true);
-	expect(typeof j.server_time).toBe("string");
-});
-
 test("HTTP POST /logs is a 200 no-op", () => {
 	const { server } = boot();
 	expect(server.http({ method: "POST", url: "/api/logs", body: "{}" }).status).toBe(200);

--- a/tests/sim/model-server.ts
+++ b/tests/sim/model-server.ts
@@ -473,8 +473,6 @@ export class ModelServer {
 		if (method === "POST" && path === "/logs") return ok({ ok: true });
 
 		if (method === "POST" && path === "/notes") return this.restPushNote(body);
-		if (method === "GET" && path === "/notes/changes") return this.restChanges();
-		if (method === "GET" && path === "/vault/heads") return this.restVaultHeads();
 		if (method === "GET" && path === "/sync/manifest") return this.restManifest();
 
 		// /notes/:id/updates (id, not path-encoded — encodeURIComponent single seg)
@@ -544,29 +542,6 @@ export class ModelServer {
 			this.fanoutUpdate("__rest__", n, raw);
 		}
 		return ok({ head: this.head(n) });
-	}
-
-	private restChanges(): SimResponse {
-		const changes = [...this.byId.values()].map((n) => ({
-			path: n.path,
-			title: titleOf(n.path),
-			content: this.text(n),
-			content_hash: this.head(n),
-			folder: folderOf(n.path),
-			tags: [] as string[],
-			mtime: n.seq,
-			updated_at: n.updatedAt,
-			deleted: n.deleted,
-			version: n.version,
-			seq: n.seq,
-		}));
-		return ok({ changes, server_time: nowIso(), has_more: false, next_cursor: null });
-	}
-
-	private restVaultHeads(): SimResponse {
-		const heads: Record<string, string> = {};
-		for (const n of this.byId.values()) heads[n.id] = this.head(n);
-		return ok({ heads });
 	}
 
 	private restManifest(): SimResponse {

--- a/tests/sync-c1-serverhash.test.ts
+++ b/tests/sync-c1-serverhash.test.ts
@@ -21,15 +21,10 @@ import { DEFAULT_SETTINGS } from "../src/types";
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "sid" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	health: mock().mockResolvedValue(true),
 	ping: mock().mockResolvedValue({ ok: true }),
 	getRateLimit: mock().mockResolvedValue(0),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getManifest: mock().mockResolvedValue(null),
 	getNote: mock().mockResolvedValue({ path: "", content: "" }),
 } as unknown as EngramApi;

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -26,7 +26,6 @@ import { DEFAULT_SETTINGS } from "../src/types";
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "sid" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -40,10 +39,6 @@ const mockApi = {
 	ping: mock().mockResolvedValue({ ok: true }),
 	pushAttachment: mock().mockResolvedValue({ attachment: {} }),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	getUpdates: mock().mockResolvedValue({ update: new Uint8Array([1, 2]), head: "head-1" }),

--- a/tests/sync-crdt-gate.test.ts
+++ b/tests/sync-crdt-gate.test.ts
@@ -8,8 +8,7 @@
  *   - Attachment upsert event STILL processes via the legacy path.
  *   - applyChange() returns false (no disk write) for markdown when CRDT is active.
  *   - applyChange() delete path still deletes when CRDT is active.
- *   - Cold-start pull (getChanges/pullViaCursor) skips markdown body write when CRDT
- *     is active.
+ *   - Cold-start catch-up skips markdown body write when CRDT is active.
  *
  * I1 — CrdtManager leak on re-setup:
  *   - Calling the teardown sequence (destroy + null) before re-wiring a new manager
@@ -59,7 +58,6 @@ function markConfirmed(engine: SyncEngine, noteId: string): void {
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "Notes/Remote.md",
@@ -82,10 +80,6 @@ const mockApi = {
 		updated_at: "2026-03-01T12:00:00Z",
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({ id: "v1", name: "Test", slug: "test" }),

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -32,7 +32,6 @@ function markConfirmed(engine: SyncEngine, noteId: string): void {
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -53,10 +52,6 @@ const mockApi = {
 		mtime: 0,
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({

--- a/tests/sync-crdt-route.test.ts
+++ b/tests/sync-crdt-route.test.ts
@@ -142,7 +142,6 @@ describe("routeModify helper", () => {
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -163,10 +162,6 @@ const mockApi = {
 		mtime: 0,
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({

--- a/tests/sync-crdt-teardown.test.ts
+++ b/tests/sync-crdt-teardown.test.ts
@@ -24,7 +24,6 @@ import { DEFAULT_SETTINGS } from "../src/types";
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "Notes/Remote.md",
@@ -47,10 +46,6 @@ const mockApi = {
 		updated_at: "2026-03-01T12:00:00Z",
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({ id: "v1", name: "Test", slug: "test" }),

--- a/tests/sync-cursor-pull.test.ts
+++ b/tests/sync-cursor-pull.test.ts
@@ -5,7 +5,7 @@
  * The REST cursor-pull cluster (pull/bootstrap/pullViaCursor/getSyncChanges +
  * syncCursor) was deleted in the REST-purge Bucket A migration — catch-up now
  * runs entirely over the socket seq-replay (catchupViaSeqReplay → applySyncChange).
- * What survives and is exercised here: the X-Device-Id header on getChanges,
+ * What survives and is exercised here: the X-Device-Id header on REST requests,
  * applySyncChange's dispatch to applyChange/applyAttachmentChange, and
  * reconcileFromManifest (server-delete-local + folder markers).
  */
@@ -36,9 +36,9 @@ describe("X-Device-Id header", () => {
 		api.setDeviceId("dev-xyz");
 		mockRequestUrl.mockResolvedValueOnce({
 			status: 200,
-			json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+			json: { notes: [], attachments: [] },
 		} as any);
-		await api.getChanges("2026-01-01T00:00:00Z");
+		await api.getManifest();
 		expect(mockRequestUrl).toHaveBeenCalledWith(
 			expect.objectContaining({
 				headers: expect.objectContaining({
@@ -51,9 +51,9 @@ describe("X-Device-Id header", () => {
 	test("omits X-Device-Id when no device id is set", async () => {
 		mockRequestUrl.mockResolvedValueOnce({
 			status: 200,
-			json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+			json: { notes: [], attachments: [] },
 		} as any);
-		await api.getChanges("2026-01-01T00:00:00Z");
+		await api.getManifest();
 		const headers = mockRequestUrl.mock.calls[0][0].headers;
 		expect(headers["X-Device-Id"]).toBeUndefined();
 	});
@@ -63,9 +63,9 @@ describe("X-Device-Id header", () => {
 		api.setDeviceId(null);
 		mockRequestUrl.mockResolvedValueOnce({
 			status: 200,
-			json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+			json: { notes: [], attachments: [] },
 		} as any);
-		await api.getChanges("2026-01-01T00:00:00Z");
+		await api.getManifest();
 		const headers = mockRequestUrl.mock.calls[0][0].headers;
 		expect(headers["X-Device-Id"]).toBeUndefined();
 	});
@@ -74,9 +74,9 @@ describe("X-Device-Id header", () => {
 		api.setDeviceId("");
 		mockRequestUrl.mockResolvedValueOnce({
 			status: 200,
-			json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+			json: { notes: [], attachments: [] },
 		} as any);
-		await api.getChanges("2026-01-01T00:00:00Z");
+		await api.getManifest();
 		const headers = mockRequestUrl.mock.calls[0][0].headers;
 		expect(headers["X-Device-Id"]).toBeUndefined();
 	});
@@ -85,17 +85,17 @@ describe("X-Device-Id header", () => {
 		api.setDeviceId("dev-1");
 		mockRequestUrl.mockResolvedValueOnce({
 			status: 200,
-			json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+			json: { notes: [], attachments: [] },
 		} as any);
-		await api.getChanges("2026-01-01T00:00:00Z");
+		await api.getManifest();
 		expect(mockRequestUrl.mock.calls[0][0].headers["X-Device-Id"]).toBe("dev-1");
 
 		api.setDeviceId("dev-2");
 		mockRequestUrl.mockResolvedValueOnce({
 			status: 200,
-			json: { changes: [], server_time: "2026-01-01T00:00:00Z" },
+			json: { notes: [], attachments: [] },
 		} as any);
-		await api.getChanges("2026-01-01T00:00:00Z");
+		await api.getManifest();
 		expect(mockRequestUrl.mock.calls[1][0].headers["X-Device-Id"]).toBe("dev-2");
 	});
 });

--- a/tests/sync-empty-content-distrust.test.ts
+++ b/tests/sync-empty-content-distrust.test.ts
@@ -22,15 +22,10 @@ import { DEFAULT_SETTINGS } from "../src/types";
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "sid" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	health: mock().mockResolvedValue(true),
 	ping: mock().mockResolvedValue({ ok: true }),
 	getRateLimit: mock().mockResolvedValue(0),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getManifest: mock().mockResolvedValue(null),
 	getNote: mock().mockResolvedValue({ path: "", content: "" }),
 } as unknown as EngramApi;

--- a/tests/sync-folder-events.test.ts
+++ b/tests/sync-folder-events.test.ts
@@ -22,11 +22,6 @@ const mockApi = {
 	deleteFolder: mock().mockResolvedValue(undefined),
 	listExplicitFolders: mock().mockResolvedValue([]),
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	ping: mock().mockResolvedValue({ ok: true }),

--- a/tests/sync-id-adoption.test.ts
+++ b/tests/sync-id-adoption.test.ts
@@ -21,7 +21,6 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "server-minted-id" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -35,10 +34,6 @@ const mockApi = {
 	ping: mock().mockResolvedValue({ ok: true }),
 	pushAttachment: mock().mockResolvedValue({ attachment: {} }),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 } as unknown as EngramApi;

--- a/tests/sync-note-id.test.ts
+++ b/tests/sync-note-id.test.ts
@@ -29,7 +29,6 @@ function pushNoteResponse(
 const mockApi = {
 	pushNote: mock(pushNoteResponse),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -50,10 +49,6 @@ const mockApi = {
 		mtime: 0,
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({

--- a/tests/sync-parse-status.test.ts
+++ b/tests/sync-parse-status.test.ts
@@ -33,7 +33,6 @@ async function flushDebounce(): Promise<void> {
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -54,10 +53,6 @@ const mockApi = {
 		mtime: 0,
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({

--- a/tests/sync-plan.test.ts
+++ b/tests/sync-plan.test.ts
@@ -11,11 +11,6 @@ const mockApi = {
 	// Legacy-backend shape: no batch endpoint — pushAll falls back to the
 	// per-note path these tests assert.
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue(null),
 	health: mock().mockResolvedValue(true),
@@ -81,20 +76,211 @@ function createEngine(overrides = {}): SyncEngine {
 
 beforeEach(() => {
 	jest.clearAllMocks();
-	(mockApi.getChanges as jest.Mock)
-		.mockReset()
-		.mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" });
-	(mockApi.getAttachmentChanges as jest.Mock)
-		.mockReset()
-		.mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" });
 	(mockApi.getManifest as jest.Mock).mockReset().mockResolvedValue(null);
 	mockApp.vault.getFiles.mockReset().mockReturnValue([]);
 });
 
+// ---------------------------------------------------------------------------
+// enumerateServerState — the op-log fold that replaced GET /notes/changes +
+// GET /attachments/changes as the preview's server inventory (#304).
+// ---------------------------------------------------------------------------
+
+function wireFeed(engine: SyncEngine, pages: any[][]) {
+	let call = 0;
+	engine.setCrdtManager({} as any);
+	engine.setCrdtLiveCheck(() => true);
+	engine.setCrdtCatchupSince(async (_cursor: number, _limit?: number) => {
+		const changes = pages[call] ?? [];
+		call++;
+		return {
+			changes,
+			has_more: call < pages.length,
+			next_seq: changes.length ? (changes[changes.length - 1].seq ?? null) : null,
+		};
+	});
+}
+
+describe("SyncEngine.enumerateServerState", () => {
+	test("folds ops per note id — last seq wins (edit supersedes create)", async () => {
+		const engine = createEngine();
+		wireFeed(engine, [
+			[
+				{
+					type: "note",
+					id: "n1",
+					seq: 1,
+					path: "a.md",
+					content: "v1",
+					content_hash: "H1",
+					deleted: false,
+				},
+				{
+					type: "note",
+					id: "n1",
+					seq: 2,
+					path: "a.md",
+					content: "v2",
+					content_hash: "H2",
+					deleted: false,
+				},
+			],
+		]);
+		const s = await (engine as any).enumerateServerState();
+		expect(s.notes.size).toBe(1);
+		expect(s.notes.get("a.md")).toEqual({ deleted: false, content: "v2", contentHash: "H2" });
+	});
+
+	test("skips a row with a null path (leaked folder-marker op) — no bogus key", async () => {
+		const engine = createEngine();
+		wireFeed(engine, [
+			[
+				{ type: "note", id: "n1", seq: 1, path: null, content: "", deleted: false },
+				{
+					type: "note",
+					id: "n2",
+					seq: 2,
+					path: "real.md",
+					content: "v",
+					content_hash: "H",
+					deleted: false,
+				},
+			],
+		]);
+		const s = await (engine as any).enumerateServerState();
+		expect(s.notes.size).toBe(1);
+		expect(s.notes.has("real.md")).toBe(true);
+		expect(s.notes.has(null as any)).toBe(false);
+		expect(s.notes.has(undefined as any)).toBe(false);
+	});
+
+	test("a rename folds to the FINAL path only (no ghost old-path row)", async () => {
+		const engine = createEngine();
+		wireFeed(engine, [
+			[
+				{
+					type: "note",
+					id: "n1",
+					seq: 1,
+					path: "old.md",
+					content: "x",
+					content_hash: "H1",
+					deleted: false,
+				},
+				{
+					type: "note",
+					id: "n1",
+					seq: 2,
+					path: "new.md",
+					content: "x",
+					content_hash: "H1",
+					deleted: false,
+				},
+			],
+		]);
+		const s = await (engine as any).enumerateServerState();
+		expect(s.notes.has("old.md")).toBe(false);
+		expect(s.notes.get("new.md")?.deleted).toBe(false);
+	});
+
+	test("a tombstone folds to deleted:true; attachments fold by path", async () => {
+		const engine = createEngine();
+		wireFeed(engine, [
+			[
+				{
+					type: "note",
+					id: "n1",
+					seq: 1,
+					path: "gone.md",
+					content: "x",
+					content_hash: "H1",
+					deleted: false,
+				},
+				{ type: "note", id: "n1", seq: 2, path: "gone.md", deleted: true },
+				{ type: "attachment", seq: 3, path: "img.png", deleted: false },
+				{ type: "attachment", seq: 4, path: "bye.png", deleted: true },
+			],
+		]);
+		const s = await (engine as any).enumerateServerState();
+		expect(s.notes.get("gone.md")?.deleted).toBe(true);
+		expect(s.attachments.get("img.png")).toEqual({ deleted: false });
+		expect(s.attachments.get("bye.png")).toEqual({ deleted: true });
+	});
+
+	test("walks every page (has_more pagination)", async () => {
+		const engine = createEngine();
+		wireFeed(engine, [
+			[
+				{
+					type: "note",
+					id: "n1",
+					seq: 1,
+					path: "a.md",
+					content: "a",
+					content_hash: "HA",
+					deleted: false,
+				},
+			],
+			[
+				{
+					type: "note",
+					id: "n2",
+					seq: 2,
+					path: "b.md",
+					content: "b",
+					content_hash: "HB",
+					deleted: false,
+				},
+			],
+		]);
+		const s = await (engine as any).enumerateServerState();
+		expect([...s.notes.keys()].sort()).toEqual(["a.md", "b.md"]);
+	});
+
+	test("throws when the channel is not live — a wrong empty plan is worse than an error", async () => {
+		const engine = createEngine();
+		engine.setCrdtManager({} as any);
+		engine.setCrdtLiveCheck(() => false);
+		engine.setCrdtCatchupSince(async () => ({ changes: [], has_more: false, next_seq: null }));
+		await expect((engine as any).enumerateServerState()).rejects.toThrow(/live socket/);
+	});
+
+	test("does NOT touch the real catch-up cursor", async () => {
+		const engine = createEngine();
+		engine.setCatchupSeq(7);
+		wireFeed(engine, [
+			[
+				{
+					type: "note",
+					id: "n1",
+					seq: 99,
+					path: "a.md",
+					content: "a",
+					content_hash: "H",
+					deleted: false,
+				},
+			],
+		]);
+		await (engine as any).enumerateServerState();
+		expect(engine.getCatchupSeq()).toBe(7);
+	});
+});
+
 describe("SyncEngine.computeSyncPlan", () => {
+	const row = (o: Partial<any> & { id: string; seq: number; path: string }) => ({
+		type: "note",
+		title: "t",
+		folder: "",
+		tags: [],
+		mtime: 1,
+		updated_at: "2026-01-01T00:00:00Z",
+		deleted: false,
+		...o,
+	});
+
 	test("empty vault and empty server returns zeroed plan", async () => {
 		const engine = createEngine();
 		mockApp.vault.getFiles.mockReturnValue([]);
+		wireFeed(engine, [[]]);
 
 		const plan = await engine.computeSyncPlan("full");
 
@@ -111,15 +297,21 @@ describe("SyncEngine.computeSyncPlan", () => {
 		expect(plan.toDeleteRemote).toEqual([]);
 	});
 
+	test("channel down: the plan REJECTS instead of rendering a wrong empty preview", async () => {
+		const engine = createEngine();
+		mockApp.vault.getFiles.mockReturnValue([]);
+		engine.setCrdtManager({} as any);
+		engine.setCrdtLiveCheck(() => false);
+		engine.setCrdtCatchupSince(async () => ({ changes: [], has_more: false, next_seq: null }));
+
+		await expect(engine.computeSyncPlan("full")).rejects.toThrow(/live socket/);
+	});
+
 	test("local files not on server are counted as toPush", async () => {
 		const engine = createEngine();
 		const files = [makeTFile("Notes/local-only.md"), makeTFile("Notes/another.md")];
 		mockApp.vault.getFiles.mockReturnValue(files);
-		// Server has no changes — files don't exist on server
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [],
-			server_time: "2026-01-01T00:00:00Z",
-		});
+		wireFeed(engine, [[]]); // op-log knows neither path
 
 		const plan = await engine.computeSyncPlan("full");
 
@@ -129,24 +321,20 @@ describe("SyncEngine.computeSyncPlan", () => {
 		expect(plan.localNoteCount).toBe(2);
 	});
 
-	test("server changes not present locally are counted as toPull", async () => {
+	test("server rows not present locally are counted as toPull", async () => {
 		const engine = createEngine();
 		mockApp.vault.getFiles.mockReturnValue([]);
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
 					path: "Notes/remote-only.md",
-					title: "Remote",
 					content: "# Remote",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: false,
-				},
+					content_hash: "H1",
+				}),
 			],
-			server_time: "2026-01-01T00:00:00Z",
-		});
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
@@ -155,54 +343,62 @@ describe("SyncEngine.computeSyncPlan", () => {
 		expect(plan.serverNoteCount).toBe(1);
 	});
 
-	test("server deletions are counted in toDeleteLocal", async () => {
+	test("server tombstones are counted in toDeleteLocal — and never pushed", async () => {
 		const engine = createEngine();
-		// Local file exists
 		const localFile = makeTFile("Notes/to-delete.md");
 		mockApp.vault.getFiles.mockReturnValue([localFile]);
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		// Server signals deletion
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
 					path: "Notes/to-delete.md",
-					title: "Gone",
-					content: "",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: true,
-				},
+					content: "x",
+					content_hash: "H1",
+				}),
+				row({ id: "n1", seq: 2, path: "Notes/to-delete.md", deleted: true }),
 			],
-			server_time: "2026-01-01T00:00:00Z",
-		});
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
 		expect(plan.toDeleteLocal).toContain("Notes/to-delete.md");
 		expect(plan.toPull.notes).not.toContain("Notes/to-delete.md");
+		// Delete-wins: a tombstoned path must not be re-pushed by the local-only leg.
+		expect(plan.toPush.notes).not.toContain("Notes/to-delete.md");
+	});
+
+	test("a rename shows NO ghost work for the old path (id fold)", async () => {
+		const engine = createEngine();
+		mockApp.vault.getFiles.mockReturnValue([]);
+		wireFeed(engine, [
+			[
+				row({ id: "n1", seq: 1, path: "Notes/old.md", content: "x", content_hash: "H1" }),
+				row({ id: "n1", seq: 2, path: "Notes/new.md", content: "x", content_hash: "H1" }),
+			],
+		]);
+
+		const plan = await engine.computeSyncPlan("full");
+
+		expect(plan.toPull.notes).toEqual(["Notes/new.md"]);
+		expect(plan.serverNoteCount).toBe(1);
 	});
 
 	test("push-all mode does not include toPull entries", async () => {
 		const engine = createEngine();
-		// Local has one file, server has a different file not locally present
 		mockApp.vault.getFiles.mockReturnValue([makeTFile("Notes/local.md")]);
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
 					path: "Notes/remote-only.md",
-					title: "Remote",
 					content: "# Remote",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: false,
-				},
+					content_hash: "H1",
+				}),
 			],
-			server_time: "2026-01-01T00:00:00Z",
-		});
+		]);
 
 		const plan = await engine.computeSyncPlan("push-all");
 
@@ -213,36 +409,31 @@ describe("SyncEngine.computeSyncPlan", () => {
 
 	test("file changed both locally and on server is a conflict", async () => {
 		const engine = createEngine();
-		const originalContent = "# Original";
-		const localContent = "# Modified locally";
 		const file = makeTFile("Notes/both-changed.md");
 		mockApp.vault.getFiles.mockReturnValue([file]);
 		mockApp.vault.getFileByPath.mockReturnValue(file);
-		mockApp.vault.cachedRead.mockResolvedValue(localContent);
-
-		// Simulate prior sync with original content hash
-		engine.importHashes({ "Notes/both-changed.md": fnv1a(originalContent) });
-
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
-					path: "Notes/both-changed.md",
-					title: "Both",
-					content: "# Modified on server",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: false,
-				},
-			],
-			server_time: "2026-01-01T00:00:00Z",
+		mockApp.vault.cachedRead.mockResolvedValue("# Modified locally");
+		// Last converge recorded the ORIGINAL on both axes.
+		engine.importSyncState({
+			"Notes/both-changed.md": { hash: fnv1a("# Original"), serverHash: "OLD-HMAC" },
 		});
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
+					path: "Notes/both-changed.md",
+					content: "# Modified on server",
+					content_hash: "NEW-HMAC",
+				}),
+			],
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
 		expect(plan.conflicts).toContain("Notes/both-changed.md");
 		expect(plan.toPull.notes).not.toContain("Notes/both-changed.md");
+		expect(plan.toPush.notes).not.toContain("Notes/both-changed.md");
 	});
 
 	test("file changed only on server (local unchanged) is a pull, not conflict", async () => {
@@ -252,25 +443,18 @@ describe("SyncEngine.computeSyncPlan", () => {
 		mockApp.vault.getFiles.mockReturnValue([file]);
 		mockApp.vault.getFileByPath.mockReturnValue(file);
 		mockApp.vault.cachedRead.mockResolvedValue(content);
-
-		// Simulate prior sync with same content hash
 		engine.importHashes({ "Notes/server-updated.md": fnv1a(content) });
-
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
 					path: "Notes/server-updated.md",
-					title: "Updated",
 					content: "# New server content",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: false,
-				},
+					content_hash: "NEW-HMAC",
+				}),
 			],
-			server_time: "2026-01-01T00:00:00Z",
-		});
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
@@ -278,235 +462,131 @@ describe("SyncEngine.computeSyncPlan", () => {
 		expect(plan.conflicts).not.toContain("Notes/server-updated.md");
 	});
 
-	test("incremental full mode: long-synced local files are NOT flagged toPush when manifest confirms server has them", async () => {
-		// Reproduces the bug from closed PR #31 where PreSyncModal showed e.g.
-		// "server: 0 / local: 299 toPush" on a fully-synced vault. computeSyncPlan
-		// was using getChanges(since=lastSync) as server inventory — long-synced
-		// files don't appear in delta, so they got falsely flagged for push.
+	test("fully-synced vault shows zero work (identical bytes → clean, no push storm)", async () => {
+		// The PR-#31 bug shape: a fully-synced vault must never render
+		// "server: 0 / local: N toPush". The op-log enumeration IS the
+		// inventory, and identical bytes short-circuit to clean.
 		const engine = createEngine();
 		const file = makeTFile("Notes/already-synced.md");
 		mockApp.vault.getFiles.mockReturnValue([file]);
-
-		// Last sync was recent — getChanges(since=lastSync) returns no delta
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [],
-			server_time: "2026-05-16T08:00:00Z",
-		});
-		// Manifest is authoritative: server has this note
-		(mockApi.getManifest as jest.Mock).mockResolvedValue({
-			notes: [{ path: "Notes/already-synced.md", content_hash: "abc123" }],
-			attachments: [],
-			total_notes: 1,
-			total_attachments: 0,
-		});
+		mockApp.vault.getFileByPath.mockReturnValue(file);
+		mockApp.vault.cachedRead.mockResolvedValue("# Test\n\nContent");
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
+					path: "Notes/already-synced.md",
+					content: "# Test\n\nContent",
+					content_hash: "H1",
+				}),
+			],
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
 		expect(plan.toPush.notes).toEqual([]);
+		expect(plan.toPull.notes).toEqual([]);
+		expect(plan.conflicts).toEqual([]);
 		expect(plan.serverNoteCount).toBe(1);
 		expect(plan.localNoteCount).toBe(1);
 	});
 
-	test("incremental full mode: file in manifest but missing locally is still toPull when delta carries content", async () => {
-		// Server has a file the user hasn't pulled yet (e.g., another device pushed it).
-		// Manifest lists the path; delta carries the content for pull.
-		const engine = createEngine();
-		mockApp.vault.getFiles.mockReturnValue([]);
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
-					path: "Notes/from-other-device.md",
-					title: "Other",
-					content: "# Other device",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: false,
-				},
-			],
-			server_time: "2026-05-16T08:00:00Z",
-		});
-		(mockApi.getManifest as jest.Mock).mockResolvedValue({
-			notes: [{ path: "Notes/from-other-device.md", content_hash: "xyz" }],
-			attachments: [],
-			total_notes: 1,
-			total_attachments: 0,
-		});
-
-		const plan = await engine.computeSyncPlan("full");
-
-		expect(plan.toPull.notes).toContain("Notes/from-other-device.md");
-		expect(plan.toPush.notes).toEqual([]);
-		expect(plan.serverNoteCount).toBe(1);
-	});
-
-	test("incremental full mode: manifest-unavailable falls back to delta-since-epoch (full inventory query)", async () => {
-		// Older self-hosted backends without /sync/manifest still need to work.
-		// Fallback: widen the delta query to since=epoch so it doubles as inventory.
-		// Slower per-call (one-shot full fetch) but correct.
-		const engine = createEngine();
-		const file = makeTFile("Notes/local.md");
-		mockApp.vault.getFiles.mockReturnValue([file]);
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		(mockApi.getManifest as jest.Mock).mockResolvedValue(null);
-
-		// Stateful mock: server returns the file ONLY when queried since epoch
-		// (i.e., full-inventory mode). A since=lastSync query gets empty.
-		(mockApi.getChanges as jest.Mock).mockImplementation((since: string) =>
-			Promise.resolve({
-				changes:
-					since === "1970-01-01T00:00:00Z"
-						? [
-								{
-									path: "Notes/local.md",
-									title: "Local",
-									content: "# Local",
-									folder: "Notes",
-									tags: [],
-									mtime: Date.now() / 1000,
-									updated_at: new Date().toISOString(),
-									deleted: false,
-								},
-							]
-						: [],
-				server_time: "2026-05-16T08:00:00Z",
-			}),
-		);
-
-		const plan = await engine.computeSyncPlan("full");
-
-		// Fix widened the since param to epoch so the delta returns the full server set
-		expect(mockApi.getChanges).toHaveBeenCalledWith("1970-01-01T00:00:00Z", expect.anything());
-		expect(plan.toPush.notes).toEqual([]);
-	});
-
-	test("locally-modified note (manifest has it, delta empty, hash diverges) is flagged toPush", async () => {
-		// The PreSyncModal previously had no way to surface "you edited a note
-		// since last sync." The delta only carries server-side changes; the
-		// modal silently missed local edits and lied about the work to do.
-		const engine = createEngine();
-		const file = makeTFile("Notes/edited.md");
-		mockApp.vault.getFiles.mockReturnValue([file]);
-		mockApp.vault.getFileByPath.mockReturnValue(file);
-		mockApp.vault.cachedRead.mockResolvedValue("# Edited locally");
-
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		// syncState was recorded at the LAST sync with a different (earlier) content
-		engine.importHashes({ "Notes/edited.md": fnv1a("# Original") });
-
-		(mockApi.getManifest as jest.Mock).mockResolvedValue({
-			notes: [{ path: "Notes/edited.md", content_hash: "server-hash" }],
-			attachments: [],
-			total_notes: 1,
-			total_attachments: 0,
-		});
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [],
-			server_time: "2026-05-16T08:00:00Z",
-		});
-
-		const plan = await engine.computeSyncPlan("full");
-
-		expect(plan.toPush.notes).toContain("Notes/edited.md");
-		expect(plan.conflicts).not.toContain("Notes/edited.md");
-	});
-
-	test("locally-modified note NOT double-counted when delta also reports a server change (pull/conflict branch handles it)", async () => {
-		// If a path is in the delta (server changed it), the existing pull/conflict
-		// branches already decide what to do. Adding the same path to toPush via
-		// the locally-modified detector would double-count and confuse the UI.
-		const engine = createEngine();
-		const file = makeTFile("Notes/both.md");
-		mockApp.vault.getFiles.mockReturnValue([file]);
-		mockApp.vault.getFileByPath.mockReturnValue(file);
-		mockApp.vault.cachedRead.mockResolvedValue("# Modified locally");
-
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		engine.importHashes({ "Notes/both.md": fnv1a("# Original") });
-
-		(mockApi.getManifest as jest.Mock).mockResolvedValue({
-			notes: [{ path: "Notes/both.md", content_hash: "server-hash" }],
-			attachments: [],
-			total_notes: 1,
-			total_attachments: 0,
-		});
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [
-				{
-					path: "Notes/both.md",
-					title: "Both",
-					content: "# Modified on server",
-					folder: "Notes",
-					tags: [],
-					mtime: Date.now() / 1000,
-					updated_at: new Date().toISOString(),
-					deleted: false,
-				},
-			],
-			server_time: "2026-05-16T08:00:00Z",
-		});
-
-		const plan = await engine.computeSyncPlan("full");
-
-		// Path appears once at most across pull/conflict/push. The pull/conflict
-		// branches above own this path; toPush must not duplicate it.
-		expect(plan.toPush.notes).not.toContain("Notes/both.md");
-	});
-
-	test("file in manifest with NO syncState entry is treated as clean (no spurious push storm on fresh install)", async () => {
-		// A fresh plugin install will have an empty syncState but a vault full
-		// of files the server already holds. Without this guard we'd push every
-		// file unnecessarily. A real content cross-check needs a plugin-side
-		// computable server hash (Tier 3 backend work) — not in scope.
+	test("fresh install (no syncState) with identical server content is clean — no spurious push storm", async () => {
 		const engine = createEngine();
 		const file = makeTFile("Notes/fresh-install.md");
 		mockApp.vault.getFiles.mockReturnValue([file]);
 		mockApp.vault.getFileByPath.mockReturnValue(file);
 		mockApp.vault.cachedRead.mockResolvedValue("# Content");
-
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		// No importHashes call — syncState is empty
-
-		(mockApi.getManifest as jest.Mock).mockResolvedValue({
-			notes: [{ path: "Notes/fresh-install.md", content_hash: "server-hash" }],
-			attachments: [],
-			total_notes: 1,
-			total_attachments: 0,
-		});
-		(mockApi.getChanges as jest.Mock).mockResolvedValue({
-			changes: [],
-			server_time: "2026-05-16T08:00:00Z",
-		});
+		// No syncState at all.
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
+					path: "Notes/fresh-install.md",
+					content: "# Content",
+					content_hash: "H1",
+				}),
+			],
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
 		expect(plan.toPush.notes).toEqual([]);
+		expect(plan.conflicts).toEqual([]);
 	});
 
-	test("file in manifest with matching syncState hash is clean (no toPush)", async () => {
+	test("locally-modified note (server unchanged: row hash == recorded serverHash) is flagged toPush", async () => {
 		const engine = createEngine();
-		const file = makeTFile("Notes/clean.md");
+		const file = makeTFile("Notes/edited.md");
+		mockApp.vault.getFiles.mockReturnValue([file]);
+		mockApp.vault.getFileByPath.mockReturnValue(file);
+		mockApp.vault.cachedRead.mockResolvedValue("# Edited locally");
+		engine.importSyncState({
+			"Notes/edited.md": { hash: fnv1a("# Original"), serverHash: "SAME-HMAC" },
+		});
+		wireFeed(engine, [
+			[
+				row({
+					id: "n1",
+					seq: 1,
+					path: "Notes/edited.md",
+					content: "# Original",
+					content_hash: "SAME-HMAC",
+				}),
+			],
+		]);
+
+		const plan = await engine.computeSyncPlan("full");
+
+		expect(plan.toPush.notes).toContain("Notes/edited.md");
+		expect(plan.conflicts).not.toContain("Notes/edited.md");
+		expect(plan.toPull.notes).not.toContain("Notes/edited.md");
+	});
+
+	test("clean bookkeeping without row content: serverHash match + local hash match → no work", async () => {
+		// A row that carries no content payload (e.g. oversized note) must still
+		// classify as clean when BOTH the recorded serverHash matches the row's
+		// hash AND the local hash matches the recorded one.
+		const engine = createEngine();
 		const content = "# Clean";
+		const file = makeTFile("Notes/clean.md");
 		mockApp.vault.getFiles.mockReturnValue([file]);
 		mockApp.vault.getFileByPath.mockReturnValue(file);
 		mockApp.vault.cachedRead.mockResolvedValue(content);
-
-		engine.setLastSync("2026-05-16T07:00:00Z");
-		engine.importHashes({ "Notes/clean.md": fnv1a(content) });
-
-		(mockApi.getManifest as jest.Mock).mockResolvedValue({
-			notes: [{ path: "Notes/clean.md", content_hash: "server-hash" }],
-			attachments: [],
-			total_notes: 1,
-			total_attachments: 0,
+		engine.importSyncState({
+			"Notes/clean.md": { hash: fnv1a(content), serverHash: "SAME-HMAC" },
 		});
+		wireFeed(engine, [
+			[row({ id: "n1", seq: 1, path: "Notes/clean.md", content_hash: "SAME-HMAC" })],
+		]);
 
 		const plan = await engine.computeSyncPlan("full");
 
 		expect(plan.toPush.notes).toEqual([]);
+		expect(plan.toPull.notes).toEqual([]);
+		expect(plan.conflicts).toEqual([]);
+	});
+
+	test("attachments ride the same feed: pull missing, delete tombstoned, push local-only", async () => {
+		const engine = createEngine();
+		const localImg = makeTFile("img/local-only.png");
+		const localGone = makeTFile("img/server-deleted.png");
+		mockApp.vault.getFiles.mockReturnValue([localImg, localGone]);
+		wireFeed(engine, [
+			[
+				{ type: "attachment", seq: 1, path: "img/remote-only.png", deleted: false },
+				{ type: "attachment", seq: 2, path: "img/server-deleted.png", deleted: true },
+			],
+		]);
+
+		const plan = await engine.computeSyncPlan("full");
+
+		expect(plan.toPull.attachments).toContain("img/remote-only.png");
+		expect(plan.toDeleteLocal).toContain("img/server-deleted.png");
+		expect(plan.toPush.attachments).toContain("img/local-only.png");
+		expect(plan.toPush.attachments).not.toContain("img/server-deleted.png");
 	});
 
 	test("ignored files (.obsidian/) are excluded from plan", async () => {
@@ -517,6 +597,7 @@ describe("SyncEngine.computeSyncPlan", () => {
 			makeTFile("Notes/legit.md"),
 		];
 		mockApp.vault.getFiles.mockReturnValue(files);
+		wireFeed(engine, [[]]);
 
 		const plan = await engine.computeSyncPlan("full");
 

--- a/tests/sync-plan.test.ts
+++ b/tests/sync-plan.test.ts
@@ -236,8 +236,39 @@ describe("SyncEngine.enumerateServerState", () => {
 		expect([...s.notes.keys()].sort()).toEqual(["a.md", "b.md"]);
 	});
 
-	test("throws when the channel is not live — a wrong empty plan is worse than an error", async () => {
+	test("waits for the socket to become live, then enumerates (startup join race)", async () => {
+		// On startup the preview can be computed before the crdt: join lands
+		// (onCrdtJoined). Rather than fail the preview outright, enumerate waits
+		// briefly for the socket to become enumerable.
 		const engine = createEngine();
+		engine.setCrdtManager({} as any);
+		let live = false;
+		engine.setCrdtLiveCheck(() => live);
+		engine.setCrdtCatchupSince(async () => ({
+			changes: [
+				{
+					type: "note",
+					id: "n1",
+					seq: 1,
+					path: "a.md",
+					content: "v",
+					content_hash: "H",
+					deleted: false,
+				},
+			] as any,
+			has_more: false,
+			next_seq: 1,
+		}));
+		setTimeout(() => {
+			live = true;
+		}, 120);
+		const s = await (engine as any).enumerateServerState();
+		expect(s.notes.get("a.md")).toEqual({ deleted: false, content: "v", contentHash: "H" });
+	});
+
+	test("throws after the wait budget when the socket never becomes live", async () => {
+		const engine = createEngine();
+		(engine as any).enumerateWaitMs = 150;
 		engine.setCrdtManager({} as any);
 		engine.setCrdtLiveCheck(() => false);
 		engine.setCrdtCatchupSince(async () => ({ changes: [], has_more: false, next_seq: null }));
@@ -299,6 +330,7 @@ describe("SyncEngine.computeSyncPlan", () => {
 
 	test("channel down: the plan REJECTS instead of rendering a wrong empty preview", async () => {
 		const engine = createEngine();
+		(engine as any).enumerateWaitMs = 150;
 		mockApp.vault.getFiles.mockReturnValue([]);
 		engine.setCrdtManager({} as any);
 		engine.setCrdtLiveCheck(() => false);

--- a/tests/sync-postpull-defer.test.ts
+++ b/tests/sync-postpull-defer.test.ts
@@ -21,11 +21,9 @@ const hang = () => new Promise<never>(() => {});
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "sid" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockImplementation(hang),
 	getManifest: mock().mockImplementation(hang),
 	health: mock().mockResolvedValue(true),
 	ping: mock().mockResolvedValue({ ok: true }),
-	getAttachmentChanges: mock().mockImplementation(hang),
 	getRateLimit: mock().mockResolvedValue(0),
 } as unknown as EngramApi;
 

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -56,17 +56,12 @@ function makeApi(): EngramApi {
 	return {
 		pushNote: mock().mockResolvedValue({ note: { path: "" }, chunks_indexed: 1 }),
 		pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-		getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 		pushAttachment: mock().mockResolvedValue({ attachment: {} }),
 		deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 		deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
 		health: mock().mockResolvedValue(true),
 		ping: mock().mockResolvedValue({ ok: true }),
 		getManifest: mock().mockResolvedValue(null),
-		getAttachmentChanges: mock().mockResolvedValue({
-			changes: [],
-			server_time: "2026-01-01T00:00:00Z",
-		}),
 		getRateLimit: mock().mockResolvedValue(0),
 		registerVault: mock().mockResolvedValue({
 			id: "v1",

--- a/tests/sync-replay-cas-enroll.test.ts
+++ b/tests/sync-replay-cas-enroll.test.ts
@@ -29,16 +29,11 @@ const mockApi = {
 		chunks_indexed: 1,
 	}),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	health: mock().mockResolvedValue(true),
 	ping: mock().mockResolvedValue({ ok: true }),
 	pushAttachment: mock().mockResolvedValue({ attachment: {} }),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 } as unknown as EngramApi;

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -18,7 +18,6 @@ import { DEFAULT_SETTINGS, type SyncAttachmentChange, type SyncNoteChange } from
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "n.md",
@@ -39,10 +38,6 @@ const mockApi = {
 		mtime: 0,
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: mock().mockResolvedValue({

--- a/tests/sync-stale-materialize.test.ts
+++ b/tests/sync-stale-materialize.test.ts
@@ -19,15 +19,10 @@ import { DEFAULT_SETTINGS } from "../src/types";
 const mockApi = {
 	pushNote: mock().mockResolvedValue({ note: { id: "sid" }, chunks_indexed: 1 }),
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	health: mock().mockResolvedValue(true),
 	ping: mock().mockResolvedValue({ ok: true }),
 	getRateLimit: mock().mockResolvedValue(0),
-	getAttachmentChanges: mock().mockResolvedValue({
-		changes: [],
-		server_time: "2026-01-01T00:00:00Z",
-	}),
 	getManifest: mock().mockResolvedValue(null),
 } as unknown as EngramApi;
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -13,7 +13,6 @@ const mockApi = {
 	// Legacy-backend shape: no batch endpoint — engine falls back to per-note
 	// pushes, which is exactly what these tests assert.
 	pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
-	getChanges: mock().mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
 	getNote: mock().mockResolvedValue({
 		path: "Notes/Remote.md",
@@ -38,9 +37,6 @@ const mockApi = {
 		updated_at: "2026-03-01T12:00:00Z",
 	}),
 	deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
-	getAttachmentChanges: jest
-		.fn()
-		.mockResolvedValue({ changes: [], server_time: "2026-01-01T00:00:00Z" }),
 	getRateLimit: mock().mockResolvedValue(0),
 	getManifest: mock().mockResolvedValue(null),
 	registerVault: jest
@@ -2284,14 +2280,6 @@ describe("SyncEngine pull accuracy", () => {
 		engine.setLastSync(oldSync);
 
 		// Pull will update lastSync to a newer server_time
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-01T12:00:00Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-01T12:00:00Z",
-		});
 
 		// A file modified between old lastSync and new server_time.
 		// .canvas so pushModifiedFiles' selected file takes the LWW REST route.
@@ -2325,14 +2313,6 @@ describe("SyncEngine pull accuracy", () => {
 		});
 
 		// Pull returns no changes but advances lastSync to a recent server_time.
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
 
 		// Tracked local file modified Feb 15 — BEFORE the post-pull server_time.
 		const trackedFile = new TFile(
@@ -2358,14 +2338,6 @@ describe("SyncEngine pull accuracy", () => {
 		const phases: string[] = [];
 		engine.onSyncProgress = (p) => phases.push(p.phase);
 
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
 		const a = new TFile("Notes/A.md", new Date("2026-02-15T00:00:00Z").getTime());
 		const b = new TFile("Notes/B.md", new Date("2026-02-15T00:00:00Z").getTime());
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValueOnce([a, b]);
@@ -2381,14 +2353,6 @@ describe("SyncEngine pull accuracy", () => {
 		// pushModifiedFiles treats them as untracked and re-pushes them on every
 		// Merge (the "pulled 0 pushed 10 every time" loop for binary files).
 		const engine = createEngine();
-
-		// Two pulls, both empty (new/empty remote), each advancing lastSync.
-		(mockApi.getChanges as jest.Mock)
-			.mockResolvedValueOnce({ changes: [], server_time: "2026-03-02T00:00:00Z" })
-			.mockResolvedValueOnce({ changes: [], server_time: "2026-03-03T00:00:00Z" });
-		(mockApi.getAttachmentChanges as jest.Mock)
-			.mockResolvedValueOnce({ changes: [], server_time: "2026-03-02T00:00:00Z" })
-			.mockResolvedValueOnce({ changes: [], server_time: "2026-03-03T00:00:00Z" });
 
 		// One attachment, last modified long ago (not edited between runs).
 		const png = new TFile("Assets/photo.png", new Date("2026-02-15T00:00:00Z").getTime());
@@ -2408,14 +2372,6 @@ describe("SyncEngine pull accuracy", () => {
 		engine.setSyncStateVaultId("vault-old"); // syncState belongs to a different vault
 		engine.importSyncState({ "Notes/Stale.md": { hash: 111 } });
 
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValueOnce([]);
 
 		await engine.fullSync();
@@ -2429,14 +2385,6 @@ describe("SyncEngine pull accuracy", () => {
 		engine.setSyncStateVaultId("vault-1");
 		engine.importSyncState({ "Notes/Keep.md": { hash: 222 } });
 
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValueOnce([]);
 
 		await engine.fullSync();
@@ -2449,14 +2397,6 @@ describe("SyncEngine pull accuracy", () => {
 		// No setSyncStateVaultId — simulates pre-upgrade data with existing state.
 		engine.importSyncState({ "Notes/Legacy.md": { hash: 333 } });
 
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-03-02T00:00:00Z",
-		});
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValueOnce([]);
 
 		await engine.fullSync();
@@ -2638,7 +2578,6 @@ describe("SyncEngine auth validation", () => {
 		const engine = createEngine();
 
 		await expect(engine.fullSync()).rejects.toThrow("Invalid API key");
-		expect(mockApi.getChanges).not.toHaveBeenCalled();
 		expect(mockApi.pushNote).not.toHaveBeenCalled();
 	});
 
@@ -3842,25 +3781,6 @@ describe("SyncEngine.pullAll with deleteLocalExtras", () => {
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValue([
 			new TFile("local-only.md", Date.now()),
 		]);
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [
-				{
-					path: "remote.md",
-					title: "remote",
-					content: "# remote",
-					folder: "",
-					tags: [],
-					mtime: 1709345678,
-					updated_at: "2026-01-01T00:00:00Z",
-					deleted: false,
-				},
-			],
-			server_time: "2026-01-01T00:00:01Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-01-01T00:00:01Z",
-		});
 
 		await engine.pullAll({ deleteLocalExtras: false });
 
@@ -3871,25 +3791,6 @@ describe("SyncEngine.pullAll with deleteLocalExtras", () => {
 		const engine = createEngine();
 		const localOnly = new TFile("local-only.md", Date.now());
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValue([localOnly]);
-		(mockApi.getChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [
-				{
-					path: "remote.md",
-					title: "remote",
-					content: "# remote",
-					folder: "",
-					tags: [],
-					mtime: 1709345678,
-					updated_at: "2026-01-01T00:00:00Z",
-					deleted: false,
-				},
-			],
-			server_time: "2026-01-01T00:00:01Z",
-		});
-		(mockApi.getAttachmentChanges as jest.Mock).mockResolvedValueOnce({
-			changes: [],
-			server_time: "2026-01-01T00:00:01Z",
-		});
 
 		await engine.pullAll({ deleteLocalExtras: true });
 
@@ -3930,14 +3831,14 @@ describe("SyncEngine sync-blocked gate", () => {
 		expect(mockApi.deleteNote).not.toHaveBeenCalled();
 	});
 
-	test("setSyncBlocked(true) makes pullAll return 0 without calling getChanges", async () => {
+	test("setSyncBlocked(true) makes pullAll return 0 without touching the server", async () => {
 		const engine = createEngine();
 		engine.setSyncBlocked(true);
 
 		const pulled = await engine.pullAll({ deleteLocalExtras: false });
 
 		expect(pulled).toBe(0);
-		expect(mockApi.getChanges).not.toHaveBeenCalled();
+		expect(mockApi.getNote).not.toHaveBeenCalled();
 	});
 
 	test("setSyncBlocked(true) makes pushAll return 0 without calling ping/pushNote", async () => {
@@ -3958,7 +3859,7 @@ describe("SyncEngine sync-blocked gate", () => {
 		const result = await engine.fullSync();
 
 		expect(result).toEqual({ pulled: 0, pushed: 0 });
-		expect(mockApi.getChanges).not.toHaveBeenCalled();
+		expect(mockApi.pushNote).not.toHaveBeenCalled();
 	});
 
 	test("setSyncBlocked(false) restores normal handleModify", async () => {


### PR DESCRIPTION
Closes #304. Redo of #311 (reverted in #313), with the two regressions that backend e2e test_55 caught now fixed.

## What #311 did (restored here)
`computeSyncPlan` enumerates server state from the crdt: op-log socket (`enumerateServerState`) instead of REST `getManifest`+`getChanges`; deletes `api.getChanges`/`getAttachmentChanges`, the `ChangesResponse`/`AttachmentChangesResponse` types, `fetchAllNoteChanges`, the bulk deadline class, and the sim `/notes/changes`+`/vault/heads` endpoints. (First commit is the exact reapply of #311.)

## The two fixes (second commit)

1. **Startup join race** — #311's `enumerateServerState` required `this.crdt` + `crdtLive()` and threw instantly. But the plan is computed the moment the user channel joins, *before* the crdt: topic join lands (`onCrdtJoined`) — so it threw `needs the live socket (op-log enumeration)` across the suite, and test_55 (which asserts on the rendered modal) failed. Now it **polls for (catchupSince && manager && crdtLive) up to `enumerateWaitMs` (8s)** before failing — the same join-wait pattern the startup catch-up already uses. Falls through to the offline error only after the budget.

2. **Vault switch** — `applyVaultChange` deliberately skips `setupNoteStream` (to avoid stacking a second modal), so the channel stayed bound to the old vault and the vault guard threw. It now **rebuilds the stream for the new vault** (`setupNoteStream`, which — unlike `saveSettings` — does not re-fire `doSyncWithFirstSyncCheck`, verified: the only modal-opening call sites are in `onload`/`saveSettings`/status-bar-click). Fix 1's wait covers the rebuild window and enumerates the new vault once its join lands.

## Tests
- New RED-first unit tests: wait-then-enumerate (socket goes live mid-wait), throw-after-budget (never live). Existing not-live tests shrink `enumerateWaitMs` to stay fast.
- `bun test` 2254 pass / 0 fail · `biome ci` clean · `bun run build` clean.

## Merge gate (the #311 lesson)
Plugin backend/e2e is report-only, so it did NOT block #311 — this PR **must not merge until backend e2e-clerk (test_55 especially) is green**. I'll verify that manually before merge.

## Backend follow-up (unchanged from #311)
`GET /notes/changes` + `GET /attachments/changes` lose their last plugin caller — backend deletion stays deploy-gated (Engram#1088-style).