### PR TITLE
fix(sync): guard delete-reconcile against identity-swap race (#283)

### DIFF
--- a/main.js
+++ b/main.js
@@ -17926,6 +17926,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  files. `null` means "not yet recorded" (fresh install or pre-upgrade
      *  data) and is adopted without wiping. */
     this.syncStateVaultId = null;
+    /** Monotonic identity-swap counter (#283). Bumped by main.ts on every OAuth
+     *  token save/clear — the points where `this.api`'s auth provider is swapped.
+     *  A destructive manifest-diff reconcile captures this before fetching the
+     *  manifest and refuses to trash if it changed while the fetch was in flight:
+     *  a manifest resolved across an identity swap can be a stale snapshot that
+     *  omits live notes, and trashing those as "server-deleted" is data loss.
+     *  Same-vault token refresh (test_48) can't be caught by the vaultId guard,
+     *  so this is a separate, swap-precise signal. */
+    this.authGeneration = 0;
     /** This user's server content_hash for EMPTY content, learned from an
      *  authoritative op-log ROW that carries "" beside its hash (the hash is a
      *  per-user HMAC — underivable client-side but deterministic; the old
@@ -18972,6 +18981,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   setSyncStateVaultId(id2) {
     this.syncStateVaultId = id2;
   }
+  /** #283: mark that the api auth provider was (or is being) swapped. Called by
+   *  main.ts on OAuth token save/clear so a manifest fetch that straddles the
+   *  swap can be detected and its destructive reconcile refused. */
+  bumpAuthGeneration() {
+    this.authGeneration++;
+  }
   /** Invalidate stale per-vault bookkeeping if the active server vault no
    *  longer matches the one syncState was recorded under. This is the
    *  self-healing backstop for vault switches that bypass the SyncPreviewModal
@@ -19770,7 +19785,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  and 3. */
   async catchUp() {
     try {
-      let manifest = await this.api.getManifest(
+      let authGenAtFetch = this.authGeneration, manifest = await this.api.getManifest(
         this.manifestSeq > 0 ? this.manifestSeq : void 0
       );
       if (manifest != null && manifest.unchanged) {
@@ -19778,7 +19793,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         let { applied: applied2 } = await this.catchupViaSeqReplay();
         return applied2;
       }
-      await this.reconcileFromManifest(manifest);
+      await this.reconcileFromManifest(manifest, authGenAtFetch);
       let behind = this.validateFromManifest(manifest), { applied } = await this.catchupViaSeqReplay(), poked = await this.healDivergedLiveBoundNotes(manifest);
       try {
         await this.syncExplicitFolders();
@@ -20513,29 +20528,36 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  resurrect it on the next push). A null manifest (pre-B1 backend / 404) is
    *  a no-op. `manifest` may be passed pre-fetched (catchUp shares one across
    *  its reconcile + live-bound-heal steps); omit it and it fetches its own. */
-  async reconcileFromManifest(manifest) {
+  async reconcileFromManifest(manifest, authGenAtFetch) {
     var _a;
-    let m = manifest === void 0 ? await this.api.getManifest() : manifest;
-    if (!m) return;
-    let serverPaths = /* @__PURE__ */ new Set([
-      ...m.notes.map((n) => (0, import_obsidian21.normalizePath)(n.path)),
-      ...m.attachments.map((a) => (0, import_obsidian21.normalizePath)(a.path))
-    ]);
-    for (let file of this.app.vault.getFiles()) {
-      if (!this.isSyncable(file) || this.shouldIgnore(file.path)) continue;
-      let np = (0, import_obsidian21.normalizePath)(file.path);
-      if (!serverPaths.has(np) && this.syncState.has(np))
-        try {
-          await this.trashRemotelyDeleted(file), this.syncState.delete(np), (_a = this.baseStore) == null || _a.delete(np), rlog().info("pull", `Reconcile: server-deleted \u2192 trashed ${file.path}`);
-        } catch (e) {
-          rlog().error(
-            "pull",
-            `Reconcile trash failed (retried next run): ${file.path} \u2014 ${errMsg(e)}`,
-            e instanceof Error ? e.stack : void 0
-          );
+    let authGen = authGenAtFetch != null ? authGenAtFetch : this.authGeneration, m = manifest === void 0 ? await this.api.getManifest() : manifest;
+    if (m) {
+      if (this.authGeneration === authGen) {
+        let serverPaths = /* @__PURE__ */ new Set([
+          ...m.notes.map((n) => (0, import_obsidian21.normalizePath)(n.path)),
+          ...m.attachments.map((a) => (0, import_obsidian21.normalizePath)(a.path))
+        ]);
+        for (let file of this.app.vault.getFiles()) {
+          if (!this.isSyncable(file) || this.shouldIgnore(file.path)) continue;
+          let np = (0, import_obsidian21.normalizePath)(file.path);
+          if (!serverPaths.has(np) && this.syncState.has(np))
+            try {
+              await this.trashRemotelyDeleted(file), this.syncState.delete(np), (_a = this.baseStore) == null || _a.delete(np), rlog().info("pull", `Reconcile: server-deleted \u2192 trashed ${file.path}`);
+            } catch (e) {
+              rlog().error(
+                "pull",
+                `Reconcile trash failed (retried next run): ${file.path} \u2014 ${errMsg(e)}`,
+                e instanceof Error ? e.stack : void 0
+              );
+            }
         }
+      } else
+        rlog().info(
+          "pull",
+          "Reconcile: skipped delete pass \u2014 identity swap raced the manifest fetch (retried next catch-up)"
+        );
+      await this.seedEmptyFolders();
     }
-    await this.seedEmptyFolders();
   }
   /** Re-converge any LIVE-BOUND note whose server content (per the manifest)
    *  diverges from our recorded baseline — independent of the seq cursor.
@@ -24171,10 +24193,10 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     return this.settings.apiKey ? new ApiKeyAuth(this.settings.apiKey, this.settings.vaultId) : null;
   }
   async saveOAuthTokens(refreshToken, vaultId, userEmail) {
-    this.settings.refreshToken = refreshToken, this.settings.userEmail = userEmail, this.settings.authMethod = "oauth", this.settings.vaultId = vaultId, this.settings.accessToken = void 0, this.settings.accessTokenExpiresAt = void 0, this.settings.accessTokenVaultId = void 0, this.authProvider = this.createAuthProvider(), this.authProvider && this.api.setAuthProvider(this.authProvider), await this.saveSettings(), this.authProvider && this.noteStream && (this.noteStream.setAuthProvider(this.authProvider), this.noteStream.setAuthProbe(() => this.api.getMe()));
+    this.syncEngine.bumpAuthGeneration(), this.settings.refreshToken = refreshToken, this.settings.userEmail = userEmail, this.settings.authMethod = "oauth", this.settings.vaultId = vaultId, this.settings.accessToken = void 0, this.settings.accessTokenExpiresAt = void 0, this.settings.accessTokenVaultId = void 0, this.authProvider = this.createAuthProvider(), this.authProvider && this.api.setAuthProvider(this.authProvider), await this.saveSettings(), this.authProvider && this.noteStream && (this.noteStream.setAuthProvider(this.authProvider), this.noteStream.setAuthProbe(() => this.api.getMe()));
   }
   async clearOAuthTokens() {
-    this.settings.refreshToken = void 0, this.settings.userEmail = void 0, this.settings.authMethod = null, this.settings.accessToken = void 0, this.settings.accessTokenExpiresAt = void 0, this.settings.accessTokenVaultId = void 0, this.authProvider = this.settings.apiKey ? new ApiKeyAuth(this.settings.apiKey, this.settings.vaultId) : null, this.authProvider && this.api.setAuthProvider(this.authProvider), await this.saveSettings(), this.authProvider && this.noteStream && (this.noteStream.setAuthProvider(this.authProvider), this.noteStream.setAuthProbe(() => this.api.getMe()));
+    this.syncEngine.bumpAuthGeneration(), this.settings.refreshToken = void 0, this.settings.userEmail = void 0, this.settings.authMethod = null, this.settings.accessToken = void 0, this.settings.accessTokenExpiresAt = void 0, this.settings.accessTokenVaultId = void 0, this.authProvider = this.settings.apiKey ? new ApiKeyAuth(this.settings.apiKey, this.settings.vaultId) : null, this.authProvider && this.api.setAuthProvider(this.authProvider), await this.saveSettings(), this.authProvider && this.noteStream && (this.noteStream.setAuthProvider(this.authProvider), this.noteStream.setAuthProbe(() => this.api.getMe()));
   }
   setupNoteStream() {
     var _a, _b, _c, _d, _e;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1480,6 +1480,10 @@ export default class EngramSyncPlugin extends Plugin {
 	}
 
 	async saveOAuthTokens(refreshToken: string, vaultId: string, userEmail: string): Promise<void> {
+		// #283: mark the identity swap so an in-flight catch-up manifest fetch
+		// straddling this call refuses its destructive delete-reconcile (a stale
+		// snapshot from the old identity would trash live notes as server-deleted).
+		this.syncEngine.bumpAuthGeneration();
 		this.settings.refreshToken = refreshToken;
 		this.settings.userEmail = userEmail;
 		this.settings.authMethod = "oauth";
@@ -1513,6 +1517,9 @@ export default class EngramSyncPlugin extends Plugin {
 	}
 
 	async clearOAuthTokens(): Promise<void> {
+		// #283: same identity-swap guard as saveOAuthTokens — a logout swaps the
+		// provider too, so a straddling manifest fetch must not delete-reconcile.
+		this.syncEngine.bumpAuthGeneration();
 		this.settings.refreshToken = undefined;
 		this.settings.userEmail = undefined;
 		this.settings.authMethod = null;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -369,6 +369,16 @@ export class SyncEngine {
 	 *  data) and is adopted without wiping. */
 	private syncStateVaultId: string | null = null;
 
+	/** Monotonic identity-swap counter (#283). Bumped by main.ts on every OAuth
+	 *  token save/clear — the points where `this.api`'s auth provider is swapped.
+	 *  A destructive manifest-diff reconcile captures this before fetching the
+	 *  manifest and refuses to trash if it changed while the fetch was in flight:
+	 *  a manifest resolved across an identity swap can be a stale snapshot that
+	 *  omits live notes, and trashing those as "server-deleted" is data loss.
+	 *  Same-vault token refresh (test_48) can't be caught by the vaultId guard,
+	 *  so this is a separate, swap-precise signal. */
+	private authGeneration = 0;
+
 	/** This user's server content_hash for EMPTY content, learned from an
 	 *  authoritative op-log ROW that carries "" beside its hash (the hash is a
 	 *  per-user HMAC — underivable client-side but deterministic; the old
@@ -1749,6 +1759,13 @@ export class SyncEngine {
 
 	setSyncStateVaultId(id: string | null): void {
 		this.syncStateVaultId = id;
+	}
+
+	/** #283: mark that the api auth provider was (or is being) swapped. Called by
+	 *  main.ts on OAuth token save/clear so a manifest fetch that straddles the
+	 *  swap can be detected and its destructive reconcile refused. */
+	bumpAuthGeneration(): void {
+		this.authGeneration++;
 	}
 
 	/** Invalidate stale per-vault bookkeeping if the active server vault no
@@ -3425,6 +3442,9 @@ export class SyncEngine {
 	 *  and 3. */
 	async catchUp(): Promise<number> {
 		try {
+			// #283: capture before the fetch so reconcileFromManifest can refuse its
+			// destructive pass if an OAuth swap lands while the manifest is in flight.
+			const authGenAtFetch = this.authGeneration;
 			const manifest = await this.api.getManifest(
 				this.manifestSeq > 0 ? this.manifestSeq : undefined,
 			);
@@ -3443,7 +3463,7 @@ export class SyncEngine {
 				const { applied } = await this.catchupViaSeqReplay();
 				return applied;
 			}
-			await this.reconcileFromManifest(manifest);
+			await this.reconcileFromManifest(manifest, authGenAtFetch);
 			const behind = this.validateFromManifest(manifest);
 			const { applied } = await this.catchupViaSeqReplay();
 			const poked = await this.healDivergedLiveBoundNotes(manifest);
@@ -4953,35 +4973,60 @@ export class SyncEngine {
 	 *  resurrect it on the next push). A null manifest (pre-B1 backend / 404) is
 	 *  a no-op. `manifest` may be passed pre-fetched (catchUp shares one across
 	 *  its reconcile + live-bound-heal steps); omit it and it fetches its own. */
-	private async reconcileFromManifest(manifest?: ManifestResponse | null): Promise<void> {
+	private async reconcileFromManifest(
+		manifest?: ManifestResponse | null,
+		authGenAtFetch?: number,
+	): Promise<void> {
+		// #283: capture the identity-swap counter BEFORE the manifest is read so a
+		// swap racing the fetch is detectable. When catchUp supplies a pre-fetched
+		// manifest it passes the gen it captured before ITS OWN fetch; the
+		// self-fetch path below captures it here.
+		const authGen = authGenAtFetch ?? this.authGeneration;
 		const m = manifest === undefined ? await this.api.getManifest() : manifest;
 		if (!m) return;
 
-		const serverPaths = new Set<string>([
-			...m.notes.map((n) => normalizePath(n.path)),
-			...m.attachments.map((a) => normalizePath(a.path)),
-		]);
+		// A manifest that resolved across an OAuth/identity swap can be a STALE
+		// snapshot missing notes the server still holds (a same-vault token
+		// refresh, so the vaultId guard can't see it — #283). Trashing those as
+		// "server-deleted" is local data loss. Skip only the DESTRUCTIVE pass;
+		// seedEmptyFolders below is non-destructive LOCAL→SERVER and stays. A real
+		// server-delete still arrives as an op-log tombstone (the primary delete
+		// path, unaffected by this skip); only the GC'd-tombstone backstop is
+		// deferred, re-running on a later clean catch-up. The skip errs toward
+		// KEEPING a note (the opposite of #283) and self-corrects on next server
+		// activity, so nothing is lost.
+		if (this.authGeneration === authGen) {
+			const serverPaths = new Set<string>([
+				...m.notes.map((n) => normalizePath(n.path)),
+				...m.attachments.map((a) => normalizePath(a.path)),
+			]);
 
-		// §F structural pass over local syncable files.
-		for (const file of this.app.vault.getFiles()) {
-			if (!this.isSyncable(file) || this.shouldIgnore(file.path)) continue;
-			const np = normalizePath(file.path);
-			if (serverPaths.has(np)) continue; // in manifest → content handled by catch-up
-			if (!this.syncState.has(np)) continue; // never synced → pushModifiedFiles handles it
+			// §F structural pass over local syncable files.
+			for (const file of this.app.vault.getFiles()) {
+				if (!this.isSyncable(file) || this.shouldIgnore(file.path)) continue;
+				const np = normalizePath(file.path);
+				if (serverPaths.has(np)) continue; // in manifest → content handled by catch-up
+				if (!this.syncState.has(np)) continue; // never synced → pushModifiedFiles handles it
 
-			// In baseline but gone from the server → server-deleted while away.
-			try {
-				await this.trashRemotelyDeleted(file);
-				this.syncState.delete(np);
-				this.baseStore?.delete(np);
-				rlog().info("pull", `Reconcile: server-deleted → trashed ${file.path}`);
-			} catch (e) {
-				rlog().error(
-					"pull",
-					`Reconcile trash failed (retried next run): ${file.path} — ${errMsg(e)}`,
-					e instanceof Error ? e.stack : undefined,
-				);
+				// In baseline but gone from the server → server-deleted while away.
+				try {
+					await this.trashRemotelyDeleted(file);
+					this.syncState.delete(np);
+					this.baseStore?.delete(np);
+					rlog().info("pull", `Reconcile: server-deleted → trashed ${file.path}`);
+				} catch (e) {
+					rlog().error(
+						"pull",
+						`Reconcile trash failed (retried next run): ${file.path} — ${errMsg(e)}`,
+						e instanceof Error ? e.stack : undefined,
+					);
+				}
 			}
+		} else {
+			rlog().info(
+				"pull",
+				"Reconcile: skipped delete pass — identity swap raced the manifest fetch (retried next catch-up)",
+			);
 		}
 
 		// Markers for folders the server can't derive. getFiles() never sees

--- a/tests/main-oauth-token-rebind.test.ts
+++ b/tests/main-oauth-token-rebind.test.ts
@@ -48,6 +48,11 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 			async saveSettings() {
 				order.push("saveSettings");
 			},
+			syncEngine: {
+				bumpAuthGeneration() {
+					order.push("bumpAuthGeneration");
+				},
+			},
 		};
 
 		await EngramSyncPlugin.prototype.saveOAuthTokens.call(
@@ -59,6 +64,11 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 
 		const apiSwapIdx = order.findIndex((o) => o.startsWith("api.setAuthProvider"));
 		const saveIdx = order.indexOf("saveSettings");
+
+		// #283: the identity-swap bump must fire before the racy saveSettings/rebuild.
+		const bumpIdx = order.indexOf("bumpAuthGeneration");
+		expect(bumpIdx).toBeGreaterThanOrEqual(0);
+		expect(bumpIdx).toBeLessThan(saveIdx);
 
 		expect(apiSwapIdx).toBeGreaterThanOrEqual(0);
 		expect(saveIdx).toBeGreaterThanOrEqual(0);
@@ -106,6 +116,11 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 			async saveSettings() {
 				order.push("saveSettings");
 			},
+			syncEngine: {
+				bumpAuthGeneration() {
+					order.push("bumpAuthGeneration");
+				},
+			},
 		};
 
 		await EngramSyncPlugin.prototype.clearOAuthTokens.call(fakeThis as never);
@@ -115,6 +130,11 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 		expect(apiSwapIdx).toBeGreaterThanOrEqual(0);
 		expect(saveIdx).toBeGreaterThanOrEqual(0);
 		expect(apiSwapIdx).toBeLessThan(saveIdx);
+
+		// #283: logout also swaps the provider — the bump must precede saveSettings.
+		const bumpIdx = order.indexOf("bumpAuthGeneration");
+		expect(bumpIdx).toBeGreaterThanOrEqual(0);
+		expect(bumpIdx).toBeLessThan(saveIdx);
 
 		// OAuth fields cleared before the save.
 		expect(fakeThis.settings.refreshToken).toBeUndefined();

--- a/tests/sync-cursor-pull.test.ts
+++ b/tests/sync-cursor-pull.test.ts
@@ -296,6 +296,26 @@ describe("SyncEngine reconcileFromManifest", () => {
 		expect(engine.exportSyncState()["gone.md"]).toBeDefined();
 	});
 
+	test("does NOT trash a live note when an identity swap races the manifest fetch (#283)", async () => {
+		// OAuth reconnect swaps the api auth provider while a fullSync/poll's
+		// manifest fetch is already in flight. The manifest resolves as a stale
+		// snapshot that omits a note the server actually still holds. Trashing it
+		// as "server-deleted" is the #283 local data-loss bug.
+		const live = fakeFile("live.md");
+		const { engine, pushFileSpy } = createEngine([live]);
+		engine.importSyncState({ "live.md": { hash: 123 } });
+		getManifest.mockImplementationOnce(async () => {
+			engine.bumpAuthGeneration(); // swap lands mid-fetch
+			return emptyManifest(); // stale: omits the still-live note
+		});
+
+		await (engine as any).reconcileFromManifest();
+
+		expect(trashFile).not.toHaveBeenCalled();
+		expect(engine.exportSyncState()["live.md"]).toBeDefined();
+		expect(pushFileSpy).not.toHaveBeenCalled();
+	});
+
 	test("a null manifest (pre-B1 backend / 404) is a no-op", async () => {
 		getManifest.mockResolvedValueOnce(null);
 		const gone = fakeFile("gone.md");

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, mock, spyOn, test } from "bun:test";
 import "fake-indexeddb/auto";
+import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import type { CrdtManager } from "../src/crdt/manager";
 import { NoteIdMap } from "../src/crdt/note-id-map";
@@ -917,5 +918,51 @@ describe("catchUp manifestSeq short-circuit (Phase E1)", () => {
 		// Fire-and-forget heal hasn't proven convergence — recording now would
 		// let every later poll short-circuit and never re-check an idle vault.
 		expect((engine as any).manifestSeq).toBe(0);
+	});
+});
+
+describe("catchUp identity-swap delete guard (#283)", () => {
+	// The production wiring: catchUp captures the auth generation BEFORE fetching
+	// the manifest and threads it into reconcileFromManifest. If an OAuth swap
+	// lands while that fetch is in flight, the manifest can be a stale snapshot
+	// missing a live note — trashing it as "server-deleted" is the #283 data loss.
+	// This guards the THREADING specifically: drop the authGenAtFetch argument at
+	// the reconcileFromManifest call and this test goes red (reconcile would then
+	// capture the post-swap generation and run the destructive pass).
+	test("does NOT trash a live note when an OAuth swap races catchUp's manifest fetch", async () => {
+		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
+		engine.importSyncState({ "Notes/gone.md": { hash: 123 } });
+		const gone = new TFile("Notes/gone.md");
+		(mockApp.vault.getFiles as ReturnType<typeof mock>).mockReturnValueOnce([gone]);
+		const trashFile = mockApp.fileManager.trashFile as ReturnType<typeof mock>;
+		trashFile.mockClear();
+		// Stub the non-reconcile downstream steps so catchUp runs to completion.
+		spyOn(engine as any, "validateFromManifest").mockReturnValue(0);
+		spyOn(engine as any, "catchupViaSeqReplay").mockResolvedValue({
+			applied: 0,
+			serverIds: new Set(),
+			serverAttachmentPaths: new Set(),
+			ran: true,
+		});
+		spyOn(engine as any, "healDivergedLiveBoundNotes").mockResolvedValue(0);
+		spyOn(engine as any, "syncExplicitFolders").mockResolvedValue(undefined);
+		spyOn(engine as any, "seedEmptyFolders").mockResolvedValue(undefined);
+		// Manifest resolves AFTER an identity swap bumped the generation, and omits
+		// the still-live note (stale snapshot from the racing swap).
+		(mockApi.getManifest as ReturnType<typeof mock>).mockImplementationOnce(async () => {
+			engine.bumpAuthGeneration();
+			return {
+				notes: [],
+				attachments: [],
+				total_notes: 0,
+				total_attachments: 0,
+				change_seq: 99,
+			};
+		});
+
+		await engine.catchUp();
+
+		expect(trashFile).not.toHaveBeenCalled();
+		expect(engine.exportSyncState()["Notes/gone.md"]).toBeDefined();
 	});
 });


### PR DESCRIPTION
## Problem (#283)

During an OAuth reconnect, `main.ts` `saveOAuthTokens` swaps `this.api`'s auth provider **non-atomically** with an already-scheduled `catchUp()`. That catch-up's manifest fetch can resolve *across* the swap as a stale snapshot missing notes the server still holds — and `reconcileFromManifest` then trashes them as "server-deleted." **Local data loss** (the note vanishes from the vault; unsaved live-bound edits are lost).

It's a same-vault token refresh, so the existing `syncStateVaultId` vault-mismatch guard **cannot** see it (that's why `runSeqReplayOnce`'s test_48 guard doesn't cover the destructive path).

## Fix

An optimistic-concurrency (generation) check:

- `authGeneration` counter on `SyncEngine`, bumped via `bumpAuthGeneration()` from `main.ts` on every OAuth token **save/clear** (the provider-swap points — verified to be the complete set; a plain access-token refresh doesn't swap the provider).
- `catchUp()` captures the generation **before** fetching the manifest and threads it into `reconcileFromManifest(manifest, authGenAtFetch)`.
- `reconcileFromManifest` refuses **only** its destructive trash pass if the generation changed while the fetch was in flight. The non-destructive `seedEmptyFolders` still runs.

A real server-delete still arrives as an op-log tombstone (primary delete path, unaffected); only the GC'd-tombstone backstop is deferred to the next clean catch-up. The skip errs toward *keeping* a note (opposite of #283) and self-corrects on next server activity.

## Tests (TDD)

- `sync-cursor-pull.test.ts` — self-fetch path: swap races the manifest fetch → live note not trashed.
- `sync-socket-catchup.test.ts` — **production catchUp path**: verified RED if the `authGenAtFetch` threading is dropped (would otherwise silently regress).
- `main-oauth-token-rebind.test.ts` — mocks completed + assert the bump fires before the racy `saveSettings`.

Full gauntlet green: 2260 pass, biome + obsidian-lint + build clean. Verified via triage that this bug is real on `main` (root cause traced to `reconcileFromManifest` sync.ts:4841, unguarded vs its `runSeqReplayOnce` sibling).

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)