### PR TITLE
test(sim): model-server sends its own STEP1 on client STEP1 (#299)

### DIFF
--- a/tests/sim/model-server.test.ts
+++ b/tests/sim/model-server.test.ts
@@ -218,6 +218,40 @@ test("WS crdt_msg STEP1 → sender gets a STEP2 that materializes server content
 	expect(doc.getText("content").toString()).toBe("server-body");
 });
 
+test("WS crdt_msg STEP1 → sender ALSO gets the server's own STEP1 (bidirectional handshake, #299)", async () => {
+	const { s, server } = boot();
+	const a = await joinCrdt(server, s, "a");
+	server.http({
+		method: "POST",
+		url: "/api/notes",
+		body: JSON.stringify({ path: "a.md", content: "server-body", mtime: 1, id: "n1" }),
+	});
+	a.recv.length = 0;
+	a.sock.send(
+		JSON.stringify([
+			CRDT_JOIN_REF,
+			"31",
+			CRDT_TOPIC,
+			CRDT_MSG,
+			{ doc_id: "n1", b64: step1Frame() },
+		]),
+	);
+	await s.drain();
+
+	// The real y_ex backend answers a client STEP1 with BOTH a STEP2 diff AND its
+	// own STEP1 (encode_sync_step1_response_v1 — the full mutual handshake, verified
+	// against the live crdt_channel: [:sync_step2, :sync_step1]). The client replies
+	// STEP2 to that STEP1, carrying any structs the server lacks — its held offline
+	// edits. A pull-only model that only returns STEP2 falsely "loses" them (#299).
+	const syncTypes = framesOf(a.recv, CRDT_MSG).map((f) => {
+		const dec2 = decoding.createDecoder(fromB64((f[4] as { b64: string }).b64));
+		decoding.readVarUint(dec2); // MESSAGE_SYNC
+		return decoding.readVarUint(dec2); // 0 = STEP1, 1 = STEP2, 2 = UPDATE
+	});
+	expect(syncTypes).toContain(syncProtocol.messageYjsSyncStep2);
+	expect(syncTypes).toContain(syncProtocol.messageYjsSyncStep1);
+});
+
 test("WS crdt_msg UPDATE (seed) → OTHER client gets note_yjs_update with raw update + head + seq", async () => {
 	const { s, server } = boot();
 	const a = await joinCrdt(server, s, "a");

--- a/tests/sim/model-server.ts
+++ b/tests/sim/model-server.ts
@@ -340,7 +340,7 @@ export class ModelServer {
 			});
 			return;
 		}
-		const { replyB64, changed } = this.applyClientFrame(n, b64);
+		const { replyB64, changed, serverStep1B64 } = this.applyClientFrame(n, b64);
 		// A STEP1 produces a STEP2 reply back to the SENDER only (a query answer).
 		if (replyB64 !== null) {
 			this.deliver(clientId, [
@@ -351,20 +351,38 @@ export class ModelServer {
 				{ doc_id: docId, b64: replyB64 },
 			]);
 		}
+		// #299: on a client STEP1, also send the server's OWN STEP1 (mutual handshake),
+		// so the sender replies STEP2 with any held structs the server lacks. Separate
+		// frame, matching the real backend's two-frame [step2, step1] reply.
+		if (serverStep1B64 !== null) {
+			this.deliver(clientId, [
+				null,
+				null,
+				n.crdtTopicKey(),
+				"crdt_msg",
+				{ doc_id: docId, b64: serverStep1B64 },
+			]);
+		}
 		// A STEP2/UPDATE that changed the server doc fans out to OTHER devices.
 		if (changed) this.fanoutUpdate(clientId, n, changed);
 	}
 
 	/** Decode a client `messageSync` frame, apply it to the note's doc, and (for
 	 *  a STEP1) return the STEP2 reply bytes. `changed` is the raw update the
-	 *  apply produced (to fan out), or null. Mirrors CrdtChannel.handleFrame. */
+	 *  apply produced (to fan out), or null. `serverStep1B64` is the server's OWN
+	 *  STEP1 sent back on a client STEP1 (see below). Mirrors CrdtChannel.handleFrame. */
 	private applyClientFrame(
 		n: Note,
 		b64: string,
-	): { replyB64: string | null; changed: Uint8Array | null } {
+	): {
+		replyB64: string | null;
+		changed: Uint8Array | null;
+		serverStep1B64: string | null;
+	} {
 		const decoder = decoding.createDecoder(fromB64(b64));
 		const messageType = decoding.readVarUint(decoder);
-		if (messageType !== MESSAGE_SYNC) return { replyB64: null, changed: null };
+		if (messageType !== MESSAGE_SYNC)
+			return { replyB64: null, changed: null, serverStep1B64: null };
 
 		const updates: Uint8Array[] = [];
 		const onUpdate = (u: Uint8Array, origin: unknown) => {
@@ -373,7 +391,7 @@ export class ModelServer {
 		n.doc.on("update", onUpdate);
 		const replyEncoder = encoding.createEncoder();
 		encoding.writeVarUint(replyEncoder, MESSAGE_SYNC);
-		syncProtocol.readSyncMessage(decoder, replyEncoder, n.doc, APPLY_ORIGIN);
+		const syncType = syncProtocol.readSyncMessage(decoder, replyEncoder, n.doc, APPLY_ORIGIN);
 		n.doc.off("update", onUpdate);
 
 		const changed = updates.length > 0 ? Y.mergeUpdates(updates) : null;
@@ -382,7 +400,23 @@ export class ModelServer {
 		// produces an empty reply, so no handshake storm (mirrors the client gate).
 		const replyB64 =
 			encoding.length(replyEncoder) > 1 ? toB64(encoding.toUint8Array(replyEncoder)) : null;
-		return { replyB64, changed };
+
+		// FIDELITY (#299): the real y_ex backend answers a client STEP1 with its OWN
+		// STEP1 too, not just the STEP2 diff — encode_sync_step1_response_v1 emits the
+		// full mutual handshake (verified against the live crdt_channel:
+		// [:sync_step2, :sync_step1]). The client replies STEP2 to that STEP1 carrying
+		// any structs the server lacks — its held offline edits. Omitting it made this
+		// model PULL-ONLY, so it never solicited a rejoining client's held ops and
+		// falsely "lost" offline edits the real backend recovers. Only a STEP1 gets a
+		// STEP1 back (a STEP2/UPDATE does not), so the exchange terminates — no storm.
+		let serverStep1B64: string | null = null;
+		if (syncType === syncProtocol.messageYjsSyncStep1) {
+			const step1Encoder = encoding.createEncoder();
+			encoding.writeVarUint(step1Encoder, MESSAGE_SYNC);
+			syncProtocol.writeSyncStep1(step1Encoder, n.doc);
+			serverStep1B64 = toB64(encoding.toUint8Array(step1Encoder));
+		}
+		return { replyB64, changed, serverStep1B64 };
 	}
 
 	private fanoutUpdate(fromClient: string, n: Note, update: Uint8Array): void {

--- a/tests/sim/random-harness.ts
+++ b/tests/sim/random-harness.ts
@@ -22,12 +22,13 @@
 // so sustained CONCURRENT ONLINE editing now converges under the strict oracle
 // and is a committed gating suite: `tests/sim/random.test.ts`. THIS file stays a
 // TOOL (`.ts`, never collected by `bun test`) for exploring the STILL-gapped
-// configs the committed suite deliberately scopes out — offline-online editing,
-// create-during-edit, and delete/rename — which remain divergent for the
-// FIDELITY reason in gap #2 + the pull-only-rejoin limitation (documented in
-// random.test.ts's header). Its workload below still edits WITHOUT opening
-// (unbound, history-less), so it also preserves a live demonstration of the
-// pre-enrollment conflict-copy storm gap #1 described for comparison.
+// configs the committed suite deliberately scopes out — create-during-edit (the
+// canSendLive/genesis-race hold) and delete/rename (the note_changed model
+// omission, gap #2 below). (Live-bound offline editing is NOT gapped: it recovers
+// via the mutual rejoin handshake now that the model-server is faithful — see
+// random.test.ts's header and the `#299` regression.) Its workload below still
+// edits WITHOUT opening (unbound, history-less), so it also preserves a live
+// demonstration of the pre-enrollment conflict-copy storm gap #1 for comparison.
 //
 // WHY THIS WORKLOAD STILL DIVERGES (as a tool):
 //

--- a/tests/sim/random.test.ts
+++ b/tests/sim/random.test.ts
@@ -32,22 +32,23 @@
 //
 // OUT OF SCOPE (documented tier gaps — deliberately NOT exercised here; NOT
 // oracle-loosening, these ops are simply not driven):
-//   * OFFLINE editing / offline-online churn. The CRDT rejoin handshake is
-//     PULL-ONLY — the backend never STEP1s back, so a client's offline (or
-//     otherwise gapped) Y.Doc ops are never re-pushed on reconnect; they reach
-//     the server only on the note's NEXT online edit via a full-state flush
-//     (sync.ts:786-790, flushHeldEditsOnCreateAck). A bound note's offline edit
-//     therefore does not converge in this CRDT-only model tier (its disk
-//     autosave is short-circuited by the isLiveBound gate, sync.ts:1982, so it
-//     can't fall back to the legacy REST queue either). The model faithfully
-//     reproduces this (model-server never solicits client ops on rejoin). This
-//     is a candidate real-fragility finding, not a plugin bug caught here — it
-//     needs isolation on the P2 real-backend tier before filing. See the report.
+//   * OFFLINE editing / offline-online churn. Kept out to keep this suite
+//     focused on sustained ONLINE concurrency — NOT because it diverges. A
+//     live-bound note's offline edit is held in the Y.Doc (its REST fallback is
+//     short-circuited by the isLiveBound gate, sync.ts:1982) and recovers on
+//     reconnect via the MUTUAL rejoin handshake: the server answers the client's
+//     re-enroll STEP1 with its OWN STEP1 (the real y_ex backend's
+//     encode_sync_step1_response_v1 — verified on the live crdt_channel as
+//     [step2, step1]), and the client replies STEP2 with the held struct. Proven
+//     deterministically by `#299 live-bound offline edit recovers on reconnect`
+//     in regressions.test.ts. (A prior model-server was PULL-ONLY and falsely
+//     "lost" these edits — the sim infidelity that mis-filed #299; fixed
+//     2026-07-23 by making the model solicit client ops on rejoin.)
 //   * CREATE-during-concurrent-edit. Editing a note still racing its
-//     genesis/enrollment (crdtHead unset → canSendLive HOLDS the edit → a
-//     permanent lineage gap the pull-only handshake never heals). Phase 1
-//     establishes notes first to keep this out; it is the same pull-only-rejoin
-//     limitation as offline.
+//     genesis/enrollment (crdtHead unset → canSendLive HOLDS the edit until the
+//     create acks). Phase 1 establishes notes first to keep this out. Distinct
+//     from offline: the hold here is the genesis race, not the rejoin handshake
+//     (which is faithful — see above).
 //   * DELETE + RENAME. The model omits note_changed (documented divergence #2):
 //     a delete/rename only reaches other replicas via a later reconnect
 //     catch-up, stranding stale old-path files at quiescence. Unchanged from the

--- a/tests/sim/regressions.test.ts
+++ b/tests/sim/regressions.test.ts
@@ -38,7 +38,13 @@
 import { afterAll, expect, test } from "bun:test";
 import { assertConverged, findWipes } from "./oracle";
 import { Replica } from "./replica";
-import { cleanup, equalSeqFence, genesisWipe, test85MissedDeliveryLocalPush } from "./scenarios";
+import {
+	cleanup,
+	equalSeqFence,
+	genesisWipe,
+	offlineBoundEditRecovers,
+	test85MissedDeliveryLocalPush,
+} from "./scenarios";
 
 // The scenarios boot replicas (via scenarios.ts), which install the process-global
 // SimClock/WebSocket/indexedDB patches. Restore them so later files in a full
@@ -72,6 +78,27 @@ test("#282 equal-seq fence: B's own-push echo must not fence the sole carrier", 
 // scripted witness for the same fence class (concurrent edits survive, no revert).
 test("test_85 missed-delivery + local push: both edits survive, no revert", async () => {
 	const r = await test85MissedDeliveryLocalPush();
+	try {
+		await assertConverged(r.topology.replicas, r.topology.server, r.topology.scheduler);
+	} finally {
+		cleanup(r.topology);
+	}
+	expect(true).toBe(true);
+});
+
+// #299 — live-bound offline edit recovers via the mutual rejoin handshake.
+//
+// DIFFERENTIAL PROOF (model-server fidelity):
+//   base  a PULL-ONLY model-server (readSyncMessage returns only STEP2) never
+//         solicits B's held struct on rejoin — B's offline edit is stranded in
+//         its Y.Doc, A never sees it, DIVERGES. This was the sim infidelity that
+//         mis-filed #299 as a real backend bug.
+//   fix   the model-server now answers a client STEP1 with its OWN STEP1 too
+//         (matching the live y_ex backend's [step2, step1] — encode_sync_step1_
+//         response_v1); B replies STEP2 with the held struct and CONVERGES.
+// The real backend was never pull-only; only the test double was.
+test("#299 live-bound offline edit recovers on reconnect (mutual handshake)", async () => {
+	const r = await offlineBoundEditRecovers();
 	try {
 		await assertConverged(r.topology.replicas, r.topology.server, r.topology.scheduler);
 	} finally {

--- a/tests/sim/scenarios.ts
+++ b/tests/sim/scenarios.ts
@@ -191,3 +191,42 @@ export async function test85MissedDeliveryLocalPush(seed = 85): Promise<Test85Re
 
 	return { topology: t, notePath };
 }
+
+// ---------------------------------------------------------------------------
+// #299 — a LIVE-BOUND note edited OFFLINE recovers on reconnect via the mutual
+// handshake. B opens (binds) the note, disconnects, and edits it: the edit is
+// held in B's Y.Doc and the REST/offline-queue fallback is short-circuited by
+// the isLiveBound gate (sync.ts:1982), so the ONLY way it can reach the server
+// is the rejoin handshake. On reconnect B re-enrolls (STEP1); a FAITHFUL server
+// answers with its OWN STEP1, and B replies STEP2 carrying the held struct — so
+// A + the server converge to B's offline edit. A pull-only model-server never
+// solicits it and the edit is silently lost — the sim infidelity that mis-filed
+// #299 as a real backend bug (the live crdt_channel replies [step2, step1]).
+// ---------------------------------------------------------------------------
+export interface Test299Result {
+	topology: Topology;
+	notePath: string;
+}
+
+export async function offlineBoundEditRecovers(seed = 299): Promise<Test299Result> {
+	const t = await boot(seed, ["A", "B"], { genesisEmptyDoc: true });
+	const [, b] = t.replicas;
+	const notePath = "offline299.md";
+	await t.replicas[0].createNote(notePath, "base\n");
+	await t.scheduler.drain();
+
+	// B binds the note live, then goes offline and edits the BOUND note.
+	await b.openNote(notePath);
+	await t.scheduler.drain();
+	await b.goOffline();
+	await t.scheduler.drain();
+	await b.editNote(notePath, "base\nfrom-B-offline\n");
+	await t.scheduler.drain();
+
+	// Reconnect: re-enroll STEP1 → server STEP1 → B replies STEP2 with the held
+	// struct → fan-out to A. All replicas + the server must converge to the edit.
+	await b.goOnline();
+	await t.scheduler.drain();
+
+	return { topology: t, notePath };
+}


### PR DESCRIPTION
## #299 was a sim-model artifact, not a backend bug

Issue #299 ("CRDT pull-only rejoin loses offline held edits") was filed on the assumption that the backend never sends its own STEP1 when a client re-enrolls. **That is false.**

The real y_ex backend answers a client STEP1 with **both** a STEP2 diff **and its own STEP1** — the full mutual y-protocols handshake (`encode_sync_step1_response_v1`). Verified directly against the live `crdt_channel`, which replies `[:sync_step2, :sync_step1]`. So a rejoining client re-pushes its held offline structs via the STEP2 reply to that server STEP1 — no loss.

The bug lived **only in the sim**: `tests/sim/model-server.ts`'s `applyClientFrame` used `syncProtocol.readSyncMessage`, which writes only a STEP2. So the test double never solicited a rejoining client's held ops and falsely "lost" a live-bound note's offline edit — the artifact that mis-filed #299 as a real fragility.

## Fix (test-only — no `src`/`main.js` change)

- `model-server.ts` — on a client **STEP1** (and only then, so the exchange terminates — no storm), also send the server's own STEP1 as a second `crdt_msg` frame, matching the real backend.
- `model-server.test.ts` — contract test asserting a client STEP1 yields both a STEP2 and a STEP1.
- `scenarios.ts` + `regressions.test.ts` — new deterministic `offlineBoundEditRecovers`: a live-bound note edited offline. **Verified RED** with the fix disabled (diverges — B's edit stranded locally, REST fallback short-circuited by `isLiveBound`, no catch-up masking), **GREEN** with it (converges via the mutual handshake alone).
- `random.test.ts` + `random-harness.ts` — corrected the now-false "pull-only backend" out-of-scope notes.

## Verification

Full gauntlet green: `bun test` 2260 pass / 0 fail, biome + obsidian-lint + build clean. Reviewed (pr-review-toolkit) — reviewer independently reproduced the RED-without-fix divergence and confirmed only a client STEP1 triggers the server STEP1.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)