### PR TITLE
chore(sync): delete materializeEmptyDiscovered REST race-closer (refs #310)

### DIFF
--- a/main.js
+++ b/main.js
@@ -18814,18 +18814,6 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     if (!path.endsWith(".md")) return;
     let normalized = (0, import_obsidian21.normalizePath)(path);
     if (this.app.vault.getAbstractFileByPath(normalized)) return;
-    try {
-      let note = await this.api.getNote(path);
-      if (note.content && note.content.length > 0) {
-        await this.flushFromCrdt(path, note.content);
-        return;
-      }
-    } catch (e) {
-      rlog().warn(
-        "crdt",
-        `materializeEmptyDiscovered: getNote failed for ${path}, materializing empty: ${errMsg(e)}`
-      );
-    }
     let text2 = this.crdt ? await this.crdt.projectedText(noteId) : "";
     await this.flushFromCrdt(path, text2);
   }

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1412,31 +1412,14 @@ export class SyncEngine {
 		// Already on disk — a content STEP2 created it, or the user already has it.
 		if (this.app.vault.getAbstractFileByPath(normalized)) return;
 
-		// An empty STEP2 is USUALLY the server's authoritative "genuinely empty"
-		// reply. Under load it can instead mean "content is in REST/DB but the
-		// note's CRDT room hasn't been seeded yet" — the author pushed via REST
-		// before its Y.Doc update reached the server. Materializing empty then
-		// races the real body and strands a permanently-empty file on this device
-		// (e2e test_38/test_43). Disambiguate against REST: if the server note has
-		// content, this empty STEP2 is stale — write the REST body, not an empty
-		// file. Proper fix is server-side (seed the Y.Doc from REST on first room
-		// open); this is the client-side race-closer.
-		try {
-			const note = await this.api.getNote(path);
-			if (note.content && note.content.length > 0) {
-				await this.flushFromCrdt(path, note.content);
-				return;
-			}
-		} catch (e) {
-			// REST unreachable, or a genuine 404 for a note not on the server yet.
-			// Fall through to the empty-materialize below — a genuinely empty note
-			// must still appear on disk even when this cross-check can't run.
-			rlog().warn(
-				"crdt",
-				`materializeEmptyDiscovered: getNote failed for ${path}, materializing empty: ${errMsg(e)}`,
-			);
-		}
-
+		// An empty STEP2 is the server's authoritative "genuinely empty" reply.
+		// The transient-empty race (an author's REST-pushed body whose Y.Doc
+		// update hadn't reached the server yet, so the room seeded empty and a
+		// premature empty file stranded on this device — e2e test_38/test_43) is
+		// now closed SERVER-SIDE by backend #1094: a room seeds from notes.content
+		// whenever the doc projects an empty body, so a content-bearing note's
+		// STEP2 already carries its body. The former client-side REST getNote
+		// cross-check (this note's #310 race-closer) is therefore redundant.
 		const text = this.crdt ? await this.crdt.projectedText(noteId) : "";
 		await this.flushFromCrdt(path, text);
 	}

--- a/tests/sync-crdt-gate.test.ts
+++ b/tests/sync-crdt-gate.test.ts
@@ -953,10 +953,8 @@ describe("P0-2 — materializeEmptyDiscovered: no-ops when syncBlocked", () => {
 
 		// File not on disk (simulating discovery)
 		(mockApp.vault.getAbstractFileByPath as any).mockReturnValue(null);
-		// No CRDT manager → projectedText falls back to ""
+		// No CRDT manager → projectedText falls back to "" → materializes empty.
 		engine.setCrdtManager(null as any);
-		// Server also has no content → genuinely empty.
-		(mockApi.getNote as any).mockResolvedValueOnce({ path: "Notes/empty.md", content: "" });
 
 		await engine.materializeEmptyDiscovered("Notes/empty.md");
 
@@ -965,49 +963,12 @@ describe("P0-2 — materializeEmptyDiscovered: no-ops when syncBlocked", () => {
 	});
 });
 
-describe("materializeEmptyDiscovered — transient-empty STEP2 race guard", () => {
-	test("writes the REST body (NOT empty) when the server note has content", async () => {
-		const engine = createEngine();
-		(mockApp.vault.getAbstractFileByPath as any).mockReturnValue(null);
-		engine.setCrdtManager(null as any); // CRDT doc empty → projectedText ""
-		// Server DID receive A's REST push — the empty STEP2 is stale, not authoritative.
-		(mockApi.getNote as any).mockResolvedValueOnce({
-			path: "Notes/race.md",
-			content: "server body v1",
-		});
-
-		await engine.materializeEmptyDiscovered("Notes/race.md");
-
-		expect(mockApi.getNote).toHaveBeenCalledWith("Notes/race.md");
-		const createArgs = (mockApp.vault.create as any).mock.calls[0];
-		expect(createArgs).toBeDefined();
-		expect(createArgs[1]).toContain("server body v1");
-	});
-
-	test("writes empty when the server confirms the note is genuinely empty", async () => {
-		const engine = createEngine();
-		(mockApp.vault.getAbstractFileByPath as any).mockReturnValue(null);
-		engine.setCrdtManager(null as any);
-		(mockApi.getNote as any).mockResolvedValueOnce({ path: "Notes/blank.md", content: "" });
-
-		await engine.materializeEmptyDiscovered("Notes/blank.md");
-
-		expect(mockApp.vault.create).toHaveBeenCalled();
-		expect((mockApp.vault.create as any).mock.calls[0][1]).toBe("");
-	});
-
-	test("falls back to empty-materialize when getNote fails (offline / 404)", async () => {
-		const engine = createEngine();
-		(mockApp.vault.getAbstractFileByPath as any).mockReturnValue(null);
-		engine.setCrdtManager(null as any);
-		(mockApi.getNote as any).mockRejectedValueOnce(new Error("404"));
-
-		await engine.materializeEmptyDiscovered("Notes/gone.md");
-
-		// A genuinely-empty note must still materialize even if REST is unreachable.
-		expect(mockApp.vault.create).toHaveBeenCalled();
-	});
-});
+// The former "transient-empty STEP2 race guard" describe block (a REST getNote
+// cross-check that distrusted an empty STEP2) was removed with the #310
+// race-closer: backend #1094 now seeds the room from notes.content server-side,
+// so materializeEmptyDiscovered materializes the doc projection directly. Its
+// convergence is covered end-to-end by e2e test_38/test_43 against the
+// #1094-in-prod backend.
 
 describe("materializeEmptyDiscovered — reads the CRDT doc via note_id, not path", () => {
 	test("projectedText is called with the note_id, never the path (no path-keyed ghost doc)", async () => {
@@ -1015,7 +976,6 @@ describe("materializeEmptyDiscovered — reads the CRDT doc via note_id, not pat
 		(mockApp.vault.getAbstractFileByPath as any).mockReturnValue(null);
 		const projectedText = mock(async () => "");
 		engine.setCrdtManager({ projectedText } as any);
-		(mockApi.getNote as any).mockResolvedValueOnce({ path: "Notes/idkeyed.md", content: "" });
 
 		await engine.materializeEmptyDiscovered("Notes/idkeyed.md", "note-abc-123");
 


### PR DESCRIPTION
## What

Deletes the client-side REST `getNote` cross-check in `materializeEmptyDiscovered` — the #310 "race-closer" for the empty-STEP2 / test_38-43 window. Backend #1094 now seeds the CRDT room from `notes.content` whenever the doc projects an empty body, so a content-bearing note's STEP2 already carries its body; the client cross-check is redundant. **#1094 is verified in prod** (release-v0.9.0 → deploy-prod → engram-infra #879 → terraform apply), so the deploy-gate is satisfied.

Removed the tests that pinned the deleted cross-check; convergence is covered end-to-end by e2e `test_38`/`test_43` against the #1094 backend.

## Scope — partial #310 (caller 1 only)

#310 also proposed deleting caller 2 (`handleStreamEvent`'s content-absent fetch) + `api.getNote`. A backend audit found the #310 "no note_id" premise **is** dead (every upsert broadcast carries `note_id`), **but** the `getNote` fallback is still a **live catch-all** for content-absent-but-id-present upserts on **non-.md (canvas) paths** and **crdt-null sessions** (e.g. a canvas folder-rename cascade). Deleting it outright would silently drop the body fetch for those. So caller 2 + `api.getNote` **stay**, tied to the canvas decision (#306). Hence `Refs #310`, not `Closes`.

## Verify
Full gauntlet green: `bun test` 2259 pass, biome + obsidian-lint + build clean.

Refs #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)