### PR TITLE
feat: thread + persist the composite {seq,id} catch-up cursor (#312)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1697,9 +1697,11 @@ var LARGE_FRAME_WARN_BYTES = 1e6, NoteChannel = class {
    *  merged notes+attachments feed), so it is causally complete and can
    *  never pend the way a state-vector delta can — this is what a
    *  reconnecting device replays to converge (deaf-note fix, e2e test_85). */
-  async crdtCatchupSince(cursorSeq, limit) {
-    let payload = { cursor_seq: cursorSeq };
-    return limit !== void 0 && (payload.limit = limit), await this.sendRequest("crdt_catchup_since", payload);
+  async crdtCatchupSince(cursorSeq, limit, cursorId) {
+    let payload = {
+      cursor_seq: cursorSeq
+    };
+    return limit !== void 0 && (payload.limit = limit), cursorId && (payload.cursor_id = cursorId), await this.sendRequest("crdt_catchup_since", payload);
   }
   async connect() {
     this.ws || (this.reconnectMs = 1e3, this.joinFailureBackoffMs = 1e3, await this.openSocket());
@@ -18214,6 +18216,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  from here so only ops written while we were away are replayed. 0 = replay
      *  from genesis (first-ever connect / after a state wipe). */
     this.catchupSeq = 0;
+    /** Composite-cursor id paired with `catchupSeq` (#312). An attachment move
+     *  writes two rows at one seq; the id lets a resumed replay continue at
+     *  `(seq, id) > (catchupSeq, catchupId)` instead of the seq-only `seq >`,
+     *  which would skip the second row. Only feeds the catch-up fetch — NOT the
+     *  gap-heal fence (that stays seq-only + hash-aware). Null = no id yet
+     *  (seq-only, e.g. a genesis replay or a pre-#312 backend). */
+    this.catchupId = null;
     /** The vault change_seq watermark of the last FULLY-processed manifest pass
      *  (Phase E1 #1065). Sent as `?since_seq=` so an unchanged vault
      *  short-circuits the manifest fetch + the manifest-driven catch-up steps.
@@ -18859,6 +18868,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   setCatchupSeq(seq3) {
     this.catchupSeq = Number.isFinite(seq3) && seq3 >= 0 ? seq3 : 0;
   }
+  getCatchupId() {
+    return this.catchupId;
+  }
+  setCatchupId(id2) {
+    this.catchupId = typeof id2 == "string" && id2.length > 0 ? id2 : null;
+  }
   getManifestSeq() {
     return this.manifestSeq;
   }
@@ -18931,7 +18946,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  point; a wipe that exists on only one path re-opens #200. */
   async wipePerVaultState() {
     var _a;
-    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
+    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
   }
   /** Reset all per-vault sync bookkeeping. Used when the user switches the
    *  active server vault inside the SyncPreviewModal so the next sync starts
@@ -19650,20 +19665,29 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  as `computeSyncPlan`'s inventory (#304, REST-purge Bucket C — the
    *  preview was their last caller). Throws when the channel is not live: the
    *  preview must error visibly, never render a wrong empty plan. */
+  /** Strict forward comparison of the composite `(seq, id)` catch-up cursor.
+   *  Returns true iff `(nextSeq, nextId)` is strictly greater than
+   *  `(curSeq, curId)` — the same keyset ordering the backend queries with. The
+   *  equal-seq case (`nextSeq === curSeq`, `nextId > curId`) is what pages
+   *  correctly across an attachment-move pair (#312). Ids compare as strings:
+   *  canonical UUIDs sort identically byte-wise (Postgres uuid) and lexically. */
+  cursorAdvances(nextSeq, nextId, curSeq, curId) {
+    return typeof nextSeq != "number" ? !1 : nextSeq > curSeq ? !0 : nextSeq < curSeq ? !1 : (nextId != null ? nextId : "") > (curId != null ? curId : "");
+  }
   async enumerateServerState() {
-    var _a, _b, _c, _d;
+    var _a, _b, _c, _d, _e, _f;
     let deadline = Date.now() + this.enumerateWaitMs;
     for (; (!this.crdtCatchupSince || !this.crdt || !((_b = (_a = this.crdtLive) == null ? void 0 : _a.call(this)) != null && _b)) && Date.now() < deadline; )
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
     if (!this.crdtCatchupSince || !this.crdt || !((_d = (_c = this.crdtLive) == null ? void 0 : _c.call(this)) != null && _d))
       throw new Error("Sync preview needs the live socket (op-log enumeration)");
-    let byId = /* @__PURE__ */ new Map(), attachments = /* @__PURE__ */ new Map(), cursor = 0;
+    let byId = /* @__PURE__ */ new Map(), attachments = /* @__PURE__ */ new Map(), cursor = 0, cursorId = null;
     for (let page = 0; page < 1e5; page++) {
-      let resp = await this.crdtCatchupSince(cursor, 500);
+      let resp = await this.crdtCatchupSince(cursor, 500, cursorId);
       for (let c of resp.changes)
-        typeof c.seq == "number" && c.seq > cursor && (cursor = c.seq), c.type === "attachment" ? c.path && attachments.set(c.path, { deleted: c.deleted }) : c.id && c.path && byId.set(c.id, c);
-      if (!resp.has_more) break;
-      typeof resp.next_seq == "number" && resp.next_seq > cursor && (cursor = resp.next_seq);
+        c.type === "attachment" ? c.path && attachments.set(c.path, { deleted: c.deleted }) : c.id && c.path && byId.set(c.id, c);
+      if (!resp.has_more || !this.cursorAdvances(resp.next_seq, (_e = resp.next_id) != null ? _e : null, cursor, cursorId)) break;
+      cursor = resp.next_seq, cursorId = (_f = resp.next_id) != null ? _f : null;
     }
     let notes = /* @__PURE__ */ new Map();
     for (let c of byId.values())
@@ -19767,15 +19791,19 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     }
   }
   async runSeqReplayOnce(fromZero, serverIds, serverAttachmentPaths, enumerateOnly = !1) {
-    var _a;
+    var _a, _b, _c;
     if (!this.crdtCatchupSince || !this.crdt) return 0;
-    let activeVault = (_a = this.settings.vaultId) != null ? _a : null, cursor = fromZero ? 0 : this.syncStateVaultId === activeVault ? this.getCatchupSeq() : 0;
-    this.seqRewindFloor !== null && !fromZero && (cursor = Math.min(cursor, this.seqRewindFloor)), this.seqRewindFloor = null;
+    let activeVault = (_a = this.settings.vaultId) != null ? _a : null, resumable = !fromZero && this.syncStateVaultId === activeVault, cursor = resumable ? this.getCatchupSeq() : 0, cursorId = resumable ? this.getCatchupId() : null;
+    if (this.seqRewindFloor !== null && !fromZero) {
+      let floored = Math.min(cursor, this.seqRewindFloor);
+      floored !== cursor && (cursorId = null), cursor = floored;
+    }
+    this.seqRewindFloor = null;
     let applied = 0;
     for (let page = 0; page < 1e5; page++) {
-      let resp;
+      let pageStartSeq = cursor, pageStartId = cursorId, resp;
       try {
-        resp = await this.crdtCatchupSince(cursor, 500);
+        resp = await this.crdtCatchupSince(cursor, 500, cursorId);
       } catch (e) {
         return rlog().warn("crdt", `seq-replay: fetch failed at cursor=${cursor} \u2014 ${errMsg(e)}`), applied;
       }
@@ -19786,10 +19814,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           } catch (e) {
             rlog().error("crdt", `seq-replay: skipped ${c.path} \u2014 ${errMsg(e)}`);
           }
-        typeof c.seq == "number" && c.seq > cursor && (cursor = c.seq), c.type === "attachment" ? c.deleted || serverAttachmentPaths.add(c.path) : c.id && !c.deleted && serverIds.add(c.id);
+        this.cursorAdvances(
+          typeof c.seq == "number" ? c.seq : null,
+          (_b = c.id) != null ? _b : null,
+          cursor,
+          cursorId
+        ) && (cursor = c.seq, cursorId = (_c = c.id) != null ? _c : null), c.type === "attachment" ? c.deleted || serverAttachmentPaths.add(c.path) : c.id && !c.deleted && serverIds.add(c.id);
       }
-      if (enumerateOnly || (this.setCatchupSeq(cursor), await this.saveData({ catchupSeq: this.getCatchupSeq() })), !resp.has_more) break;
-      typeof resp.next_seq == "number" && resp.next_seq > cursor && (cursor = resp.next_seq);
+      if (enumerateOnly || (this.setCatchupSeq(cursor), this.setCatchupId(cursorId), await this.saveData({
+        catchupSeq: this.getCatchupSeq(),
+        catchupId: this.getCatchupId()
+      })), !resp.has_more || !this.cursorAdvances(cursor, cursorId, pageStartSeq, pageStartId)) break;
     }
     return applied;
   }
@@ -23589,7 +23624,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       "lifecycle",
       `Plugin loading | v${this.manifest.version} | ${import_obsidian26.Platform.isMobile ? "mobile" : "desktop"}`
     ), this.syncEngine = new SyncEngine(this.app, this.api, this.settings, async (data) => {
-      data.lastSync !== void 0 && this.syncEngine.setLastSync(data.lastSync), data.catchupSeq !== void 0 && this.syncEngine.setCatchupSeq(data.catchupSeq), data.manifestSeq !== void 0 && this.syncEngine.setManifestSeq(data.manifestSeq), await this.savePluginData(this.syncEngine.getLastSync());
+      data.lastSync !== void 0 && this.syncEngine.setLastSync(data.lastSync), data.catchupSeq !== void 0 && this.syncEngine.setCatchupSeq(data.catchupSeq), data.catchupId !== void 0 && this.syncEngine.setCatchupId(data.catchupId), data.manifestSeq !== void 0 && this.syncEngine.setManifestSeq(data.manifestSeq), await this.savePluginData(this.syncEngine.getLastSync());
     }), this.syncLog = new SyncLog(), this.syncEngine.syncLog = this.syncLog, this.syncEngine.setCrdtLiveCheck(() => {
       var _a2, _b2;
       return (_b2 = (_a2 = this.noteStream) == null ? void 0 : _a2.isCrdtConnected()) != null ? _b2 : !1;
@@ -23666,7 +23701,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       }
     );
     let saved = await this.loadPluginData();
-    saved != null && saved.lastSync && this.syncEngine.setLastSync(saved.lastSync), (saved == null ? void 0 : saved.catchupSeq) !== void 0 && this.syncEngine.setCatchupSeq(saved.catchupSeq), (saved == null ? void 0 : saved.manifestSeq) !== void 0 && this.syncEngine.setManifestSeq(saved.manifestSeq), (_a = saved == null ? void 0 : saved.offlineQueue) != null && _a.length && this.syncEngine.queue.load(saved.offlineQueue), (_b = saved == null ? void 0 : saved.crdtOpQueue) != null && _b.length && ((_c = this.crdtOpQueue) == null || _c.load(saved.crdtOpQueue)), (saved == null ? void 0 : saved.syncStateVaultId) !== void 0 && this.syncEngine.setSyncStateVaultId(saved.syncStateVaultId), saved != null && saved.syncState ? this.syncEngine.importSyncState(saved.syncState) : saved != null && saved.syncedHashes && (this.syncEngine.importHashes(saved.syncedHashes), devLog().log("lifecycle", "Migrated legacy syncedHashes \u2192 syncState")), this.syncEngine.issues.hydrate(saved == null ? void 0 : saved.syncIssues), this.syncEngine.ignoredFiles.hydrate(saved == null ? void 0 : saved.ignoredFiles), this.settings.planState && this.syncEngine.hydratePlanState(this.settings.planState), this.settingTab = new EngramSyncSettingTab(this.app, this), this.addSettingTab(this.settingTab), this.registerEvent(
+    saved != null && saved.lastSync && this.syncEngine.setLastSync(saved.lastSync), (saved == null ? void 0 : saved.catchupSeq) !== void 0 && this.syncEngine.setCatchupSeq(saved.catchupSeq), (saved == null ? void 0 : saved.catchupId) !== void 0 && this.syncEngine.setCatchupId(saved.catchupId), (saved == null ? void 0 : saved.manifestSeq) !== void 0 && this.syncEngine.setManifestSeq(saved.manifestSeq), (_a = saved == null ? void 0 : saved.offlineQueue) != null && _a.length && this.syncEngine.queue.load(saved.offlineQueue), (_b = saved == null ? void 0 : saved.crdtOpQueue) != null && _b.length && ((_c = this.crdtOpQueue) == null || _c.load(saved.crdtOpQueue)), (saved == null ? void 0 : saved.syncStateVaultId) !== void 0 && this.syncEngine.setSyncStateVaultId(saved.syncStateVaultId), saved != null && saved.syncState ? this.syncEngine.importSyncState(saved.syncState) : saved != null && saved.syncedHashes && (this.syncEngine.importHashes(saved.syncedHashes), devLog().log("lifecycle", "Migrated legacy syncedHashes \u2192 syncState")), this.syncEngine.issues.hydrate(saved == null ? void 0 : saved.syncIssues), this.syncEngine.ignoredFiles.hydrate(saved == null ? void 0 : saved.ignoredFiles), this.settings.planState && this.syncEngine.hydratePlanState(this.settings.planState), this.settingTab = new EngramSyncSettingTab(this.app, this), this.addSettingTab(this.settingTab), this.registerEvent(
       this.app.vault.on("modify", (file) => {
         this.syncEngine.handleModify(file);
       })
@@ -24038,6 +24073,9 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       // reason (like deviceId) or the next saveData() wipes it; 0 = replay
       // from genesis.
       catchupSeq: this.syncEngine.getCatchupSeq(),
+      // Composite-cursor id paired with catchupSeq (#312) — re-listed for the
+      // wholesale-save reason.
+      catchupId: this.syncEngine.getCatchupId(),
       // Manifest since_seq watermark (E1 #1065) — re-listed for the same
       // wholesale-save reason.
       manifestSeq: this.syncEngine.getManifestSeq(),

--- a/main.js
+++ b/main.js
@@ -1483,7 +1483,15 @@ function fullJitterDelay(windowMs, rng = Math.random) {
 function topicUserIdIsStale(currentUserId, authenticatedUserId) {
   return authenticatedUserId ? currentUserId !== authenticatedUserId : !1;
 }
-var LARGE_FRAME_WARN_BYTES = 1e6, NoteChannel = class {
+var LARGE_FRAME_WARN_BYTES = 1e6;
+function makeCrdtCatchupSender(channel, currentVaultId) {
+  return (cursorSeq, limit, cursorId) => {
+    if (channel.getVaultId() !== currentVaultId())
+      throw new Error("Sync preview needs the live socket (vault switching)");
+    return channel.crdtCatchupSince(cursorSeq, limit, cursorId);
+  };
+}
+var NoteChannel = class {
   constructor(baseUrl, apiKey, userId, vaultId = null, deviceId = null) {
     this.ws = null;
     this.ref = 0;
@@ -24292,11 +24300,9 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       }, channel.onPlanState = (raw) => {
         let parsed = parsePlanState(raw, Date.now());
         parsed && queueMicrotask(() => this.syncEngine.applyPlanState(parsed));
-      }, this.noteStream = channel, this.authProvider && this.noteStream.setAuthProvider(this.authProvider), this.syncEngine.setCrdtCreate((id2, path) => channel.crdtCreate(id2, path)), this.syncEngine.setCrdtCreateBatch((creates) => channel.crdtCreateBatch(creates)), this.syncEngine.setCrdtDelete((id2) => channel.crdtDeleteAcked(id2)), this.syncEngine.setCrdtCatchupSince((cursorSeq, limit) => {
-        if (channel.getVaultId() !== this.settings.vaultId)
-          throw new Error("Sync preview needs the live socket (vault switching)");
-        return channel.crdtCatchupSince(cursorSeq, limit);
-      }), this.settings.vaultId) {
+      }, this.noteStream = channel, this.authProvider && this.noteStream.setAuthProvider(this.authProvider), this.syncEngine.setCrdtCreate((id2, path) => channel.crdtCreate(id2, path)), this.syncEngine.setCrdtCreateBatch((creates) => channel.crdtCreateBatch(creates)), this.syncEngine.setCrdtDelete((id2) => channel.crdtDeleteAcked(id2)), this.syncEngine.setCrdtCatchupSince(
+        makeCrdtCatchupSender(channel, () => this.settings.vaultId)
+      ), this.settings.vaultId) {
         let dbPrefix = this.settings.vaultId;
         if (typeof indexedDB.databases == "function" ? await ensureDocSchema(dbPrefix, window.localStorage, {
           list: () => indexedDB.databases(),

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -99,6 +99,29 @@ const LARGE_FRAME_WARN_BYTES = 1_000_000;
  */
 import type { NoteStreamEvent, SyncChange } from "./types";
 
+/** Build the catch-up sender the SyncEngine calls (`setCrdtCatchupSince`).
+ *  Guards each fetch against a vault mismatch — a stale channel enumerating the
+ *  WRONG vault would render it as the current vault's plan (#314) — and forwards
+ *  ALL THREE args, including the composite `cursorId` (#312). Extracted from
+ *  main.ts's inline wiring precisely so a dropped arg is caught by a unit test:
+ *  TS parameter bivariance silently accepts a shorter closure, so the compiler
+ *  won't flag `(seq, limit) => ...` where `(seq, limit, id) => ...` is meant. */
+export function makeCrdtCatchupSender(
+	channel: Pick<NoteChannel, "getVaultId" | "crdtCatchupSince">,
+	currentVaultId: () => string | null,
+): (
+	cursorSeq: number,
+	limit?: number,
+	cursorId?: string | null,
+) => ReturnType<NoteChannel["crdtCatchupSince"]> {
+	return (cursorSeq, limit, cursorId) => {
+		if (channel.getVaultId() !== currentVaultId()) {
+			throw new Error("Sync preview needs the live socket (vault switching)");
+		}
+		return channel.crdtCatchupSince(cursorSeq, limit, cursorId);
+	};
+}
+
 export class NoteChannel {
 	private ws: WebSocket | null = null;
 	private ref = 0;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -399,13 +399,26 @@ export class NoteChannel {
 	async crdtCatchupSince(
 		cursorSeq: number,
 		limit?: number,
-	): Promise<{ changes: SyncChange[]; has_more: boolean; next_seq: number | null }> {
-		const payload: { cursor_seq: number; limit?: number } = { cursor_seq: cursorSeq };
+		cursorId?: string | null,
+	): Promise<{
+		changes: SyncChange[];
+		has_more: boolean;
+		next_seq: number | null;
+		// Composite keyset id paired with next_seq (#312). Absent from a pre-#312
+		// backend — callers fall back to the seq-only cursor when it's undefined.
+		next_id?: string | null;
+	}> {
+		const payload: { cursor_seq: number; limit?: number; cursor_id?: string } = {
+			cursor_seq: cursorSeq,
+		};
 		if (limit !== undefined) payload.limit = limit;
+		// Only send a real id; omit for the seq-only first page / pre-#312 fallback.
+		if (cursorId) payload.cursor_id = cursorId;
 		return (await this.sendRequest("crdt_catchup_since", payload)) as {
 			changes: SyncChange[];
 			has_more: boolean;
 			next_seq: number | null;
+			next_id?: string | null;
 		};
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -104,6 +104,9 @@ interface PluginData {
 	 *  offlineQueue: flat pending list, restored on startup, pruned past TTL. */
 	crdtOpQueue?: CrdtOp[];
 	catchupSeq?: number;
+	/** Composite-cursor id paired with `catchupSeq` (#312) so an interrupted
+	 *  replay resumes at `(seq, id)` and can't skip an equal-seq move sibling. */
+	catchupId?: string | null;
 	/** Manifest change_seq watermark of the last fully-processed catch-up pass
 	 *  (Phase E1 #1065) — sent as ?since_seq= to short-circuit an unchanged vault. */
 	manifestSeq?: number;
@@ -399,6 +402,9 @@ export default class EngramSyncPlugin extends Plugin {
 			if (data.catchupSeq !== undefined) {
 				this.syncEngine.setCatchupSeq(data.catchupSeq);
 			}
+			if (data.catchupId !== undefined) {
+				this.syncEngine.setCatchupId(data.catchupId);
+			}
 			if (data.manifestSeq !== undefined) {
 				this.syncEngine.setManifestSeq(data.manifestSeq);
 			}
@@ -552,6 +558,9 @@ export default class EngramSyncPlugin extends Plugin {
 		}
 		if (saved?.catchupSeq !== undefined) {
 			this.syncEngine.setCatchupSeq(saved.catchupSeq);
+		}
+		if (saved?.catchupId !== undefined) {
+			this.syncEngine.setCatchupId(saved.catchupId);
 		}
 		if (saved?.manifestSeq !== undefined) {
 			this.syncEngine.setManifestSeq(saved.manifestSeq);
@@ -1310,6 +1319,9 @@ export default class EngramSyncPlugin extends Plugin {
 			// reason (like deviceId) or the next saveData() wipes it; 0 = replay
 			// from genesis.
 			catchupSeq: this.syncEngine.getCatchupSeq(),
+			// Composite-cursor id paired with catchupSeq (#312) — re-listed for the
+			// wholesale-save reason.
+			catchupId: this.syncEngine.getCatchupId(),
 			// Manifest since_seq watermark (E1 #1065) — re-listed for the same
 			// wholesale-save reason.
 			manifestSeq: this.syncEngine.getManifestSeq(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ import {
 	seededAccessToken,
 } from "./auth";
 import { migrateCloudApiUrl, withClearedAuth } from "./auth-state";
-import { NoteChannel, connectRetryDelayMs } from "./channel";
+import { NoteChannel, connectRetryDelayMs, makeCrdtCatchupSender } from "./channel";
 import { ConflictModal } from "./conflict-modal";
 import { makeCrdtOpSend } from "./crdt-op-dispatch";
 import { type CrdtOp, CrdtOpQueue } from "./crdt-op-queue";
@@ -1870,21 +1870,12 @@ export default class EngramSyncPlugin extends Plugin {
 				// Delete (and durable create genesis) now route through the plugin-
 				// lifetime crdtOpQueue, wired once in onload, not per-channel here.
 				// Single-path convergence: seq-ordered op-log replayed over the socket.
-				this.syncEngine.setCrdtCatchupSince((cursorSeq, limit) => {
-					// The op-log feed is vault-scoped. applyVaultChange rebuilds the
-					// stream for the new vault before computing the plan, so this
-					// closure normally captures the current vault's channel. This
-					// guard is defense against any future path that flips
-					// settings.vaultId without rebuilding: a stale channel would
-					// enumerate the OLD vault and render it as the new vault's plan.
-					// Refuse rather than mislead (enumerateServerState waits for the
-					// rebuilt channel to go live, so this fires only on a true stale
-					// mismatch, not the rebuild window).
-					if (channel.getVaultId() !== this.settings.vaultId) {
-						throw new Error("Sync preview needs the live socket (vault switching)");
-					}
-					return channel.crdtCatchupSince(cursorSeq, limit);
-				});
+				// Vault-mismatch guard (#314) + composite-cursor forwarding (#312),
+				// extracted to a tested helper so a dropped arg can't silently make
+				// the fix inert (TS bivariance accepts a shorter closure).
+				this.syncEngine.setCrdtCatchupSince(
+					makeCrdtCatchupSender(channel, () => this.settings.vaultId),
+				);
 
 				// Wire CRDT transport through this channel.
 				// Only wire when vaultId is known: the crdt: topic is keyed by

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1510,6 +1510,7 @@ export class SyncEngine {
 		private saveData: (data: {
 			lastSync?: string;
 			catchupSeq?: number;
+			catchupId?: string | null;
 			manifestSeq?: number;
 			// Signals the engine mutated the shared noteIdMap and it should be
 			// persisted. main.ts's savePluginData writes the map instance directly
@@ -1563,6 +1564,22 @@ export class SyncEngine {
 
 	setCatchupSeq(seq: number): void {
 		this.catchupSeq = Number.isFinite(seq) && seq >= 0 ? seq : 0;
+	}
+
+	/** Composite-cursor id paired with `catchupSeq` (#312). An attachment move
+	 *  writes two rows at one seq; the id lets a resumed replay continue at
+	 *  `(seq, id) > (catchupSeq, catchupId)` instead of the seq-only `seq >`,
+	 *  which would skip the second row. Only feeds the catch-up fetch — NOT the
+	 *  gap-heal fence (that stays seq-only + hash-aware). Null = no id yet
+	 *  (seq-only, e.g. a genesis replay or a pre-#312 backend). */
+	private catchupId: string | null = null;
+
+	getCatchupId(): string | null {
+		return this.catchupId;
+	}
+
+	setCatchupId(id: string | null): void {
+		this.catchupId = typeof id === "string" && id.length > 0 ? id : null;
 	}
 
 	/** The vault change_seq watermark of the last FULLY-processed manifest pass
@@ -1691,6 +1708,7 @@ export class SyncEngine {
 		// seq feed — reset to 0 so the next catch-up replays the new vault from
 		// genesis (else a stale high seq would suppress it entirely).
 		this.catchupSeq = 0;
+		this.catchupId = null;
 		// Same cross-vault hazard for the manifest watermark (E1 #1065): a
 		// stale since_seq could integer-collide with the NEW vault's change_seq
 		// and wrongly short-circuit the first reconcile after a swap.
@@ -3169,14 +3187,26 @@ export class SyncEngine {
 		| ((
 				cursorSeq: number,
 				limit?: number,
-		  ) => Promise<{ changes: SyncChange[]; has_more: boolean; next_seq: number | null }>)
+				cursorId?: string | null,
+		  ) => Promise<{
+				changes: SyncChange[];
+				has_more: boolean;
+				next_seq: number | null;
+				next_id?: string | null;
+		  }>)
 		| null = null;
 
 	setCrdtCatchupSince(
 		fn: (
 			cursorSeq: number,
 			limit?: number,
-		) => Promise<{ changes: SyncChange[]; has_more: boolean; next_seq: number | null }>,
+			cursorId?: string | null,
+		) => Promise<{
+			changes: SyncChange[];
+			has_more: boolean;
+			next_seq: number | null;
+			next_id?: string | null;
+		}>,
 	): void {
 		this.crdtCatchupSince = fn;
 	}
@@ -3228,6 +3258,24 @@ export class SyncEngine {
 	 *  as `computeSyncPlan`'s inventory (#304, REST-purge Bucket C — the
 	 *  preview was their last caller). Throws when the channel is not live: the
 	 *  preview must error visibly, never render a wrong empty plan. */
+	/** Strict forward comparison of the composite `(seq, id)` catch-up cursor.
+	 *  Returns true iff `(nextSeq, nextId)` is strictly greater than
+	 *  `(curSeq, curId)` — the same keyset ordering the backend queries with. The
+	 *  equal-seq case (`nextSeq === curSeq`, `nextId > curId`) is what pages
+	 *  correctly across an attachment-move pair (#312). Ids compare as strings:
+	 *  canonical UUIDs sort identically byte-wise (Postgres uuid) and lexically. */
+	private cursorAdvances(
+		nextSeq: number | null,
+		nextId: string | null,
+		curSeq: number,
+		curId: string | null,
+	): boolean {
+		if (typeof nextSeq !== "number") return false;
+		if (nextSeq > curSeq) return true;
+		if (nextSeq < curSeq) return false;
+		return (nextId ?? "") > (curId ?? "");
+	}
+
 	private async enumerateServerState(): Promise<{
 		notes: Map<string, { deleted: boolean; content?: string; contentHash?: string }>;
 		attachments: Map<string, { deleted: boolean }>;
@@ -3252,12 +3300,12 @@ export class SyncEngine {
 		const byId = new Map<string, Extract<SyncChange, { type: "note" }>>();
 		const attachments = new Map<string, { deleted: boolean }>();
 		let cursor = 0;
+		let cursorId: string | null = null;
 		// Loop ceiling is corruption protection, not a real limit (mirrors
 		// runSeqReplayOnce): 100k pages x 500 rows.
 		for (let page = 0; page < 100_000; page++) {
-			const resp = await this.crdtCatchupSince(cursor, 500);
+			const resp = await this.crdtCatchupSince(cursor, 500, cursorId);
 			for (const c of resp.changes) {
-				if (typeof c.seq === "number" && c.seq > cursor) cursor = c.seq;
 				if (c.type === "attachment") {
 					if (c.path) attachments.set(c.path, { deleted: c.deleted });
 				} else if (c.id && c.path) {
@@ -3268,9 +3316,13 @@ export class SyncEngine {
 				}
 			}
 			if (!resp.has_more) break;
-			if (typeof resp.next_seq === "number" && resp.next_seq > cursor) {
-				cursor = resp.next_seq;
-			}
+			// Composite advance: `next_seq` can EQUAL `cursor` for an attachment
+			// move's two same-seq rows split across the page boundary (#312); the
+			// paired `next_id` continues past the exact row. A non-advancing cursor
+			// (backend quirk / pre-#312 empty next) breaks the loop.
+			if (!this.cursorAdvances(resp.next_seq, resp.next_id ?? null, cursor, cursorId)) break;
+			cursor = resp.next_seq as number;
+			cursorId = resp.next_id ?? null;
 		}
 		const notes = new Map<
 			string,
@@ -3439,11 +3491,12 @@ export class SyncEngine {
 		// test_48). Replay that vault from genesis instead; applySyncChange is
 		// idempotent, so a redundant-from-0 replay is safe.
 		const activeVault = this.settings.vaultId ?? null;
-		let cursor = fromZero
-			? 0
-			: this.syncStateVaultId === activeVault
-				? this.getCatchupSeq()
-				: 0;
+		const resumable = !fromZero && this.syncStateVaultId === activeVault;
+		let cursor = resumable ? this.getCatchupSeq() : 0;
+		// Composite-cursor id (#312), paired with `cursor`. Only resumes from the
+		// persisted id when we resume from the persisted seq — a genesis / cross-
+		// vault replay starts seq-only (null).
+		let cursorId: string | null = resumable ? this.getCatchupId() : null;
 		// E1 (#1065): consume a validator rewind atomically at run start. The
 		// validator must NOT write the cursor directly — an in-flight replay
 		// persists its own monotonically-advanced cursor per page and would
@@ -3451,16 +3504,27 @@ export class SyncEngine {
 		// cursor writer). The single-flight loop re-enters here, so a floor set
 		// mid-run is picked up by the coalesced re-run.
 		if (this.seqRewindFloor !== null && !fromZero) {
-			cursor = Math.min(cursor, this.seqRewindFloor);
+			const floored = Math.min(cursor, this.seqRewindFloor);
+			// A rewind to a lower seq invalidates the paired id (it belonged to the
+			// higher cursor) — resume seq-only from the floor.
+			if (floored !== cursor) cursorId = null;
+			cursor = floored;
 		}
 		this.seqRewindFloor = null;
 		let applied = 0;
 		// Bound the loop far above any real backlog (matches pullViaCursor). Applies
 		// are idempotent, so persisting the cursor per page is at-least-once safe.
 		for (let page = 0; page < 100_000; page++) {
-			let resp: { changes: SyncChange[]; has_more: boolean; next_seq: number | null };
+			const pageStartSeq = cursor;
+			const pageStartId = cursorId;
+			let resp: {
+				changes: SyncChange[];
+				has_more: boolean;
+				next_seq: number | null;
+				next_id?: string | null;
+			};
 			try {
-				resp = await this.crdtCatchupSince(cursor, 500);
+				resp = await this.crdtCatchupSince(cursor, 500, cursorId);
 			} catch (e) {
 				rlog().warn("crdt", `seq-replay: fetch failed at cursor=${cursor} — ${errMsg(e)}`);
 				return applied;
@@ -3478,7 +3542,19 @@ export class SyncEngine {
 				}
 				// Advance past every op we've SEEN (applied or skipped) so the cursor
 				// is monotonic and a permanently-unappliable op can't stall the feed.
-				if (typeof c.seq === "number" && c.seq > cursor) cursor = c.seq;
+				// Composite (seq, id): the feed is {seq,id}-sorted, so the last row of
+				// a page is its max — that becomes the resume point persisted below.
+				if (
+					this.cursorAdvances(
+						typeof c.seq === "number" ? c.seq : null,
+						c.id ?? null,
+						cursor,
+						cursorId,
+					)
+				) {
+					cursor = c.seq;
+					cursorId = c.id ?? null;
+				}
 				// Every non-deleted id/path SEEN (applied or skipped) — the
 				// pull-all-delete / push-all-delete choices (Tasks 5/5b/6) need the
 				// full server id-set and attachment-path-set, not just the
@@ -3493,23 +3569,26 @@ export class SyncEngine {
 			// genuine catch-up needs to still see every op this enumeration walked
 			// past, since none of them were applied.
 			if (!enumerateOnly) {
+				// Persist the COMPOSITE resume point: an interrupted replay that
+				// stopped mid equal-seq pair must resume at (seq, id), not seq-only,
+				// or the sibling row is skipped (#312). The gap-heal fence still
+				// reads catchupSeq (seq) only — it is untouched.
 				this.setCatchupSeq(cursor);
-				await this.saveData({ catchupSeq: this.getCatchupSeq() });
+				this.setCatchupId(cursorId);
+				await this.saveData({
+					catchupSeq: this.getCatchupSeq(),
+					catchupId: this.getCatchupId(),
+				});
 			}
 			if (!resp.has_more) break;
-			// Guard against a `next_seq` that doesn't move forward (a backend quirk
-			// or malformed page) regressing the cursor mid-replay — `cursor` must
-			// stay monotonic across every page of THIS call so the per-page
-			// persisted write above can never move backwards. This intentionally
-			// does NOT compare against `this.getCatchupSeq()`: the cross-vault
-			// mismatch case above starts `cursor` at 0 on purpose to overwrite a
-			// stale higher cursor left by a different vault, and that reset must
-			// still be allowed to persist a lower value than what's currently
-			// stored (setCatchupSeq itself is intentionally left un-guarded so
-			// resets keep working; see final-review fix notes).
-			if (typeof resp.next_seq === "number" && resp.next_seq > cursor) {
-				cursor = resp.next_seq;
-			}
+			// Stuck-cursor guard: the per-op advance above already moved `cursor`
+			// to this page's max {seq, id} (the feed is sorted, so that equals the
+			// backend's {next_seq, next_id}). If a page returned rows but the
+			// composite cursor did NOT advance from the page start (a backend quirk
+			// / empty page with has_more), stop rather than refetch forever. This
+			// replaces the old seq-only `next_seq > cursor` guard, which would have
+			// wrongly refused to advance across an equal-seq pair boundary.
+			if (!this.cursorAdvances(cursor, cursorId, pageStartSeq, pageStartId)) break;
 		}
 		return applied;
 	}

--- a/tests/channel.test.ts
+++ b/tests/channel.test.ts
@@ -3,7 +3,7 @@
  */
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { AuthProvider } from "../src/auth";
-import { NoteChannel, connectRetryDelayMs } from "../src/channel";
+import { NoteChannel, connectRetryDelayMs, makeCrdtCatchupSender } from "../src/channel";
 
 // Capture WebSocket constructor calls
 let lastWsUrl: string | null = null;
@@ -792,5 +792,40 @@ describe("NoteChannel onResume (mobile foreground recovery)", () => {
 		expect(lastWsInstance).toBeNull();
 
 		(globalThis as any).WebSocket = MockWebSocket;
+	});
+});
+
+describe("makeCrdtCatchupSender (wiring #312/#314)", () => {
+	function fakeChannel(vaultId: string | null) {
+		const calls: Array<[number, number | undefined, string | null | undefined]> = [];
+		return {
+			calls,
+			getVaultId: () => vaultId,
+			crdtCatchupSince: async (
+				cursorSeq: number,
+				limit?: number,
+				cursorId?: string | null,
+			) => {
+				calls.push([cursorSeq, limit, cursorId]);
+				return { changes: [], has_more: false, next_seq: null };
+			},
+		};
+	}
+
+	test("forwards ALL THREE args incl. the composite cursorId (#312)", async () => {
+		// Regression guard: the production wiring once dropped cursorId (arity-2
+		// closure), making the whole composite-cursor fix inert — TS bivariance
+		// didn't flag it.
+		const ch = fakeChannel("v1");
+		const send = makeCrdtCatchupSender(ch, () => "v1");
+		await send(5, 500, "row-id");
+		expect(ch.calls[0]).toEqual([5, 500, "row-id"]);
+	});
+
+	test("throws on a vault mismatch instead of enumerating the wrong vault (#314)", () => {
+		const ch = fakeChannel("old-vault");
+		const send = makeCrdtCatchupSender(ch, () => "new-vault");
+		expect(() => send(0, 500, null)).toThrow(/vault switching/);
+		expect(ch.calls).toHaveLength(0);
 	});
 });

--- a/tests/sync-plan.test.ts
+++ b/tests/sync-plan.test.ts
@@ -275,6 +275,57 @@ describe("SyncEngine.enumerateServerState", () => {
 		await expect((engine as any).enumerateServerState()).rejects.toThrow(/live socket/);
 	});
 
+	test("threads the composite {seq,id} cursor to page past an equal-seq move pair (#312)", async () => {
+		// An attachment move writes two rows at ONE seq. If the plugin pages by
+		// seq only, the backend's `seq > cursor` skips the sibling. The plugin
+		// must send `cursor_id` from the prior page's `next_id` so the backend
+		// can continue at `(seq, id) > (cursor_seq, cursor_id)`.
+		const engine = createEngine();
+		engine.setCrdtManager({} as any);
+		engine.setCrdtLiveCheck(() => true);
+		const calls: Array<{ seq: number; id: string | null }> = [];
+		let call = 0;
+		engine.setCrdtCatchupSince(
+			async (cursor: number, _limit?: number, cursorId?: string | null) => {
+				calls.push({ seq: cursor, id: cursorId ?? null });
+				if (call++ === 0) {
+					return {
+						changes: [
+							{
+								type: "note",
+								id: "aaa",
+								seq: 5,
+								path: "new.md",
+								content: "x",
+								content_hash: "H",
+								deleted: false,
+							},
+						] as any,
+						has_more: true,
+						next_seq: 5,
+						next_id: "aaa",
+					};
+				}
+				return {
+					changes: [
+						{ type: "note", id: "bbb", seq: 5, path: "old.md", deleted: true },
+					] as any,
+					has_more: false,
+					next_seq: 5,
+					next_id: "bbb",
+				};
+			},
+		);
+
+		const s = await (engine as any).enumerateServerState();
+
+		// Page 2 was reached (not stopped by a seq-only `next_seq > cursor` guard)
+		// AND fetched with the composite cursor from page 1's next_id.
+		expect(calls[1]).toEqual({ seq: 5, id: "aaa" });
+		expect(s.notes.has("new.md")).toBe(true);
+		expect(s.notes.get("old.md")?.deleted).toBe(true);
+	});
+
 	test("does NOT touch the real catch-up cursor", async () => {
 		const engine = createEngine();
 		engine.setCatchupSeq(7);

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -278,6 +278,47 @@ describe("catchupViaSeqReplay", () => {
 		expect(engine.getCatchupSeq()).toBe(7);
 	});
 
+	test("threads + persists the composite {seq,id} cursor across an equal-seq pair (#312)", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		(engine as any).applySyncChange = mock(async () => true);
+		const seen: Array<{ seq: number; id: string | null }> = [];
+		const pages = [
+			{
+				changes: [attachmentOp(5, "id-new", "new.png")],
+				has_more: true,
+				next_seq: 5,
+				next_id: "id-new",
+			},
+			{
+				changes: [attachmentOp(5, "id-old", "old.png", true)],
+				has_more: false,
+				next_seq: null,
+				next_id: null,
+			},
+		];
+		let i = 0;
+		engine.setCrdtCatchupSince(
+			async (cursor: number, _limit?: number, cursorId?: string | null) => {
+				seen.push({ seq: cursor, id: cursorId ?? null });
+				return pages[i++];
+			},
+		);
+
+		await engine.catchupViaSeqReplay();
+
+		// Page 2 was fetched with the composite cursor from page 1's next_id. A
+		// seq-only cursor would send {5, null}, and the backend's `seq > 5` would
+		// drop the sibling old.png.
+		expect(seen).toEqual([
+			{ seq: 0, id: null },
+			{ seq: 5, id: "id-new" },
+		]);
+		// The persisted resume point is the last row's {seq, id} — an interrupted
+		// replay resumes at (5, id-old), not seq-only.
+		expect(engine.getCatchupSeq()).toBe(5);
+		expect(engine.getCatchupId()).toBe("id-old");
+	});
+
 	test("paginates while has_more, resuming each page from next_seq", async () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		(engine as any).applySyncChange = mock(async () => true);


### PR DESCRIPTION
Closes #312 (plugin half). Pairs with backend engram-app/engram#1097.

## Problem
The seq-replay pagination (`enumerateServerState` for the sync preview + `runSeqReplayOnce` for catch-up) sent `cursor_seq` only. An attachment move writes two rows at **one seq**; when a page boundary splits them, the backend's `seq > cursor` skips the second on the next fetch — a ghost old path survives.

## Fix
- `crdtCatchupSince` (channel + engine type) gains `cursorId` in / `next_id` out.
- New `cursorAdvances()` does the strict `(seq, id)` keyset comparison. Both loops advance on it, so `next_seq` **equalling** `cursor` with a greater id keeps paging — the old seq-only `next_seq > cursor` guard would have wrongly stopped at the pair boundary.
- `catchupId` is persisted alongside `catchupSeq` (new field + accessors, in the data.json blob, loaded on startup, reset on vault change / validator rewind) so an **interrupted** replay resumes at `(seq, id)` and can't skip the sibling. The hash-aware gap-heal fence still reads `catchupSeq` (seq) only — deliberately untouched.

**Backward-compatible:** a pre-#312 backend returns no `next_id` → `cursorId` stays null → seq-only, exactly as today. So this can merge/ship before or after the backend without breakage.

## Tests (TDD)
- `enumerateServerState`: asserts page 2 is fetched with the composite cursor `{5, "aaa"}` from page 1's `next_id` — verified RED (fails to `{5, null}`) without the `cursorId` send.
- `runSeqReplayOnce`: asserts the composite fetch on page 2 AND that `catchupId` persists to the last row's id.

## Gauntlet
`bun test` 2256 pass / 0 fail · `biome ci` clean · `lint:obsidian` clean · `bun run build` clean.

## Deploy note
The composite fix is only *active* once backend #1097 is in prod (it supplies `next_id` + honors `cursor_id`); until then the plugin runs seq-only as before. Not deploy-gated (degrades gracefully), but the pair should land together.