### PR TITLE
feat: modal-free drift-conflict-copy for CRDT md double-divergence (refs #306)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-drift-conflict-copy-phase-a.md
+++ b/docs/superpowers/plans/2026-07-23-drift-conflict-copy-phase-a.md
@@ -1,0 +1,232 @@
+# Drift-Conflict-Copy (Phase A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace md double-divergence's route into the legacy conflict tail with a single modal-free drift-conflict-copy: keep local untouched, write the authoritative version as a `(conflict <stamp>)` sibling, fire a Notice.
+
+**Architecture:** Reroute the `localDiverged` branch in the CRDT catch-up path (`applyChange`) to the *existing* `writeDriftConflictCopy` helper + `socketConverge`, instead of setting `crdtConflictFallthrough` and falling into the legacy tail. Remove the now-dead flag + its guard. Canvas is untouched; nothing is deleted.
+
+> **AS-BUILT (deviation from the sketch below):** A `writeDriftConflictCopy` helper ALREADY existed (`sync.ts:1375`, used at 3 drift sites) with the opposite orientation to the original spec — it preserves the **local** edit as the `(conflict <date>).md` copy and the main file converges to the server. Per user decision, Phase A REUSES it (consistency across 4 sites, no new method) and converges the main file via `socketConverge` (Yjs), not a raw snapshot write. The RED test and the `test_14` regression test in `sync-catchup.test.ts` were updated to the new modal-free contract (local preserved as copy + re-handshake fired, `onConflict` never called). Steps below describe the original sketch; the shipped change is smaller.
+
+**Tech Stack:** TypeScript, Bun test runner (Jest-compatible), Obsidian API (mocked in `tests/__mocks__/obsidian.ts`).
+
+## Global Constraints
+
+- Plugin version bumps are owned by release-please — do NOT bump `manifest.json`/`package.json`/`versions.json` in this PR.
+- Conventional commits; no em dashes in prose/commits.
+- Lint before push: `bun run build` (tsc) + `bun test` + `./node_modules/.bin/biome ci` + `bun run lint:obsidian` + `bun run lint:css`.
+- Branch prefix must not be `ci/`; use `feat/` or `fix/`.
+- No suppression (no `// @ts-ignore`, no skipped tests) — fix root cause.
+
+---
+
+### Task 1: Add `writeDriftConflictCopy` and reroute md double-divergence to it
+
+**Files:**
+- Modify: `src/sync.ts` (add method near the existing copy helper ~`1361-1370`; edit the catch-up branch `5513-5523`; edit flag decl `5301` + guard `5600`)
+- Test: `tests/sync.test.ts` (new test in the CRDT catch-up describe block)
+
+**Interfaces:**
+- Consumes (existing on `SyncEngine`): `createFileWithFolders(path: string, content: string): Promise<void>`, `syncState: Map<string, {hash:number; version?:number; serverHash?:string; seq?:number}>`, `baseStore?.set(path: string, content: string, version: number)`, `fnv1a(s: string): number`, `normalizePath` (from obsidian), `Notice` (from obsidian, already imported at `sync.ts:4`), `rlog()`.
+- Produces: `private async writeDriftConflictCopy(localPath: string, authoritativeContent: string, change: NoteChange): Promise<void>` — writes `<base> (conflict <stamp>).<ext>`, records syncState+baseStore for the copy, fires a Notice. Never touches `localPath` on disk.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/sync.test.ts`, inside the describe block that exercises the CRDT catch-up path (mirror the drift setup from the existing test "preserves genuine drift as a keep-both copy…" at ~line 601, but for the non-deleted catch-up branch that reaches `sync.ts:5460` else → `5513` `localDiverged`). Uses `createEngine()` (line 115), `NoteIdMap`, `__noticeCapture` (from the obsidian mock), `fnv1a`, `makeChange`.
+
+```ts
+test("md double-divergence writes a modal-free drift-conflict-copy of remote, keeps local", async () => {
+	const engine = createEngine(); // ready:true → this.crdt set
+	const path = "Notes/Drift.md";
+
+	const map = new NoteIdMap();
+	map.set(path, "id-drift");
+	engine.setNoteIdMap(map);
+
+	const baseline = "# Base\n";
+	const localDrift = "# Base\nlocal unsynced edit\n";
+	const remote = "# Base\nremote edit\n";
+
+	// Recorded baseline (serverHash defined so this is a CRDT-managed cold row,
+	// hash disagrees with disk == local drift) — routes to sync.ts:5460 else,
+	// and fnv1a(remote) !== stored.hash so it is NOT the echo/lagged branch (5488).
+	(engine as unknown as { syncState: Map<string, unknown> }).syncState.set(path, {
+		hash: fnv1a(baseline),
+		serverHash: "old-server-hash",
+	});
+
+	const existingFile = new TFile(path);
+	(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(existingFile);
+	mockApp.vault.cachedRead.mockResolvedValue(localDrift);
+
+	let onConflictCalled = false;
+	engine.onConflict = async () => {
+		onConflictCalled = true;
+		return { choice: "skip" };
+	};
+	__noticeCapture.notices.length = 0;
+
+	await engine.applyChange(
+		makeChange({ path, content: remote, content_hash: "new-server-hash", version: 2 }),
+	);
+
+	// Remote written as a (conflict …) sibling; local NOT modified; modal never shown.
+	const createCall = (mockApp.vault.create as jest.Mock).mock.calls[0];
+	expect(createCall[0]).toMatch(/\(conflict .*\)\.md$/);
+	expect(createCall[1]).toBe(remote);
+	expect(mockApp.vault.modify).not.toHaveBeenCalledWith(existingFile, remote);
+	expect(onConflictCalled).toBe(false);
+	expect(__noticeCapture.notices.length).toBeGreaterThan(0);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd plugin && bun test tests/sync.test.ts -t "drift-conflict-copy"`
+Expected: FAIL — currently the branch sets `crdtConflictFallthrough=true` and falls into the legacy tail, which (with `onConflict` returning `skip`) calls the modal (`onConflictCalled=true`) and creates no `(conflict …)` copy. If the RED does not fail on these assertions, the setup did not reach `sync.ts:5513` — adjust the preconditions (verify `crdtOwnsBody` is true and the row bypasses the `5488` echo branch) until it fails for the right reason.
+
+- [ ] **Step 3: Add the `writeDriftConflictCopy` method**
+
+Add near the existing conflict-copy helper (~`sync.ts:1361`):
+
+```ts
+/** Modal-free drift resolution: the on-disk file AND the authoritative doc
+ *  both moved off the last-synced baseline. Keep local untouched; save the
+ *  authoritative version as a sibling "(conflict <stamp>)" copy the user can
+ *  reconcile by hand. Replaces the legacy three-way-merge/modal tail for the
+ *  CRDT double-divergence case (#306 Phase A). */
+private async writeDriftConflictCopy(
+	localPath: string,
+	authoritativeContent: string,
+	change: NoteChange,
+): Promise<void> {
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+	const dot = localPath.lastIndexOf(".");
+	const base = dot > 0 ? localPath.slice(0, dot) : localPath;
+	const ext = dot > 0 ? localPath.slice(dot + 1) : "md";
+	const conflictPath = normalizePath(`${base} (conflict ${stamp}).${ext}`);
+	await this.createFileWithFolders(conflictPath, authoritativeContent);
+	this.syncState.set(conflictPath, {
+		hash: fnv1a(authoritativeContent),
+		version: change.version,
+	});
+	if (change.version != null) {
+		this.baseStore?.set(conflictPath, authoritativeContent, change.version);
+	}
+	new Notice(
+		`Engram: sync conflict on ${localPath} — saved remote copy as ${conflictPath}`,
+	);
+	rlog().warn("conflict", `drift-copy: ${localPath} -> ${conflictPath}`);
+}
+```
+
+- [ ] **Step 4: Reroute the `localDiverged` branch**
+
+At `sync.ts:5513-5523`, replace the flag assignment with a direct call + early return:
+
+```ts
+			const localDiverged =
+				localNow !== null &&
+				stored?.hash !== undefined &&
+				fnv1a(localNow) !== stored.hash &&
+				localNow !== content;
+			if (localDiverged) {
+				rlog().warn(
+					"pull",
+					`CRDT catch-up: local+remote both diverged, writing drift-conflict-copy ${change.path}`,
+				);
+				await this.writeDriftConflictCopy(normalized, content, change);
+				return false;
+			} else if (
+```
+
+- [ ] **Step 5: Remove the now-dead `crdtConflictFallthrough` flag**
+
+The flag is now never set to `true` (only site was `5523`). Remove the declaration at `sync.ts:5301` (`let crdtConflictFallthrough = false;`) and change the guard at `sync.ts:5600` from `if (!crdtConflictFallthrough) return false;` to `return false;`. Verify with `grep -n crdtConflictFallthrough src/sync.ts` → no matches.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd plugin && bun test tests/sync.test.ts -t "drift-conflict-copy"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd plugin && git add src/sync.ts tests/sync.test.ts
+git commit -m "feat: modal-free drift-conflict-copy for md double-divergence (refs #306)"
+```
+
+---
+
+### Task 2: Guard test (non-drift does not copy) + full gauntlet
+
+**Files:**
+- Test: `tests/sync.test.ts`
+
+**Interfaces:**
+- Consumes: everything from Task 1.
+
+- [ ] **Step 1: Write the guard test**
+
+```ts
+test("md catch-up with clean local (no drift) does NOT write a conflict copy", async () => {
+	const engine = createEngine();
+	const path = "Notes/Clean.md";
+	const map = new NoteIdMap();
+	map.set(path, "id-clean");
+	engine.setNoteIdMap(map);
+
+	const baseline = "# Base\n";
+	const remote = "# Base\nremote edit\n";
+	// Disk still equals the last-synced baseline == NOT drifted.
+	(engine as unknown as { syncState: Map<string, unknown> }).syncState.set(path, {
+		hash: fnv1a(baseline),
+		serverHash: "old-server-hash",
+	});
+	const existingFile = new TFile(path);
+	(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(existingFile);
+	mockApp.vault.cachedRead.mockResolvedValue(baseline);
+	__noticeCapture.notices.length = 0;
+
+	await engine.applyChange(
+		makeChange({ path, content: remote, content_hash: "new-server-hash", version: 2 }),
+	);
+
+	// No (conflict …) copy: clean local converges via the room, not a drift-copy.
+	const created = (mockApp.vault.create as jest.Mock).mock.calls.map((c) => c[0]);
+	expect(created.some((p: string) => /\(conflict .*\)/.test(p))).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run it (RED then GREEN)**
+
+Run: `cd plugin && bun test tests/sync.test.ts -t "does NOT write a conflict copy"`
+Expected: PASS immediately (the clean-local path was never rerouted). If it FAILS (a copy was written), the Task 1 reroute is over-firing — the `localDiverged` guard must require `fnv1a(localNow) !== stored.hash`; fix before proceeding.
+
+- [ ] **Step 3: Full plugin gauntlet**
+
+Run and confirm all green:
+```bash
+cd plugin
+bun run build
+bun test
+./node_modules/.bin/biome ci
+bun run lint:obsidian
+bun run lint:css
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd plugin && git add tests/sync.test.ts
+git commit -m "test: guard that clean-local md catch-up writes no drift-copy (refs #306)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Phase A of the spec = drift-conflict-copy function (Task 1 method) + reroute md `crdtConflictFallthrough` (Task 1 steps 4-5) + modal-free + Notice (Task 1 test) + delete nothing (canvas/onCorruption tail untouched — confirmed: canvas never enters the `crdtOwnsBody` block, so it still reaches the legacy tail at `5603`). The threeWayMerge tradeoff is realized because md no longer reaches `threeWayMerge` (only the tail called it, and md no longer falls through) — but the file is NOT deleted here (canvas still uses it) per Phase A scope. Covered.
+- **Placeholder scan:** none.
+- **Type consistency:** `writeDriftConflictCopy(localPath, authoritativeContent, change)` used consistently; `NoteChange` is the existing type passed to `applyChange`; `change.version` is `number | null | undefined` as used at the existing keep-both site.
+- **Known risk:** the RED test setup must actually reach `sync.ts:5513`. Step 2 explicitly gates on the RED failing for the right reason; if it doesn't, adjust preconditions (this is why it is TDD, not a guess).

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1373,8 +1373,12 @@ export class SyncEngine {
 	 *  real errors (disk full, permission, illegal path) propagate. Returns the
 	 *  conflict path written. */
 	private async writeDriftConflictCopy(normalized: string, localDisk: string): Promise<string> {
-		const date = new Date().toISOString().slice(0, 10);
-		const conflictPath = `${normalized.replace(/\.md$/, "")} (conflict ${date}).md`;
+		// Millisecond-precision stamp (not date-only): two double-divergence
+		// resolutions on the SAME note within one day would otherwise produce an
+		// identical path, and createFileWithFolders degrades that collision to an
+		// in-place modify — silently clobbering the first preserved copy.
+		const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+		const conflictPath = `${normalized.replace(/\.md$/, "")} (conflict ${stamp}).md`;
 		await this.createFileWithFolders(conflictPath, localDisk);
 		this.syncState.set(normalizePath(conflictPath), { hash: fnv1a(localDisk) });
 		return conflictPath;
@@ -5326,7 +5330,6 @@ export class SyncEngine {
 		// REMOTE both diverged from the last-synced state (a real conflict),
 		// the block falls through to the legacy conflict flow below instead of
 		// silently backfilling over the local edit.
-		let crdtConflictFallthrough = false;
 		if (crdtOwnsBody) {
 			// noteId resolved above (shared with the anti-stale guard). This is
 			// populated for the merged-feed caller (applySyncChange learns `id`
@@ -5543,13 +5546,56 @@ export class SyncEngine {
 							stored?.hash !== undefined &&
 							fnv1a(localNow) !== stored.hash &&
 							localNow !== content;
-						if (localDiverged) {
+						if (localDiverged && localNow !== null) {
+							// Both the on-disk file AND the authoritative doc moved off
+							// the last-synced baseline. Preserve the local drift as a
+							// "(conflict)" copy (existing convention, shared with the
+							// tombstone/foreign-delete sites) and converge the main file
+							// to the server via the room — no three-way merge, no modal
+							// (#306 Phase A: the drift-copy replaces the legacy tail for
+							// the CRDT double-divergence case).
 							rlog().warn(
 								"pull",
-								`CRDT catch-up: local+remote both diverged, routing to conflict flow ${change.path}`,
+								`CRDT catch-up: local+remote both diverged, drift-copy + converge ${change.path}`,
 							);
-							crdtConflictFallthrough = true;
-						} else if (
+							let copy: string | null = null;
+							try {
+								copy = await this.writeDriftConflictCopy(normalized, localNow);
+							} catch (e) {
+								rlog().warn(
+									"conflict",
+									`drift-copy capture failed for ${normalized}: ${errMsg(e)}`,
+								);
+							}
+							if (copy === null) {
+								// The local edit could NOT be backed up. Do NOT converge:
+								// socketConverge would overwrite the main file with the
+								// server version, destroying the only remaining copy of
+								// the local edit. Leave disk untouched; the next catch-up
+								// re-attempts the copy for this still-diverged row.
+								rlog().warn(
+									"conflict",
+									`drift-copy failed — leaving ${normalized} intact, deferring convergence to next catch-up`,
+								);
+								return false;
+							}
+							new Notice(
+								`Engram: sync conflict on ${normalized} — your local edit was saved as ${copy}`,
+							);
+							if (noteId) {
+								this.pendingConvergence.set(noteId, {
+									path: normalized,
+									serverHash: change.content_hash,
+									content,
+									version: change.version,
+									seq: change.seq,
+								});
+								this.socketConverge(normalized, noteId);
+							}
+							return false;
+						}
+
+						if (
 							noteId &&
 							stored?.serverHash === undefined &&
 							localNow !== null &&
@@ -5625,7 +5671,11 @@ export class SyncEngine {
 					rlog().info("pull", `CRDT-managed: re-enroll for catch-up ${change.path}`);
 				}
 			}
-			if (!crdtConflictFallthrough) return false;
+			// CRDT-managed markdown never falls through to the legacy conflict
+			// tail: the double-divergence case is handled inline above by the
+			// drift-copy (#306 Phase A). The tail below serves canvas + other
+			// non-CRDT notes only.
+			return false;
 		}
 
 		// Create or update the file

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -385,15 +385,16 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(state?.seq).toBeUndefined();
 	});
 
-	test("local edit + remote edit diverged: routes to conflict flow — skip preserves local (test_14 regression)", async () => {
-		const { engine } = crdtEngine({ conflictResolution: "modal" });
+	test("local edit + remote edit diverged: drift-copy preserves local + converges main, no modal (test_14 regression)", async () => {
+		const { engine, enroll, reset } = crdtEngine({ conflictResolution: "modal" });
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
 		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		// Local content NO LONGER matches the last-synced hash — the user
-		// edited it. The server ALSO moved. That is a conflict, not a catch-up:
-		// backfilling would silently overwrite the local edit (2026-07-08
-		// e2e test_14: "skip" was never consulted).
+		// Local content NO LONGER matches the last-synced hash (user edited it)
+		// and the server ALSO moved: a real double-divergence. #306 Phase A
+		// resolves it modal-free — the local edit is preserved as a "(conflict)"
+		// copy (never silently overwritten, the test_14 invariant) and the main
+		// file converges to the server via the room re-handshake.
 		mockApp.vault.cachedRead.mockResolvedValue("Edited by B");
 		engine.importSyncState({
 			"owned.md": { hash: fnv1a("Base content"), version: 1, serverHash: "old-hash" },
@@ -410,10 +411,51 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 			mtime: 50,
 		} as any);
 
-		// The conflict flow was consulted and skip left everything untouched.
-		expect(onConflict).toHaveBeenCalledTimes(1);
-		expect(mockApp.vault.modify).not.toHaveBeenCalled();
-		expect(mockApp.vault.process).not.toHaveBeenCalled();
+		// No modal; the local edit is saved as a "(conflict)" copy (never lost).
+		expect(onConflict).not.toHaveBeenCalled();
+		const conflictCreate = (mockApp.vault.create as any).mock.calls.find((c: unknown[]) =>
+			/\(conflict .*\)\.md$/.test(c[0] as string),
+		);
+		expect(conflictCreate).toBeDefined();
+		expect(conflictCreate?.[1]).toBe("Edited by B");
+		// Main converges via the room re-handshake; nothing recorded until STEP2.
+		expect(reset).toHaveBeenCalledWith("note-id-1");
+		expect(enroll).toHaveBeenCalledWith("note-id-1");
+		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
+	});
+
+	test("drift-copy: if the conflict-copy write FAILS, do NOT converge (local edit not silently lost)", async () => {
+		const { engine, enroll, reset } = crdtEngine({ conflictResolution: "modal" });
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		// Only the main file exists; the "(conflict …)" path does NOT — so a failed
+		// vault.create is a genuine write failure, not the already-exists degrade.
+		mockApp.vault.getAbstractFileByPath.mockImplementation((p: string) =>
+			p === "owned.md" ? localFile : null,
+		);
+		mockApp.vault.cachedRead.mockResolvedValue("Edited by B");
+		// The conflict-copy write fails (disk full / permission). The local edit
+		// could NOT be preserved, so convergence must be SKIPPED — otherwise the
+		// room re-handshake would overwrite the main file and the local edit would
+		// exist in neither the copy nor the file.
+		mockApp.vault.create.mockRejectedValue(new Error("disk full"));
+		engine.importSyncState({
+			"owned.md": { hash: fnv1a("Base content"), version: 1, serverHash: "old-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "Edited by A",
+			content_hash: "new-hash",
+			version: 2,
+			mtime: 50,
+		} as any);
+
+		// No convergence fired, so the diverged local file is left intact on disk
+		// for the next catch-up to retry the copy.
+		expect(reset).not.toHaveBeenCalled();
+		expect(enroll).not.toHaveBeenCalled();
 		expect(engine.exportSyncState()["owned.md"]?.serverHash).toBe("old-hash");
 	});
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -638,6 +638,104 @@ describe("SyncEngine.applySyncChange (apply behavior)", () => {
 		expect(mockApi.pushNote).not.toHaveBeenCalled();
 	});
 
+	test("md double-divergence (#306) writes a modal-free drift-conflict-copy of remote, keeps local", async () => {
+		// conflictResolution:"modal" so the OLD behaviour would call onConflict —
+		// the meaningful RED. setCrdtManager makes crdtOwnsBody true so applyChange
+		// enters the CRDT catch-up block and reaches the localDiverged branch.
+		const engine = createEngine({ conflictResolution: "modal" });
+		engine.setCrdtManager({
+			removeDoc: () => Promise.resolve(),
+			closeDoc: () => {},
+		} as unknown as import("../src/crdt/manager").CrdtManager);
+		const path = "Notes/Drift306.md";
+
+		const map = new NoteIdMap();
+		map.set(path, "id-drift-306");
+		engine.setNoteIdMap(map);
+
+		const baseline = "# Base\n";
+		const localDrift = "# Base\nlocal unsynced edit\n";
+		const remote = "# Base\nremote edit\n";
+		// Recorded baseline disagrees with disk (local drift) AND remote content
+		// hash differs from the row's — both sides moved off the baseline.
+		(engine as unknown as { syncState: Map<string, unknown> }).syncState.set(path, {
+			hash: fnv1a(baseline),
+			serverHash: "old-server-hash",
+		});
+
+		const existingFile = new TFile(path);
+		(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(existingFile);
+		mockApp.vault.cachedRead.mockResolvedValue(localDrift);
+
+		let onConflictCalled = false;
+		engine.onConflict = async () => {
+			onConflictCalled = true;
+			return { choice: "skip" as const };
+		};
+		__noticeCapture.notices.length = 0;
+
+		await engine.applyChange({
+			type: "note",
+			id: "id-drift-306",
+			path,
+			content: remote,
+			content_hash: "new-server-hash",
+			version: 2,
+			mtime: 1709345678,
+			deleted: false,
+		} as unknown as Parameters<typeof engine.applyChange>[0]);
+
+		// Local drift preserved as a "(conflict …)" sibling (existing convention);
+		// main converges to the server via socketConverge; no modal shown.
+		const conflictCreate = (mockApp.vault.create as jest.Mock).mock.calls.find((c: unknown[]) =>
+			/\(conflict .*\)\.md$/.test(c[0] as string),
+		);
+		expect(conflictCreate).toBeDefined();
+		expect(conflictCreate?.[1]).toBe(localDrift);
+		expect(onConflictCalled).toBe(false);
+		expect(__noticeCapture.notices.length).toBeGreaterThan(0);
+	});
+
+	test("md catch-up with a clean local file (no drift) writes NO conflict copy", async () => {
+		const engine = createEngine({ conflictResolution: "modal" });
+		engine.setCrdtManager({
+			removeDoc: () => Promise.resolve(),
+			closeDoc: () => {},
+		} as unknown as import("../src/crdt/manager").CrdtManager);
+		const path = "Notes/Clean306.md";
+
+		const map = new NoteIdMap();
+		map.set(path, "id-clean-306");
+		engine.setNoteIdMap(map);
+
+		const baseline = "# Base\n";
+		const remote = "# Base\nremote edit\n";
+		// Disk still equals the last-synced baseline == NOT drifted.
+		(engine as unknown as { syncState: Map<string, unknown> }).syncState.set(path, {
+			hash: fnv1a(baseline),
+			serverHash: "old-server-hash",
+		});
+		const existingFile = new TFile(path);
+		(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(existingFile);
+		mockApp.vault.cachedRead.mockResolvedValue(baseline);
+		__noticeCapture.notices.length = 0;
+
+		await engine.applyChange({
+			type: "note",
+			id: "id-clean-306",
+			path,
+			content: remote,
+			content_hash: "new-server-hash",
+			version: 2,
+			mtime: 1709345678,
+			deleted: false,
+		} as unknown as Parameters<typeof engine.applyChange>[0]);
+
+		// Clean local converges via the room, never a drift-copy.
+		const created = (mockApp.vault.create as jest.Mock).mock.calls.map((c: unknown[]) => c[0]);
+		expect(created.some((p: unknown) => /\(conflict .*\)/.test(p as string))).toBe(false);
+	});
+
 	test("still skips + resurrects a legacy (non-CRDT) note with unsynced edits", async () => {
 		const { engine } = makeCrdtDeleteEngine();
 		// No id mapping → not CRDT-managed → legacy resurrection protection.


### PR DESCRIPTION
**#306 Phase A** of the canvas-CRDT initiative (spec: `50 Engineering/_Superpowers Specs/2026-07-23-canvas-crdt-sync-design.md` in the Engram vault).

## What changes
When a CRDT-managed markdown file **and** the authoritative doc both diverge from the last-synced baseline (the `localDiverged` case in `applyChange`'s CRDT catch-up), it now resolves **modal-free** instead of routing into the legacy conflict tail (`threeWayMerge` → `ConflictModal`):

- preserve the local edit as a `(conflict <ts>).md` copy via the **existing** `writeDriftConflictCopy` helper (same convention as the CRDT-tombstone + WS-foreign-delete drift sites), and
- converge the main file to the server via `socketConverge` (Yjs).

The now-dead `crdtConflictFallthrough` flag + its guard are removed — a CRDT-managed md note never falls through to the legacy tail. Canvas and other non-CRDT notes still reach the tail (nothing deleted; `three-way-merge.ts` / `conflict-modal.ts` stay until Phase C, after canvas moves to CRDT in Phase B).

## Data-loss guards (from code review)
- **Copy-write failure does not converge.** If `writeDriftConflictCopy` throws, we do NOT run `socketConverge` (which would overwrite main with the server version and destroy the un-backed-up local edit). Disk is left intact; the next catch-up retries. Regression-tested.
- **Millisecond stamp.** Bumped the shared helper's stamp from date-only to ms precision so a second same-day conflict on one note can't collide and clobber the first copy.

## Tests (TDD, RED-first)
- New: md double-divergence writes a `(conflict)` copy of **local**, no modal, Notice fired; clean-local writes no copy; copy-write-failure skips convergence.
- Updated: the `test_14` regression to the new modal-free contract (local preserved as copy, re-handshake fired, `onConflict` never called).

## Verification
`bun run build` (tsc) · full `bun test` **2262 pass, 0 fail** · biome + eslint (`lint:obsidian`) + stylelint (`lint:css`) all clean. Code-reviewed; both findings fixed in-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj