### PR TITLE
feat(crdt): canvas onto CRDT — structural Yjs sync (#306 Phase B, plugin)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-canvas-crdt-phase-b-plugin.md
+++ b/docs/superpowers/plans/2026-07-24-canvas-crdt-phase-b-plugin.md
@@ -1,0 +1,58 @@
+# Plan: #306 Phase B (plugin) — canvas onto the CRDT path
+
+**Date:** 2026-07-24
+**Repo:** engram-obsidian (worktree `feat/canvas-crdt-plugin`)
+**Pairs with:** backend PR #1107 (must merge first). Spec: Engram vault `50 Engineering/_Superpowers Specs/2026-07-23-canvas-crdt-sync-design.md`.
+**Goal:** Route `.canvas` notes through the same Yjs CRDT transport `.md` uses, with a *structural* doc schema (per-element merge), so canvas leaves the legacy REST/LWW + conflict tail. Unblocks Phase C (delete three-way-merge/diff/conflict-modal).
+
+## Design decisions
+
+1. **Structural schema (approved, do not relitigate).** Canvas doc = `Y.Map "nodes"` (keyed by node id) + `Y.Map "edges"` (keyed by edge id) + `Y.Map "canvas_meta"` (top-level non-node/edge fields) + `Y.Array "nodes_order"` + `Y.Array "edges_order"` (preserve array order == z-index; mirrors the existing `frontmatter_order` pattern). Order arrays are NOT in the one-liner spec but are required for project∘reconcile identity and stable disk hashes; they merge like `frontmatter_order`.
+2. **Manager learns doc kind once, stores it on the entry.** `manager.ts` has zero type-awareness today (keyed by bare noteId). Thread a `kind: "note" | "canvas"` into the doc-creating entry point; store on the `entry()` value. The two `doc.on("update")` listeners and the projection method branch on `e.kind` (markdown→`projectNote`, canvas→`projectCanvas`). Default `"note"` keeps every existing caller unchanged. Kind derived from file extension at the sync.ts call sites.
+3. **Reuse, don't fork, the transport + drift path.** Canvas rides `crdt_create`/`crdt_msg`/`crdt_delete`/`crdt_catchup` unchanged. Canvas divergence routes through the SAME `writeDriftConflictCopy` + `socketConverge` the md `localDiverged` branch uses (generalize the helper's hardcoded `.md` suffix).
+4. **JSON fidelity.** Obsidian writes `.canvas` as `JSON.stringify(data, null, "\t")` (tabs). `projectCanvas` must match byte-for-byte or every pull re-hashes/re-writes. Confirm the exact format from an Obsidian-written canvas before finalizing.
+
+## Stages (TDD, RED-first each; one concern per commit)
+
+### Stage 1 — manager canvas schema (pure, unit-tested in isolation)
+- Add `canvas-codec.ts` (or functions in `manager.ts`): `seedCanvasInto(doc, jsonStr)` and `projectCanvas(doc)`.
+  - `seedCanvasInto`: parse JSON; upsert changed nodes/edges by id into the Y.Maps; delete removed ids; replace order arrays; canvas_meta for leftover top-level keys. One `doc.transact`.
+  - `projectCanvas`: rebuild `{...canvas_meta, nodes:[order→node], edges:[order→edge]}` → `JSON.stringify(_, null, "\t")`.
+- **RED test** (mirror `manager.test.ts:409` round-trip): `projectCanvas(seedCanvasInto(doc, json)) === json` (identity); concurrent per-element merge (two docs edit different nodes → both survive); node delete propagates; malformed JSON → no throw (keep-local fallback signalled).
+
+### Stage 2 — manager kind-threading
+- Thread `kind` into `entry()`/`getDoc`/`applyLocalEdit`/`projectedText`/`encodeGenesisUpdate`; store on entry; branch the two update listeners + `projectedText` on `e.kind`. `applyLocalEdit` for a canvas doc calls `seedCanvasInto` instead of `seedContentInto`; the flush listener projects via `projectCanvas`.
+- **RED test**: `applyLocalEdit(id, canvasJson, "canvas")` populates nodes/edges maps (not the content Y.Text); a remote update flushes canvas JSON to disk via the listener.
+
+### Stage 3 — sync.ts push (canvas → crdt_create / crdt_msg)
+- Generalize the `file.extension === "md"` push gates (`:2466/2498/2587/2610/2800`) + `routeModify` `isMarkdown` params to admit canvas (pass `kind`). Canvas reaches genesis `crdt_create` / `routeModify`→`applyLocalEdit`(canvas) / durable `crdtEnqueue create` instead of `api.pushNote` `:2814`.
+- `routeModify` `:92` gate: `isMarkdown` → `isCrdtEligible` (md OR canvas); keep the byte cap (canvas can be large — same 4MiB cap; oversized canvas falls back to REST push, which survives).
+- `handleModify` `crdtManaged` `:1968` + live-bound skip `:1982`: include canvas.
+- **RED test**: update `sync-crdt-route.test.ts:399` (was ".canvas uses legacy pushNote") to assert canvas now routes through `applyLocalEdit`/crdt_create; canvas enroll test `sync-crdt-gate.test.ts:320`.
+
+### Stage 4 — sync.ts delete + rename (canvas → crdt_delete / rename-as-move)
+- Delete `:2067/2081`: canvas → `crdtEnqueue {kind:"delete"}`, drop `api.deleteNote`. Teardown gates `:2056/2089/2097/4457/5262`: include canvas so `removeDoc` runs.
+- Rename `:2140/2153`: canvas → md no-tombstone rename-as-move (drop old-path `api.deleteNote`).
+- Offline queue delete `:7335`: verify canvas delete rides crdt.
+- **RED test**: canvas delete enqueues crdt delete + tears down doc; canvas rename moves without REST tombstone.
+
+### Stage 5 — sync.ts pull (canvas enters crdtOwnsBody block)
+- `crdtOwnsBody` `:5285`: `.md` → md-or-canvas. Canvas now enters the CRDT pull-apply block (`:5333-5679`) and skips the legacy REST/LWW + conflict tail `:5681+`. Anti-stale guard `:5309`.
+- Flush/materialize gates `:838/1010/1414/1449/4487`: include canvas.
+- Drift: generalize `writeDriftConflictCopy` `:1381` (`.md$` → the real ext); route canvas `localDiverged` `:5544` through the same drift-copy + `socketConverge`.
+- **RED test**: canvas remote upsert applies via CRDT (no ConflictModal); canvas external-disk-drift writes a `(conflict …).canvas` copy + converges.
+
+### Stage 6 — migration + full-suite + biome/lints
+- Confirm existing-canvas migration (REST/LWW row, no Yjs state): first open seeds the room from the local `.canvas` file; two-device seed converges by node-id (empty-doc guard #1043/#1094). Add/adjust a sim or route test.
+- `bun test` full suite green; fix the legacy canvas tests that pinned REST behavior; `biome ci`, `lint:obsidian`, `lint:css`, `bun run build` (tsc). NO version bump (release-please owns it).
+
+## Verification / merge
+- Full `bun test` + biome + build green locally.
+- code-reviewer agent, all findings fixed in-PR.
+- Paired e2e: backend #1107 merges FIRST, then push plugin branch, re-trigger the engram-side `plugin-e2e-trigger`, and verify the `e2e-crdt` + `e2e-clerk` JOB conclusions green directly (roll-up flakes).
+- One PR (one initiative). Refs #306.
+
+## Risks / open
+- Canvas JSON format fidelity (tabs vs spaces, key order) — verify against a real Obsidian canvas.
+- Node/edge array order under concurrent reorder — order arrays give a deterministic merge, not necessarily the user's intended z-order on a true concurrent reorder (acceptable for Phase 1 file-sync).
+- Large-canvas cap: oversized canvas still falls to REST push (`api.pushNote` survives) — the drift-copy/pull path must tolerate a canvas that is REST on one device, CRDT on another during rollout.

--- a/main.js
+++ b/main.js
@@ -21273,8 +21273,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  wrap (`encodeUpdateFrame`), so the frame the server applies via
    *  SharedDoc.send_yjs_message is byte-identical to what a live `crdt_msg`
    *  would deliver — a divergent encoding would corrupt content on merge. */
-  encodeGenesisFrame(content) {
-    return encodeUpdateFrame(this.crdt.encodeGenesisUpdate(content));
+  encodeGenesisFrame(content, kind = "note") {
+    return encodeUpdateFrame(this.crdt.encodeGenesisUpdate(content, kind));
   }
   /** Record local state after a genesis note's server row is created (batch
    *  path). Mirrors pushFile's post-`crdt_create` bookkeeping (sync.ts ~2574):
@@ -21383,7 +21383,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         await this.pushFile(file, !0) ? pushed++ : failed++;
         continue;
       }
-      let b64 = this.encodeGenesisFrame(content), size2 = b64.length, pushedPath = file.path, noteId = (_d = (_c = this.noteIdMap) == null ? void 0 : _c.get(np)) != null ? _d : uuid7();
+      let b64 = this.encodeGenesisFrame(content, file.extension === "canvas" ? "canvas" : "note"), size2 = b64.length, pushedPath = file.path, noteId = (_d = (_c = this.noteIdMap) == null ? void 0 : _c.get(np)) != null ? _d : uuid7();
       if (this.noteIdMap && !this.noteIdMap.get(np) && this.noteIdMap.set(np, noteId), size2 > PAYLOAD_BUDGET) {
         await this.pushFile(file, !0) ? pushed++ : failed++;
         continue;

--- a/main.js
+++ b/main.js
@@ -12209,6 +12209,79 @@ function diffIntoYText(text2, incoming) {
   text2.doc ? text2.doc.transact(apply) : apply();
 }
 
+// src/crdt/canvas-codec.ts
+var NODES_KEY = "nodes", EDGES_KEY = "edges", NODES_ORDER_KEY = "nodes_order", EDGES_ORDER_KEY = "edges_order", CANVAS_META_KEY = "canvas_meta";
+function parseCanvas(json) {
+  let data;
+  try {
+    data = JSON.parse(json);
+  } catch (e) {
+    return null;
+  }
+  if (data === null || typeof data != "object" || Array.isArray(data)) return null;
+  let obj = data, nodes = asElements(obj.nodes), edges = asElements(obj.edges);
+  if (nodes === null || edges === null) return null;
+  let meta = {};
+  for (let [k, v] of Object.entries(obj))
+    k !== NODES_KEY && k !== EDGES_KEY && (meta[k] = v);
+  return { nodes, edges, meta };
+}
+function asElements(v) {
+  if (v === void 0) return [];
+  if (!Array.isArray(v)) return null;
+  let out = [];
+  for (let el of v) {
+    if (el === null || typeof el != "object" || Array.isArray(el) || typeof el.id != "string") return null;
+    out.push(el);
+  }
+  return out;
+}
+function seedCanvasInto(doc2, json) {
+  let parsed = parseCanvas(json);
+  return parsed === null ? !1 : (doc2.transact(() => {
+    upsertElements(doc2.getMap(NODES_KEY), doc2.getArray(NODES_ORDER_KEY), parsed.nodes), upsertElements(doc2.getMap(EDGES_KEY), doc2.getArray(EDGES_ORDER_KEY), parsed.edges), upsertMeta(doc2.getMap(CANVAS_META_KEY), parsed.meta);
+  }), !0);
+}
+function upsertElements(map3, order, elements) {
+  let ids = new Set(elements.map((e) => e.id));
+  for (let el of elements) {
+    let cur = map3.get(el.id);
+    (cur === void 0 || !jsonEqual(cur, el)) && map3.set(el.id, el);
+  }
+  for (let id2 of [...map3.keys()])
+    ids.has(id2) || map3.delete(id2);
+  order.length > 0 && order.delete(0, order.length), elements.length > 0 && order.insert(
+    0,
+    elements.map((e) => e.id)
+  );
+}
+function upsertMeta(map3, meta) {
+  for (let [k, v] of Object.entries(meta))
+    jsonEqual(map3.get(k), v) || map3.set(k, v);
+  for (let k of [...map3.keys()])
+    k in meta || map3.delete(k);
+}
+function projectCanvas(doc2) {
+  let meta = doc2.getMap(CANVAS_META_KEY).toJSON(), nodes = orderedElements(doc2.getMap(NODES_KEY), doc2.getArray(NODES_ORDER_KEY)), edges = orderedElements(doc2.getMap(EDGES_KEY), doc2.getArray(EDGES_ORDER_KEY));
+  return JSON.stringify({ ...meta, nodes, edges }, null, "	");
+}
+function orderedElements(map3, order) {
+  let out = [], seen = /* @__PURE__ */ new Set();
+  for (let id2 of order.toArray()) {
+    let el = map3.get(id2);
+    el !== void 0 && !seen.has(id2) && (out.push(el), seen.add(id2));
+  }
+  for (let id2 of [...map3.keys()].sort())
+    seen.has(id2) || out.push(map3.get(id2));
+  return out;
+}
+function canvasIsEmpty(doc2) {
+  return doc2.getMap(NODES_KEY).size === 0 && doc2.getMap(EDGES_KEY).size === 0;
+}
+function jsonEqual(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
 // node_modules/yaml/browser/dist/nodes/identity.js
 var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias"), DOC = /* @__PURE__ */ Symbol.for("yaml.document"), MAP = /* @__PURE__ */ Symbol.for("yaml.map"), PAIR = /* @__PURE__ */ Symbol.for("yaml.pair"), SCALAR = /* @__PURE__ */ Symbol.for("yaml.scalar"), SEQ = /* @__PURE__ */ Symbol.for("yaml.seq"), NODE_TYPE = /* @__PURE__ */ Symbol.for("yaml.node.type"), isAlias = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === ALIAS, isDocument = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === DOC, isMap = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === MAP, isPair = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === PAIR, isScalar = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SCALAR, isSeq = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SEQ;
 function isCollection(node) {
@@ -17191,8 +17264,8 @@ var _CrdtManager = class _CrdtManager {
       if (!stable)
         return null;
     }
-    let lca = hasLca != null ? hasLca : this.textHasHistory(e.text);
-    return !lca && ((_b = (_a = this.opts).isUnchangedSynced) != null && _b.call(_a, noteId, content)) || this.seedContentInto(e.doc, e.text, content, lca), content;
+    let lca = hasLca != null ? hasLca : e.kind === "canvas" ? !canvasIsEmpty(e.doc) : this.textHasHistory(e.text);
+    return !lca && ((_b = (_a = this.opts).isUnchangedSynced) != null && _b.call(_a, noteId, content)) ? content : e.kind === "canvas" ? seedCanvasInto(e.doc, content) ? content : null : (this.seedContentInto(e.doc, e.text, content, lca), content);
   }
   /**
    * Ingest a disk-content string into a doc's Y.Text + frontmatter shared types
@@ -17225,10 +17298,10 @@ var _CrdtManager = class _CrdtManager {
    * doubling (#846) — the real doc adopts the server lineage on its first
    * handshake.
    */
-  encodeGenesisUpdate(content) {
+  encodeGenesisUpdate(content, kind = "note") {
     let doc2 = new Doc();
     try {
-      return this.seedContentInto(doc2, doc2.getText(CONTENT_KEY), content, !1), encodeStateAsUpdate(doc2);
+      return kind === "canvas" ? seedCanvasInto(doc2, content) : this.seedContentInto(doc2, doc2.getText(CONTENT_KEY), content, !1), encodeStateAsUpdate(doc2);
     } finally {
       doc2.destroy();
     }
@@ -17301,11 +17374,15 @@ var _CrdtManager = class _CrdtManager {
    * transiently-empty in-memory doc.
    */
   async hasHistory(noteId) {
-    return this.textHasHistory((await this.entry(noteId)).text);
+    let e = await this.entry(noteId);
+    return e.kind === "canvas" ? !canvasIsEmpty(e.doc) : this.textHasHistory(e.text);
   }
-  /** Full reconstructed file (frontmatter fence + body) as it would be written to disk. */
+  /** Full reconstructed file as it would be written to disk: a markdown file
+   *  (frontmatter fence + body) or a canvas JSON document. */
   async projectedText(noteId) {
-    let e = await this.entry(noteId), { order, values } = frontmatterOf(e.doc);
+    let e = await this.entry(noteId);
+    if (e.kind === "canvas") return projectCanvas(e.doc);
+    let { order, values } = frontmatterOf(e.doc);
     return projectNote(order, values, e.text.toJSON(), rawFrontmatterOf(e.doc));
   }
   /**
@@ -17380,7 +17457,9 @@ var _CrdtManager = class _CrdtManager {
    * Returns true if the doc was flattened, false if the threshold was not met.
    */
   async flattenIfBloated(noteId) {
-    let e = await this.entry(noteId), encoded = encodeStateAsUpdate(e.doc), clientIds = decodeStateVector(encodeStateVector(e.doc)).size;
+    let e = await this.entry(noteId);
+    if (e.kind === "canvas") return !1;
+    let encoded = encodeStateAsUpdate(e.doc), clientIds = decodeStateVector(encodeStateVector(e.doc)).size;
     if (encoded.length < _CrdtManager.MAX_CONTENT_BYTES || clientIds < _CrdtManager.MAX_CLIENT_IDS)
       return !1;
     let plaintext = e.text.toJSON(), { order, values } = frontmatterOf(e.doc), raws = rawFrontmatterOf(e.doc), id2 = this.docId(noteId);
@@ -17431,35 +17510,45 @@ var _CrdtManager = class _CrdtManager {
    *   remote update → flushed to disk via `onFlushToDisk`; NOT forwarded
    */
   async entry(noteId) {
+    var _a, _b, _c;
     let id2 = this.docId(noteId), cached = this.docs.get(id2);
     if (cached)
       return await cached.ready, cached;
-    let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), text2 = doc2.getText(CONTENT_KEY), ready = persistence.whenSynced.then(() => {
-    }), entry = { doc: doc2, persistence, text: text2, ready, remoteSeq: 0, hadContent: !1 };
+    let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), kind = (_c = (_b = (_a = this.opts).docKind) == null ? void 0 : _b.call(_a, noteId)) != null ? _c : "note", text2 = doc2.getText(CONTENT_KEY), ready = persistence.whenSynced.then(() => {
+    }), hasContent2 = () => kind === "canvas" ? !canvasIsEmpty(doc2) : text2.length > 0, entry = {
+      doc: doc2,
+      persistence,
+      kind,
+      text: text2,
+      ready,
+      remoteSeq: 0,
+      hadContent: !1
+    };
     return persistence.on("error", (err) => {
-      var _a, _b;
-      return (_b = (_a = this.opts).onPersistError) == null ? void 0 : _b.call(_a, noteId, err);
+      var _a2, _b2;
+      return (_b2 = (_a2 = this.opts).onPersistError) == null ? void 0 : _b2.call(_a2, noteId, err);
     }), doc2.on("update", (update, origin) => {
-      text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
+      hasContent2() && (entry.hadContent = !0), origin !== REMOTE_ORIGIN && (this.opts.canSendLive && !this.opts.canSendLive(id2) || this.opts.onUpdate(id2, update, origin));
     }), doc2.on("update", (_u, origin) => {
-      if (text2.length > 0 && (entry.hadContent = !0), origin !== REMOTE_ORIGIN) return;
-      entry.remoteSeq += 1;
-      let { order, values } = frontmatterOf(doc2), raws = rawFrontmatterOf(doc2), body = text2.toJSON();
-      if (body.length === 0 && !entry.hadContent) {
+      if (hasContent2() && (entry.hadContent = !0), origin !== REMOTE_ORIGIN) return;
+      if (entry.remoteSeq += 1, !hasContent2() && !entry.hadContent) {
         rlog().warn(
           "crdt",
-          `remote-merge flush SKIPPED for ${noteId}: empty body on never-seeded doc (#288 genesis guard)`
+          `remote-merge flush SKIPPED for ${noteId}: empty ${kind} on never-seeded doc (#288 genesis guard)`
         );
         return;
       }
-      let flush = Promise.resolve(
-        this.opts.onFlushToDisk(noteId, projectNote(order, values, body, raws))
-      );
+      let projected = kind === "canvas" ? projectCanvas(doc2) : projectNote(
+        frontmatterOf(doc2).order,
+        frontmatterOf(doc2).values,
+        text2.toJSON(),
+        rawFrontmatterOf(doc2)
+      ), flush = Promise.resolve(this.opts.onFlushToDisk(noteId, projected));
       this.pendingFlush.set(id2, flush), flush.catch(() => {
       }).finally(() => {
         this.pendingFlush.get(id2) === flush && this.pendingFlush.delete(id2);
       });
-    }), this.docs.set(id2, entry), await ready, text2.length > 0 && (entry.hadContent = !0), entry;
+    }), this.docs.set(id2, entry), await ready, hasContent2() && (entry.hadContent = !0), entry;
   }
   /**
    * Returns true when the Y.Text already carries CRDT history (content
@@ -17771,7 +17860,7 @@ function exceedsCrdtNoteLimit(content, maxBytes) {
   return maxBytes > 0 && new TextEncoder().encode(content).length > maxBytes;
 }
 async function routeModify(file, crdt, maxBytes) {
-  if (!file.isMarkdown) return null;
+  if (!file.crdtEligible) return null;
   let content = await file.readContent();
   if (exceedsCrdtNoteLimit(content, maxBytes))
     return null;
@@ -18495,7 +18584,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  exists. Md + size gated exactly like the pre-push enroll (an oversized
    *  doc must never enroll — 8 MB WS frame limit). */
   refireEnrollmentOnFirstConfirm(noteId, path, content) {
-    !noteId || !this.crdtEnrollment || this.isNoteConfirmed(noteId) || path.endsWith(".md") && (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) || this.isLiveBound((0, import_obsidian21.normalizePath)(path)) && (this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId)));
+    !noteId || !this.crdtEnrollment || this.isNoteConfirmed(noteId) || this.isCrdtEligiblePath(path) && (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) || this.isLiveBound((0, import_obsidian21.normalizePath)(path)) && (this.crdtEnrollment.reset(noteId), this.crdtEnrollment.enroll(noteId)));
   }
   /** Drop a note_id's confirmed status when its server row is deleted, so a
    *  subsequent push of the same id (a rename's new-path push) takes the
@@ -18577,11 +18666,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       (_c = this.crdtEnrollment) == null || _c.reset(localId);
     }
     let file = this.crdt ? this.app.vault.getAbstractFileByPath(normalized) : null;
-    if (this.crdt && file instanceof import_obsidian21.TFile && this.isMarkdown(file))
+    if (this.crdt && file instanceof import_obsidian21.TFile && this.isCrdtEligible(file))
       try {
         let consumed = await routeModify(
           {
-            isMarkdown: !0,
+            crdtEligible: !0,
             noteId: effectiveId,
             readContent: () => this.app.vault.cachedRead(file)
           },
@@ -18781,7 +18870,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  real errors (disk full, permission, illegal path) propagate. Returns the
    *  conflict path written. */
   async writeDriftConflictCopy(normalized, localDisk) {
-    let date = (/* @__PURE__ */ new Date()).toISOString().slice(0, 10), conflictPath = `${normalized.replace(/\.md$/, "")} (conflict ${date}).md`;
+    let stamp = (/* @__PURE__ */ new Date()).toISOString().replace(/[:.]/g, "-"), ext = normalized.endsWith(".canvas") ? "canvas" : "md", conflictPath = `${normalized.replace(/\.(md|canvas)$/, "")} (conflict ${stamp}).${ext}`;
     return await this.createFileWithFolders(conflictPath, localDisk), this.syncState.set((0, import_obsidian21.normalizePath)(conflictPath), { hash: fnv1a(localDisk) }), conflictPath;
   }
   /** Materialize an EMPTY note whose emptiness the server has just confirmed.
@@ -18811,7 +18900,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       );
       return;
     }
-    if (!path.endsWith(".md")) return;
+    if (!this.isCrdtEligiblePath(path)) return;
     let normalized = (0, import_obsidian21.normalizePath)(path);
     if (this.app.vault.getAbstractFileByPath(normalized)) return;
     let text2 = this.crdt ? await this.crdt.projectedText(noteId) : "";
@@ -18836,7 +18925,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  null), where the isSynced gate is the backstop. */
   async materializeRelocated(path, noteId) {
     var _a, _b;
-    if (!this.crdt || !path.endsWith(".md") || typeof this.crdt.isSynced != "function" || !this.crdt.isSynced(noteId) || this.app.vault.getAbstractFileByPath((0, import_obsidian21.normalizePath)(path))) return;
+    if (!this.crdt || !this.isCrdtEligiblePath(path) || typeof this.crdt.isSynced != "function" || !this.crdt.isSynced(noteId) || this.app.vault.getAbstractFileByPath((0, import_obsidian21.normalizePath)(path))) return;
     let text2 = await this.crdt.projectedText(noteId), canonical = (_b = (_a = this.noteIdMap) == null ? void 0 : _a.pathForId(noteId)) != null ? _b : null;
     if (canonical !== null && (0, import_obsidian21.normalizePath)(canonical) !== (0, import_obsidian21.normalizePath)(path)) {
       rlog().info(
@@ -19088,6 +19177,24 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   isMarkdown(file) {
     return file instanceof import_obsidian21.TFile && file.extension === "md";
   }
+  /** CRDT-eligible = markdown OR canvas: both sync over the Yjs transport
+   *  (the manager's docKind picks the per-type schema). Binary/attachment
+   *  types are NOT eligible and stay on the REST/attachment path. */
+  isCrdtEligible(file) {
+    return file instanceof import_obsidian21.TFile && (file.extension === "md" || file.extension === "canvas");
+  }
+  /** Path-string variant of isCrdtEligible for the pull/apply path, which works
+   *  with normalized paths (from a NoteChange), not TFile handles. */
+  isCrdtEligiblePath(path) {
+    return path.endsWith(".md") || path.endsWith(".canvas");
+  }
+  /** True for a canvas note path. Canvas is CRDT but STRUCTURAL: its authoritative
+   *  content lives in the Yjs doc, never notes.content (which the backend keeps
+   *  vestigial for canvas), so the pull path must converge it over the Yjs
+   *  handshake, never by writing the seq-feed `content`. */
+  isCanvasPath(path) {
+    return path.endsWith(".canvas");
+  }
   /** Check if a file should be synced (markdown, canvas, or binary attachment). */
   isSyncable(file) {
     return file instanceof import_obsidian21.TFile ? TEXT_EXTENSIONS.has(file.extension) || BINARY_EXTENSIONS.has(file.extension) : !1;
@@ -19112,7 +19219,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       this.pendingPostPullPushes.add(file.path), this.schedulePostPullDrain();
       return;
     }
-    let crdtManaged = !!this.crdt && this.isMarkdown(file);
+    let crdtManaged = !!this.crdt && this.isCrdtEligible(file);
     if (!crdtManaged && this.recentlyFlushed.has(file.path)) {
       rlog().info("sync", `Modify echo skip (recently flushed from CRDT): ${file.path}`);
       return;
@@ -19138,14 +19245,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     existing && (window.clearTimeout(existing), this.debounceTimers.delete(file.path));
     let crdtNoteId = isBinary ? null : (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(file.path)) != null ? _b : null;
     if (crdtNoteId && this.markRecentlyDeleted(crdtNoteId), isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path), this.syncState.delete((0, import_obsidian21.normalizePath)(file.path)), this.remotelyDeleted.has(file.path)) {
-      this.remotelyDeleted.delete(file.path), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), file.path.endsWith(".md") && crdtNoteId && (await ((_d = this.crdt) == null ? void 0 : _d.removeDoc(crdtNoteId)), (_e = this.crdtEnrollment) == null || _e.reset(crdtNoteId));
+      this.remotelyDeleted.delete(file.path), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && (await ((_d = this.crdt) == null ? void 0 : _d.removeDoc(crdtNoteId)), (_e = this.crdtEnrollment) == null || _e.reset(crdtNoteId));
       return;
     }
     try {
-      isBinary ? (await this.api.deleteAttachment(file.path), this.goOnline()) : file.path.endsWith(".md") ? crdtNoteId && ((_f = this.crdtEnqueue) == null || _f.call(this, { kind: "delete", docId: crdtNoteId, path: file.path })) : (await this.api.deleteNote(file.path), this.goOnline()), file.path.endsWith(".md") && crdtNoteId && (await ((_g = this.crdt) == null ? void 0 : _g.removeDoc(crdtNoteId)), (_h = this.crdtEnrollment) == null || _h.reset(crdtNoteId));
+      isBinary ? (await this.api.deleteAttachment(file.path), this.goOnline()) : this.isCrdtEligible(file) ? crdtNoteId && ((_f = this.crdtEnqueue) == null || _f.call(this, { kind: "delete", docId: crdtNoteId, path: file.path })) : (await this.api.deleteNote(file.path), this.goOnline()), this.isCrdtEligible(file) && crdtNoteId && (await ((_g = this.crdt) == null ? void 0 : _g.removeDoc(crdtNoteId)), (_h = this.crdtEnrollment) == null || _h.reset(crdtNoteId));
     } catch (e) {
       if (isHttpStatus(e, 404)) {
-        this.goOnline(), file.path.endsWith(".md") && crdtNoteId && (await ((_i = this.crdt) == null ? void 0 : _i.removeDoc(crdtNoteId)), (_j = this.crdtEnrollment) == null || _j.reset(crdtNoteId));
+        this.goOnline(), this.isCrdtEligible(file) && crdtNoteId && (await ((_i = this.crdt) == null ? void 0 : _i.removeDoc(crdtNoteId)), (_j = this.crdtEnrollment) == null || _j.reset(crdtNoteId));
         return;
       }
       console.error("Engram Sync: failed to delete %s", file.path, e), await this.enqueueChange({
@@ -19168,7 +19275,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let isBinary = this.isBinaryFile(file);
     if (isBinary || (_a = this.noteIdMap) == null || _a.rename(oldPath, file.path), !this.shouldIgnore(oldPath))
       try {
-        isBinary ? (await this.api.deleteAttachment(oldPath), this.goOnline()) : oldPath.endsWith(".md") || (await this.api.deleteNote(oldPath), this.goOnline());
+        isBinary ? (await this.api.deleteAttachment(oldPath), this.goOnline()) : this.isCrdtEligible(file) || (await this.api.deleteNote(oldPath), this.goOnline());
       } catch (e) {
         isHttpStatus(e, 404) ? this.goOnline() : (console.error("Engram Sync: failed to delete old path %s", oldPath, e), await this.enqueueChange({
           path: oldPath,
@@ -19319,13 +19426,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             ), !1;
           noteId = uuid7(), this.noteIdMap.set(file.path, noteId);
         }
-        if (file.extension === "md" && rlog().info(
+        if (this.isCrdtEligible(file) && rlog().info(
           "push",
           `route: ${file.path} crdt=${!!this.crdt} server=${this.hasServerNote(noteId)} confirmed=${noteId ? this.isNoteConfirmed(noteId) : !1} live=${(_e = (_d = this.crdtLive) == null ? void 0 : _d.call(this)) != null ? _e : !0} id=${noteId != null ? noteId : "none"}`
         ), this.crdt && noteId && this.hasServerNote(noteId)) {
           let consumed = await routeModify(
             {
-              isMarkdown: file.extension === "md",
+              crdtEligible: this.isCrdtEligible(file),
               noteId,
               // A LIVE read, not the frozen `content` above: routeModify
               // forwards this as the manager's stale-snapshot reread, and a
@@ -19344,9 +19451,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           ), rlog().info(
             "push",
             `CRDT edit queued durably (channel down): ${file.path}`
-          ), !0)) : (file.extension === "md" && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) && this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_i = this.crdtEnrollment) == null || _i.enroll(noteId)), !0);
+          ), !0)) : (this.isCrdtEligible(file) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) && this.isLiveBound((0, import_obsidian21.normalizePath)(file.path)) && ((_i = this.crdtEnrollment) == null || _i.enroll(noteId)), !0);
         }
-        if (this.crdtCreate && this.crdt && noteId && file.extension === "md" && !this.hasServerNote(noteId) && ((_k = (_j = this.crdtLive) == null ? void 0 : _j.call(this)) == null || _k) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
+        if (this.crdtCreate && this.crdt && noteId && this.isCrdtEligible(file) && !this.hasServerNote(noteId) && ((_k = (_j = this.crdtLive) == null ? void 0 : _j.call(this)) == null || _k) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
           try {
             let serverId = await this.crdtCreate(noteId, pushedPath), effectiveId = noteId;
             try {
@@ -19367,7 +19474,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
                   `crdt_create ADOPT: remapped ${pushedPath} ${noteId} -> ${serverId}`
                 ), effectiveId = serverId), consumed = await routeModify(
                   {
-                    isMarkdown: !0,
+                    crdtEligible: !0,
                     noteId: effectiveId,
                     readContent: () => this.app.vault.cachedRead(file)
                   },
@@ -19400,7 +19507,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               `crdt_create failed, enqueued for durable retry: ${pushedPath} | ${String(err)}`
             ), this.crdtEnqueue ? (this.crdtEnqueue({ kind: "create", docId: noteId, path: pushedPath }), !0) : !1;
           }
-        if (file.extension === "md" && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
+        if (this.isCrdtEligible(file) && !exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES))
           return this.crdtEnqueue && this.crdt && noteId && !this.hasServerNote(noteId) && this.crdtEnqueue({ kind: "create", docId: noteId, path: pushedPath }), !1;
         let resp = await this.api.pushNote(pushedPath, content, mtime);
         if ("conflict" in resp)
@@ -20315,7 +20422,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         }
         await this.trashRemotelyDeleted(existing), await this.removeEmptyFolders(normalized), this.syncState.delete(normalized), (_k = this.baseStore) == null || _k.delete(normalized);
       }
-      if (normalized.endsWith(".md")) {
+      if (this.isCrdtEligiblePath(normalized)) {
         (_l = this.noteIdMap) == null || _l.delete(normalized);
         let roomId2 = targetId != null ? targetId : currentId;
         roomId2 && (await ((_m = this.crdt) == null ? void 0 : _m.removeDoc(roomId2)), (_n = this.crdtEnrollment) == null || _n.reset(roomId2));
@@ -20337,7 +20444,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             },
             attachment.content_base64
           );
-        } else if (this.crdt && event.path.endsWith(".md") && ((_p = event.id) != null ? _p : (_o = this.noteIdMap) != null && _o.get(event.path))) {
+        } else if (this.crdt && this.isCrdtEligiblePath(event.path) && ((_p = event.id) != null ? _p : (_o = this.noteIdMap) != null && _o.get(event.path))) {
           let noteId = (_r = event.id) != null ? _r : (_q = this.noteIdMap) == null ? void 0 : _q.get(event.path), canonicalPath = (_t2 = (_s = this.noteIdMap) == null ? void 0 : _s.pathForId(noteId)) != null ? _t2 : null;
           if (canonicalPath !== null && (0, import_obsidian21.normalizePath)(canonicalPath) !== (0, import_obsidian21.normalizePath)(event.path))
             rlog().info(
@@ -20345,7 +20452,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               `Stale-path upsert ignored for ${noteId}: canonical=${canonicalPath} event=${event.path}`
             );
           else {
-            (_u = this.noteIdMap) == null || _u.set(event.path, noteId), this.confirmNoteId(noteId), this.isLiveBound((0, import_obsidian21.normalizePath)(event.path)) && ((_v = this.crdtEnrollment) == null || _v.enroll(noteId));
+            (_u = this.noteIdMap) == null || _u.set(event.path, noteId), this.confirmNoteId(noteId), (this.isCanvasPath((0, import_obsidian21.normalizePath)(event.path)) || this.isLiveBound((0, import_obsidian21.normalizePath)(event.path))) && ((_v = this.crdtEnrollment) == null || _v.enroll(noteId));
             let np = (0, import_obsidian21.normalizePath)(event.path), priorState = this.syncState.get(np);
             event.content_hash !== void 0 && (priorState == null ? void 0 : priorState.serverHash) === void 0 && this.syncState.set(np, {
               hash: (_w = priorState == null ? void 0 : priorState.hash) != null ? _w : fnv1a(""),
@@ -20629,7 +20736,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  Returns true when a file was actually created, modified, or trashed.
    *  When forceOverwrite is true, skip conflict detection and always apply. */
   async applyChange(change, forceOverwrite = !1) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y, _z, _A, _B;
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p, _q, _r, _s, _t2, _u, _v, _w, _x, _y, _z, _A, _B, _C;
     if (this.shouldIgnore(change.path))
       return devLog().log("pull", `applyChange SKIP (ignored): ${change.path}`), !1;
     !change.deleted && change.content === "" && change.content_hash && (this.emptyContentHash = change.content_hash);
@@ -20680,14 +20787,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               `CRDT tombstone honoured (no drift): ${change.path} | syncedHash=${(_e = lastSynced == null ? void 0 : lastSynced.hash) != null ? _e : "none"}`
             );
         }
-        return await this.trashRemotelyDeleted(existing2), await this.removeEmptyFolders(normalized), this.syncState.delete(normalized), (_f = this.baseStore) == null || _f.delete(normalized), rlog().info("pull", `Deleted: ${change.path}`), crdtNoteId && normalized.endsWith(".md") && ((_g = this.noteIdMap) == null || _g.delete(normalized), await ((_h = this.crdt) == null ? void 0 : _h.removeDoc(crdtNoteId)), (_i = this.crdtEnrollment) == null || _i.reset(crdtNoteId)), !0;
+        return await this.trashRemotelyDeleted(existing2), await this.removeEmptyFolders(normalized), this.syncState.delete(normalized), (_f = this.baseStore) == null || _f.delete(normalized), rlog().info("pull", `Deleted: ${change.path}`), crdtNoteId && this.isCrdtEligiblePath(normalized) && ((_g = this.noteIdMap) == null || _g.delete(normalized), await ((_h = this.crdt) == null ? void 0 : _h.removeDoc(crdtNoteId)), (_i = this.crdtEnrollment) == null || _i.reset(crdtNoteId)), !0;
       }
       return !1;
     }
     let content = change.content;
     if (content === void 0)
       throw new Error(`applyChange: missing content for ${change.path}`);
-    let crdtOwnsBody = !!(this.crdt && normalized.endsWith(".md")), noteId = (_k = (_j = this.noteIdMap) == null ? void 0 : _j.get(normalized)) != null ? _k : null;
+    let crdtOwnsBody = !!(this.crdt && this.isCrdtEligiblePath(normalized)), noteId = (_k = (_j = this.noteIdMap) == null ? void 0 : _j.get(normalized)) != null ? _k : null;
     if (!forceOverwrite && !(crdtOwnsBody && noteId) && change.version !== void 0) {
       let known = (_l = this.syncState.get(normalized)) == null ? void 0 : _l.version;
       if (known !== void 0 && known >= change.version && this.app.vault.getFileByPath(normalized))
@@ -20696,17 +20803,18 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           `applyChange skip (stale v${change.version} <= synced v${known}): ${change.path}`
         ), !1;
     }
-    let crdtConflictFallthrough = !1;
     if (crdtOwnsBody) {
+      if (this.isCanvasPath(normalized))
+        return noteId && ((_m = this.crdtEnrollment) == null || _m.enroll(noteId)), rlog().info("pull", `CRDT canvas: enroll for Yjs convergence ${change.path}`), !1;
       if (!this.app.vault.getFileByPath(normalized))
-        noteId && this.isLiveBound(normalized) && ((_m = this.crdtEnrollment) == null || _m.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content);
+        noteId && this.isLiveBound(normalized) && ((_n = this.crdtEnrollment) == null || _n.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content);
       else {
-        noteId && this.isLiveBound(normalized) && ((_n = this.crdtEnrollment) == null || _n.enroll(noteId));
+        noteId && this.isLiveBound(normalized) && ((_o = this.crdtEnrollment) == null || _o.enroll(noteId));
         let stored = this.syncState.get(normalized), contentMatches = !change.content_hash || (stored == null ? void 0 : stored.serverHash) === change.content_hash;
         if (change.seq !== void 0 ? (stored == null ? void 0 : stored.seq) !== void 0 && (change.seq < stored.seq || change.seq === stored.seq && contentMatches) : (stored == null ? void 0 : stored.version) !== void 0 && change.version !== void 0 && change.version <= stored.version)
           rlog().info(
             "pull",
-            `CRDT catch-up: stale row (seq ${(_o = change.seq) != null ? _o : "-"}/${(_p = stored == null ? void 0 : stored.seq) != null ? _p : "-"} v${(_q = change.version) != null ? _q : "-"}/${(_r = stored == null ? void 0 : stored.version) != null ? _r : "-"}) \u2014 history, skip ${change.path}`
+            `CRDT catch-up: stale row (seq ${(_p = change.seq) != null ? _p : "-"}/${(_q = stored == null ? void 0 : stored.seq) != null ? _q : "-"} v${(_r = change.version) != null ? _r : "-"}/${(_s = stored == null ? void 0 : stored.version) != null ? _s : "-"}) \u2014 history, skip ${change.path}`
           );
         else if (change.content_hash && (stored == null ? void 0 : stored.serverHash) !== change.content_hash)
           if (this.isLiveBound(normalized)) {
@@ -20740,14 +20848,38 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
                 version: change.version,
                 seq: change.seq
               }), this.socketConverge(normalized, noteId), !1;
-            localNow !== null && (stored == null ? void 0 : stored.hash) !== void 0 && fnv1a(localNow) !== stored.hash && localNow !== content ? (rlog().warn(
-              "pull",
-              `CRDT catch-up: local+remote both diverged, routing to conflict flow ${change.path}`
-            ), crdtConflictFallthrough = !0) : noteId && (stored == null ? void 0 : stored.serverHash) === void 0 && localNow !== null && localNow === content ? (rlog().info(
+            if (localNow !== null && (stored == null ? void 0 : stored.hash) !== void 0 && fnv1a(localNow) !== stored.hash && localNow !== content && localNow !== null) {
+              rlog().warn(
+                "pull",
+                `CRDT catch-up: local+remote both diverged, drift-copy + converge ${change.path}`
+              );
+              let copy2 = null;
+              try {
+                copy2 = await this.writeDriftConflictCopy(normalized, localNow);
+              } catch (e) {
+                rlog().warn(
+                  "conflict",
+                  `drift-copy capture failed for ${normalized}: ${errMsg(e)}`
+                );
+              }
+              return copy2 === null ? (rlog().warn(
+                "conflict",
+                `drift-copy failed \u2014 leaving ${normalized} intact, deferring convergence to next catch-up`
+              ), !1) : (new import_obsidian21.Notice(
+                `Engram: sync conflict on ${normalized} \u2014 your local edit was saved as ${copy2}`
+              ), noteId && (this.pendingConvergence.set(noteId, {
+                path: normalized,
+                serverHash: change.content_hash,
+                content,
+                version: change.version,
+                seq: change.seq
+              }), this.socketConverge(normalized, noteId)), !1);
+            }
+            noteId && (stored == null ? void 0 : stored.serverHash) === void 0 && localNow !== null && localNow === content ? (rlog().info(
               "pull",
               `CRDT catch-up: no-CAS-base quiet record (disk==row) ${change.path}`
             ), this.syncState.set(normalized, {
-              ...(_s = this.syncState.get(normalized)) != null ? _s : {},
+              ...(_t2 = this.syncState.get(normalized)) != null ? _t2 : {},
               hash: fnv1a(content),
               version: change.version,
               serverHash: change.content_hash
@@ -20773,7 +20905,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         else
           rlog().info("pull", `CRDT-managed: re-enroll for catch-up ${change.path}`);
       }
-      if (!crdtConflictFallthrough) return !1;
+      return !1;
     }
     let existing = this.app.vault.getFileByPath(normalized);
     if (existing) {
@@ -20795,14 +20927,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           "conflict",
           `Detected: ${change.path} | firstSync=${firstSync} | localHash=${localHash} | syncedHash=${lastSyncedHash != null ? lastSyncedHash : "none"} | localMtime=${new Date(localMtime * 1e3).toISOString()} | remoteMtime=${new Date(change.mtime * 1e3).toISOString()} | localLen=${localContent.length} | remoteLen=${content.length}`
         );
-        let pullBase = (_t2 = this.baseStore) == null ? void 0 : _t2.get(normalized);
+        let pullBase = (_u = this.baseStore) == null ? void 0 : _u.get(normalized);
         if (pullBase) {
           let merge2 = threeWayMerge(pullBase.content, localContent, content);
           if (merge2.clean) {
             await this.modifyFile(existing, merge2.merged), this.syncState.set(normalized, {
               hash: fnv1a(merge2.merged),
               version: change.version
-            }), change.version != null && ((_u = this.baseStore) == null || _u.set(normalized, merge2.merged, change.version));
+            }), change.version != null && ((_v = this.baseStore) == null || _v.set(normalized, merge2.merged, change.version));
             try {
               await this.pushFile(existing, !0);
             } catch (e) {
@@ -20853,7 +20985,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             await this.createFileWithFolders(conflictPath, content), this.syncState.set((0, import_obsidian21.normalizePath)(conflictPath), {
               hash: fnv1a(content),
               version: change.version
-            }), change.version != null && ((_v = this.baseStore) == null || _v.set(
+            }), change.version != null && ((_w = this.baseStore) == null || _w.set(
               (0, import_obsidian21.normalizePath)(conflictPath),
               content,
               change.version
@@ -20875,7 +21007,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             await this.modifyFile(existing, resolution.mergedContent), this.syncState.set(normalized, {
               hash: fnv1a(resolution.mergedContent),
               version: change.version
-            }), change.version != null && ((_w = this.baseStore) == null || _w.set(
+            }), change.version != null && ((_x = this.baseStore) == null || _x.set(
               normalized,
               resolution.mergedContent,
               change.version
@@ -20901,15 +21033,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           // E1 (#1065): record the row's seq so the manifest validator can
           // integer-diff this path (a legacy change without one keeps the
           // prior value rather than erasing it).
-          seq: typeof change.seq == "number" ? change.seq : (_x = this.syncState.get(normalized)) == null ? void 0 : _x.seq
-        }), change.version != null && ((_y = this.baseStore) == null || _y.set(normalized, content, change.version)), rlog().info("pull", `Unchanged: ${change.path}`), !1;
+          seq: typeof change.seq == "number" ? change.seq : (_y = this.syncState.get(normalized)) == null ? void 0 : _y.seq
+        }), change.version != null && ((_z = this.baseStore) == null || _z.set(normalized, content, change.version)), rlog().info("pull", `Unchanged: ${change.path}`), !1;
       return devLog().log("pull", `applyChange OVERWRITE: ${change.path} (len=${content.length})`), await this.modifyFile(existing, content), this.syncState.set(normalized, {
         hash: fnv1a(content),
         version: change.version,
         serverHash: change.content_hash,
         // E1 (#1065): seq recorded for the manifest validator's integer diff.
-        seq: typeof change.seq == "number" ? change.seq : (_z = this.syncState.get(normalized)) == null ? void 0 : _z.seq
-      }), change.version != null && ((_A = this.baseStore) == null || _A.set(normalized, content, change.version)), rlog().info(
+        seq: typeof change.seq == "number" ? change.seq : (_A = this.syncState.get(normalized)) == null ? void 0 : _A.seq
+      }), change.version != null && ((_B = this.baseStore) == null || _B.set(normalized, content, change.version)), rlog().info(
         "pull",
         `Applied: ${change.path} | localLen=${localContent.length} | remoteLen=${content.length}`
       ), !0;
@@ -20930,7 +21062,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       serverHash: change.content_hash,
       // E1 (#1065): seq recorded for the manifest validator's integer diff.
       seq: typeof change.seq == "number" ? change.seq : void 0
-    }), change.version != null && ((_B = this.baseStore) == null || _B.set(normalized, content, change.version)), rlog().info("pull", `Created: ${change.path} | len=${content.length}`), !0;
+    }), change.version != null && ((_C = this.baseStore) == null || _C.set(normalized, content, change.version)), rlog().info("pull", `Created: ${change.path} | len=${content.length}`), !0;
   }
   /** Apply a remote attachment change to the vault.
    *  If contentBase64 is provided (from WebSocket), use it directly. Otherwise fetch it.
@@ -23189,6 +23321,14 @@ function createCrdtWiring(deps) {
     // is staged for this note_id), so fire-and-forget is safe here.
     onSynced: (noteId) => {
       syncEngine.commitCrdtConvergence(noteId);
+    },
+    // Doc shape from the note's path. `.canvas` → the structural nodes/edges
+    // schema; everything else → markdown. Resolved once per doc at creation.
+    // The path is always mapped before a doc is minted in the normal push/pull
+    // flows; an unmapped id (rare heal path) safely defaults to markdown.
+    docKind: (noteId) => {
+      var _a2;
+      return (_a2 = noteIdMap.pathForId(noteId)) != null && _a2.endsWith(".canvas") ? "canvas" : "note";
     }
   }), channel = new CrdtChannel({
     manager,

--- a/src/crdt/canvas-codec.ts
+++ b/src/crdt/canvas-codec.ts
@@ -1,0 +1,182 @@
+import type * as Y from "yjs";
+
+/**
+ * Structural CRDT codec for Obsidian `.canvas` files (JSON Canvas format).
+ *
+ * A canvas doc keeps its data in per-element Y.Maps keyed by the element's
+ * stable `id` — NOT in a body Y.Text like markdown. Stable ids are what let two
+ * devices edit different nodes concurrently and merge per-element, instead of
+ * char-diffing the JSON (which would corrupt it). Mirrors, structurally, the
+ * markdown frontmatter codec: `seedCanvasInto` == `seedContentInto`,
+ * `projectCanvas` == `projectNote`.
+ *
+ * Schema (Y.Doc shared types):
+ *   Y.Map   "nodes"        node id  -> node object
+ *   Y.Map   "edges"        edge id  -> edge object
+ *   Y.Array "nodes_order"  node id order (== array/z-index order on disk)
+ *   Y.Array "edges_order"  edge id order
+ *   Y.Map   "canvas_meta"  any top-level key other than nodes/edges (forward-compat)
+ *
+ * Per-node granularity is deliberate (spec 2026-07-23 decision #1): concurrent
+ * edits to DIFFERENT nodes both survive; concurrent edits to the SAME node are
+ * last-writer-wins on the whole node. Order arrays merge like frontmatter_order.
+ */
+
+export const NODES_KEY = "nodes";
+export const EDGES_KEY = "edges";
+export const NODES_ORDER_KEY = "nodes_order";
+export const EDGES_ORDER_KEY = "edges_order";
+export const CANVAS_META_KEY = "canvas_meta";
+
+export type CanvasElement = Record<string, unknown> & { id: string };
+
+interface ParsedCanvas {
+	nodes: CanvasElement[];
+	edges: CanvasElement[];
+	meta: Record<string, unknown>;
+}
+
+/**
+ * Parse a `.canvas` string into structured nodes/edges/meta, or `null` when it
+ * is not a mergeable canvas (not an object, nodes/edges not element arrays, or
+ * an element without a stable string `id`). `null` means "keep it opaque" — the
+ * caller falls back (drift-copy / REST), never a corrupting structural merge.
+ */
+export function parseCanvas(json: string): ParsedCanvas | null {
+	let data: unknown;
+	try {
+		data = JSON.parse(json);
+	} catch {
+		return null;
+	}
+	if (data === null || typeof data !== "object" || Array.isArray(data)) return null;
+
+	const obj = data as Record<string, unknown>;
+	const nodes = asElements(obj.nodes);
+	const edges = asElements(obj.edges);
+	if (nodes === null || edges === null) return null;
+
+	const meta: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(obj)) {
+		if (k !== NODES_KEY && k !== EDGES_KEY) meta[k] = v;
+	}
+	return { nodes, edges, meta };
+}
+
+// An absent nodes/edges key is a valid empty canvas; a present-but-non-array or
+// an element missing a string id is not mergeable.
+function asElements(v: unknown): CanvasElement[] | null {
+	if (v === undefined) return [];
+	if (!Array.isArray(v)) return null;
+	const out: CanvasElement[] = [];
+	for (const el of v) {
+		if (el === null || typeof el !== "object" || Array.isArray(el)) return null;
+		const id = (el as Record<string, unknown>).id;
+		if (typeof id !== "string") return null;
+		out.push(el as CanvasElement);
+	}
+	return out;
+}
+
+/**
+ * Save→reconcile: upsert changed nodes/edges by id, delete removed ids, replace
+ * the order arrays and canvas_meta — all in ONE transaction so a merge never
+ * observes a half-applied canvas. Returns `false` (doc untouched) when the input
+ * is not a mergeable canvas.
+ */
+export function seedCanvasInto(doc: Y.Doc, json: string): boolean {
+	const parsed = parseCanvas(json);
+	if (parsed === null) return false;
+
+	doc.transact(() => {
+		upsertElements(doc.getMap(NODES_KEY), doc.getArray<string>(NODES_ORDER_KEY), parsed.nodes);
+		upsertElements(doc.getMap(EDGES_KEY), doc.getArray<string>(EDGES_ORDER_KEY), parsed.edges);
+		upsertMeta(doc.getMap(CANVAS_META_KEY), parsed.meta);
+	});
+	return true;
+}
+
+function upsertElements(
+	map: Y.Map<CanvasElement>,
+	order: Y.Array<string>,
+	elements: CanvasElement[],
+): void {
+	const ids = new Set(elements.map((e) => e.id));
+	for (const el of elements) {
+		// Only write a changed element — an identical re-set would ship a needless
+		// Yjs op (and, on the same node, clobber a concurrent edit for no reason).
+		const cur = map.get(el.id);
+		if (cur === undefined || !jsonEqual(cur, el)) map.set(el.id, el);
+	}
+	for (const id of [...map.keys()]) {
+		if (!ids.has(id)) map.delete(id);
+	}
+	// Replace the order array wholesale (small list; mirrors applyFrontmatterInto).
+	if (order.length > 0) order.delete(0, order.length);
+	if (elements.length > 0)
+		order.insert(
+			0,
+			elements.map((e) => e.id),
+		);
+}
+
+function upsertMeta(map: Y.Map<unknown>, meta: Record<string, unknown>): void {
+	for (const [k, v] of Object.entries(meta)) {
+		if (!jsonEqual(map.get(k), v)) map.set(k, v);
+	}
+	for (const k of [...map.keys()]) {
+		if (!(k in meta)) map.delete(k);
+	}
+}
+
+/**
+ * Pull→project: rebuild the `.canvas` file from the Y.Maps. Serialized to match
+ * Obsidian (tab indent, nodes-before-edges). ponytail: the exact whitespace is a
+ * calibration knob, not correctness — the codec parses JSON structurally on the
+ * way IN, so a format mismatch produces no structural delta (no echo loop);
+ * matched here only so a pull writes a file Obsidian re-reads without reformat.
+ */
+export function projectCanvas(doc: Y.Doc): string {
+	const meta = doc.getMap<unknown>(CANVAS_META_KEY).toJSON();
+	const nodes = orderedElements(doc.getMap(NODES_KEY), doc.getArray<string>(NODES_ORDER_KEY));
+	const edges = orderedElements(doc.getMap(EDGES_KEY), doc.getArray<string>(EDGES_ORDER_KEY));
+	return JSON.stringify({ ...meta, nodes, edges }, null, "\t");
+}
+
+/** Elements in order-array order, then any map entries the order array missed
+ *  (a merge could add to the map and the order array separately) — so a node is
+ *  never silently dropped from disk. */
+function orderedElements(map: Y.Map<CanvasElement>, order: Y.Array<string>): CanvasElement[] {
+	const out: CanvasElement[] = [];
+	const seen = new Set<string>();
+	for (const id of order.toArray()) {
+		const el = map.get(id);
+		if (el !== undefined && !seen.has(id)) {
+			out.push(el);
+			seen.add(id);
+		}
+	}
+	for (const id of [...map.keys()].sort()) {
+		if (!seen.has(id)) out.push(map.get(id) as CanvasElement);
+	}
+	return out;
+}
+
+/** Read helpers (parallel to frontmatterOf) — used by the manager + tests. */
+export function nodesOf(doc: Y.Doc): CanvasElement[] {
+	return orderedElements(doc.getMap(NODES_KEY), doc.getArray<string>(NODES_ORDER_KEY));
+}
+
+export function edgesOf(doc: Y.Doc): CanvasElement[] {
+	return orderedElements(doc.getMap(EDGES_KEY), doc.getArray<string>(EDGES_ORDER_KEY));
+}
+
+/** True when the doc carries no canvas structure yet (fresh/unseeded). The
+ *  canvas analog of `text.length > 0` for the empty-genesis flush guard. */
+export function canvasIsEmpty(doc: Y.Doc): boolean {
+	return doc.getMap(NODES_KEY).size === 0 && doc.getMap(EDGES_KEY).size === 0;
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+	return JSON.stringify(a) === JSON.stringify(b);
+}

--- a/src/crdt/manager.ts
+++ b/src/crdt/manager.ts
@@ -2,7 +2,16 @@ import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 import { rlog } from "../remote-log";
 import { diffIntoYText, seedOnce } from "./bridge";
+import { canvasIsEmpty, projectCanvas, seedCanvasInto } from "./canvas-codec";
 import { parseFrontmatter, projectNote, splitFrontmatter } from "./frontmatter-codec";
+
+/**
+ * A note's CRDT doc shape. `"note"` = markdown (frontmatter Y.Map + body
+ * Y.Text). `"canvas"` = structural (nodes/edges Y.Maps — see canvas-codec).
+ * The manager learns a doc's kind once, at first `entry()`, via the `docKind`
+ * option, and branches its seed + disk-projection on it.
+ */
+export type DocKind = "note" | "canvas";
 
 /**
  * Transaction origin stamped on remotely-applied updates. Updates carrying
@@ -121,11 +130,22 @@ export interface CrdtManagerOptions {
 	 * side is idempotent (no-op when nothing is staged), so this is cheap.
 	 */
 	onSynced?: (noteId: string) => void;
+	/**
+	 * Resolve a note's doc shape (markdown vs canvas) from its id. Called ONCE
+	 * per doc, when `entry()` first mints it, and cached on the entry. sync.ts
+	 * wires this from the note's path (`.canvas` → "canvas"). Absent/unknown →
+	 * "note" (markdown), the safe default that keeps every existing caller and
+	 * test unchanged.
+	 */
+	docKind?: (noteId: string) => DocKind;
 }
 
 interface Entry {
 	doc: Y.Doc;
 	persistence: IndexeddbPersistence;
+	/** This doc's shape, resolved once at creation via `opts.docKind`. Selects
+	 *  the seed codec (markdown vs canvas) and the disk projection. */
+	kind: DocKind;
 	text: Y.Text;
 	/** Resolves once IndexeddbPersistence has replayed stored updates. */
 	ready: Promise<void>;
@@ -397,18 +417,28 @@ export class CrdtManager {
 			}
 		}
 
-		const lca = hasLca ?? this.textHasHistory(e.text);
+		const lca =
+			hasLca ?? (e.kind === "canvas" ? !canvasIsEmpty(e.doc) : this.textHasHistory(e.text));
 
 		// Adopt-first seed gate (#161): a history-less doc whose disk content is
 		// byte-identical to the last-synced content has nothing local to
 		// preserve — seeding it would re-encode server-known content on this
-		// client's lineage (the #846 doubling). Leave the doc empty (body AND
-		// frontmatter) and let the first STEP2 populate it on the server's
-		// lineage; later real edits diff in on that shared history. Returns
-		// `true` ("handled, nothing to push") — a legacy fallback here would
-		// mass re-push every known-synced file on a fresh-IDB cold start.
+		// client's lineage (the #846 doubling). Leave the doc empty and let the
+		// first STEP2 populate it on the server's lineage; later real edits diff in
+		// on that shared history. Returns `content` ("handled, nothing to push") —
+		// a legacy fallback here would mass re-push every known-synced file on a
+		// fresh-IDB cold start.
 		if (!lca && this.opts.isUnchangedSynced?.(noteId, content)) {
 			return content;
+		}
+
+		if (e.kind === "canvas") {
+			// Structural docs are immune to the #846 second-lineage doubling (Y.Map
+			// keyed by id merges LWW-per-element, never appends), so the seedOnce
+			// gate the markdown body needs is unnecessary — the codec's upsert is
+			// idempotent and merge-safe. Malformed canvas → NOT consumed (null): the
+			// caller's drift-copy / legacy fallback owns it, never a corrupt merge.
+			return seedCanvasInto(e.doc, content) ? content : null;
 		}
 
 		this.seedContentInto(e.doc, e.text, content, lca);
@@ -453,10 +483,11 @@ export class CrdtManager {
 	 * doubling (#846) — the real doc adopts the server lineage on its first
 	 * handshake.
 	 */
-	encodeGenesisUpdate(content: string): Uint8Array {
+	encodeGenesisUpdate(content: string, kind: DocKind = "note"): Uint8Array {
 		const doc = new Y.Doc();
 		try {
-			this.seedContentInto(doc, doc.getText(CONTENT_KEY), content, false);
+			if (kind === "canvas") seedCanvasInto(doc, content);
+			else this.seedContentInto(doc, doc.getText(CONTENT_KEY), content, false);
 			return Y.encodeStateAsUpdate(doc);
 		} finally {
 			doc.destroy();
@@ -553,12 +584,15 @@ export class CrdtManager {
 	 * transiently-empty in-memory doc.
 	 */
 	async hasHistory(noteId: string): Promise<boolean> {
-		return this.textHasHistory((await this.entry(noteId)).text);
+		const e = await this.entry(noteId);
+		return e.kind === "canvas" ? !canvasIsEmpty(e.doc) : this.textHasHistory(e.text);
 	}
 
-	/** Full reconstructed file (frontmatter fence + body) as it would be written to disk. */
+	/** Full reconstructed file as it would be written to disk: a markdown file
+	 *  (frontmatter fence + body) or a canvas JSON document. */
 	async projectedText(noteId: string): Promise<string> {
 		const e = await this.entry(noteId);
+		if (e.kind === "canvas") return projectCanvas(e.doc);
 		const { order, values } = frontmatterOf(e.doc);
 		return projectNote(order, values, e.text.toJSON(), rawFrontmatterOf(e.doc));
 	}
@@ -677,6 +711,12 @@ export class CrdtManager {
 	 */
 	async flattenIfBloated(noteId: string): Promise<boolean> {
 		const e = await this.entry(noteId);
+		// ponytail: no structural flatten for canvas yet. This path reseeds via the
+		// markdown frontmatter+body codec, which would wipe the nodes/edges maps.
+		// A canvas that crosses the bloat threshold keeps its full state vector;
+		// add a nodes/edges-preserving flatten in Phase 2 if a real board hits it
+		// (mirrors the backend do_structural_checkpoint no-flatten decision).
+		if (e.kind === "canvas") return false;
 		const encoded = Y.encodeStateAsUpdate(e.doc);
 		const clientIds = Y.decodeStateVector(Y.encodeStateVector(e.doc)).size;
 
@@ -802,10 +842,25 @@ export class CrdtManager {
 		// CrdtManagerOptions.dbPrefix) — but `id` (bare, no prefix) is still what
 		// goes on the wire and keys the in-memory `docs` map.
 		const persistence = new IndexeddbPersistence(this.storeName(noteId), doc);
+		const kind = this.opts.docKind?.(noteId) ?? "note";
+		// Markdown body Y.Text. For a canvas doc this stays permanently empty (its
+		// data lives in the nodes/edges Y.Maps); it exists only so the many
+		// markdown code paths that read `entry.text` never see undefined.
 		const text = doc.getText(CONTENT_KEY);
 		const ready: Promise<void> = persistence.whenSynced.then(() => undefined);
+		// `hasContent` differs by shape: markdown = body Y.Text non-empty; canvas =
+		// nodes/edges maps non-empty. Gates the empty-genesis flush guard (#288).
+		const hasContent = () => (kind === "canvas" ? !canvasIsEmpty(doc) : text.length > 0);
 		// Created BEFORE the listeners below so they can tick entry.remoteSeq.
-		const entry: Entry = { doc, persistence, text, ready, remoteSeq: 0, hadContent: false };
+		const entry: Entry = {
+			doc,
+			persistence,
+			kind,
+			text,
+			ready,
+			remoteSeq: 0,
+			hadContent: false,
+		};
 
 		// Surface IndexedDB quota / storage errors via onPersistError instead of
 		// throwing into the sync loop. On iOS WKWebView the per-origin quota is
@@ -815,7 +870,7 @@ export class CrdtManager {
 
 		// Local-edit path: forward update to the channel; skip remote-origin updates.
 		doc.on("update", (update: Uint8Array, origin: unknown) => {
-			if (text.length > 0) entry.hadContent = true; // also covers IDB-replay updates
+			if (hasContent()) entry.hadContent = true; // also covers IDB-replay updates
 			if (origin === REMOTE_ORIGIN) return;
 			if (this.opts.canSendLive && !this.opts.canSendLive(id)) return; // HOLD: not create-acked
 			this.opts.onUpdate(id, update, origin);
@@ -825,34 +880,40 @@ export class CrdtManager {
 		// Reconstruct the full file (frontmatter fence + body) from the Y.Map/Y.Array
 		// and body Y.Text so disk always gets a complete, valid markdown file.
 		doc.on("update", (_u: Uint8Array, origin: unknown) => {
-			if (text.length > 0) entry.hadContent = true;
+			if (hasContent()) entry.hadContent = true;
 			if (origin !== REMOTE_ORIGIN) return;
 			entry.remoteSeq += 1;
-			const { order, values } = frontmatterOf(doc);
-			const raws = rawFrontmatterOf(doc);
-			const body = text.toJSON();
 			// Guard A (#288, e2e test_39): an unseeded genesis (structure ops only,
-			// body never held content) must NOT flush empty over the creator's
+			// content never held) must NOT flush empty over the creator's
 			// just-written file — the wipe echo-skips on the empty hash and locks
 			// in on both devices. Invariant (crdt-editor-bind-race-pollution.md,
 			// #257 bind-path analog): empty + never-seeded is NEVER a legitimate
 			// empty; a genuine remote delete-all had content first (hadContent
 			// true) and still flushes below. Genuinely empty notes materialize via
 			// sync.ts materializeEmptyDiscovered → flushFromCrdt, not this listener.
-			if (body.length === 0 && !entry.hadContent) {
+			if (!hasContent() && !entry.hadContent) {
 				rlog().warn(
 					"crdt",
-					`remote-merge flush SKIPPED for ${noteId}: empty body on never-seeded doc (#288 genesis guard)`,
+					`remote-merge flush SKIPPED for ${noteId}: empty ${kind} on never-seeded doc (#288 genesis guard)`,
 				);
 				return;
 			}
+			// Reconstruct the full on-disk file from the doc's shared types: a
+			// markdown file (frontmatter fence + body) or a canvas JSON document.
+			const projected =
+				kind === "canvas"
+					? projectCanvas(doc)
+					: projectNote(
+							frontmatterOf(doc).order,
+							frontmatterOf(doc).values,
+							text.toJSON(),
+							rawFrontmatterOf(doc),
+						);
 			// Record the flush promise (do NOT fire-and-forget): applyRemoteUpdate
 			// awaits it so a write failure rejects the apply and the caller leaves
 			// crdtHead unadvanced (#235). Promise.resolve() normalizes a sync/void
 			// return from a test double into an awaitable.
-			const flush = Promise.resolve(
-				this.opts.onFlushToDisk(noteId, projectNote(order, values, body, raws)),
-			);
+			const flush = Promise.resolve(this.opts.onFlushToDisk(noteId, projected));
 			this.pendingFlush.set(id, flush);
 			// Room-path updates (crdt/channel readSyncMessage applies straight to
 			// the doc) never consume this entry the way applyRemoteUpdate does —
@@ -869,9 +930,9 @@ export class CrdtManager {
 
 		this.docs.set(id, entry);
 		await ready;
-		// IDB hydration replayed stored updates above; a rehydrated non-empty body
+		// IDB hydration replayed stored updates above; rehydrated non-empty content
 		// counts as "has held content" (#288) even if no listener observed it.
-		if (text.length > 0) entry.hadContent = true;
+		if (hasContent()) entry.hadContent = true;
 		return entry;
 	}
 

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -287,6 +287,11 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		// inbound frame; commitCrdtConvergence is idempotent (no-op when nothing
 		// is staged for this note_id), so fire-and-forget is safe here.
 		onSynced: (noteId) => void syncEngine.commitCrdtConvergence(noteId),
+		// Doc shape from the note's path. `.canvas` → the structural nodes/edges
+		// schema; everything else → markdown. Resolved once per doc at creation.
+		// The path is always mapped before a doc is minted in the normal push/pull
+		// flows; an unmapped id (rare heal path) safely defaults to markdown.
+		docKind: (noteId) => (noteIdMap.pathForId(noteId)?.endsWith(".canvas") ? "canvas" : "note"),
 	});
 
 	const channel = new CrdtChannel({

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -6551,7 +6551,10 @@ export class SyncEngine {
 				else failed++;
 				continue;
 			}
-			const b64 = this.encodeGenesisFrame(content, file.extension === "canvas" ? "canvas" : "note");
+			const b64 = this.encodeGenesisFrame(
+				content,
+				file.extension === "canvas" ? "canvas" : "note",
+			);
 			const size = b64.length;
 			// #245: snapshot the path now — TFile.path is live and a mid-request
 			// rename would otherwise desync result matching + the pushing set.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5,7 +5,7 @@ import { type App, Notice, type TAbstractFile, TFile, TFolder, normalizePath } f
 import { type EngramApi, arrayBufferToBase64, base64ToArrayBuffer } from "./api";
 import type { BaseStore } from "./base-store";
 import { encodeUpdateFrame } from "./crdt/channel";
-import type { CrdtManager } from "./crdt/manager";
+import type { CrdtManager, DocKind } from "./crdt/manager";
 import type { NoteIdMap } from "./crdt/note-id-map";
 import { uuid7 } from "./crdt/uuid7";
 import { devLog } from "./dev-log";
@@ -6356,8 +6356,12 @@ export class SyncEngine {
 	 *  wrap (`encodeUpdateFrame`), so the frame the server applies via
 	 *  SharedDoc.send_yjs_message is byte-identical to what a live `crdt_msg`
 	 *  would deliver — a divergent encoding would corrupt content on merge. */
-	private encodeGenesisFrame(content: string): string {
-		return encodeUpdateFrame(this.crdt!.encodeGenesisUpdate(content));
+	private encodeGenesisFrame(content: string, kind: DocKind = "note"): string {
+		// Thread the doc kind: this is the ONE encode site that bypasses the
+		// manager's docKind (a throwaway doc, no entry()), so a canvas batch-genesis
+		// must be told to seed structurally — else it stuffs canvas JSON into the
+		// markdown body Y.Text and every peer projects an empty {nodes,edges} (#306).
+		return encodeUpdateFrame(this.crdt!.encodeGenesisUpdate(content, kind));
 	}
 
 	/** Record local state after a genesis note's server row is created (batch
@@ -6547,7 +6551,7 @@ export class SyncEngine {
 				else failed++;
 				continue;
 			}
-			const b64 = this.encodeGenesisFrame(content);
+			const b64 = this.encodeGenesisFrame(content, file.extension === "canvas" ? "canvas" : "note");
 			const size = b64.length;
 			// #245: snapshot the path now — TFile.path is live and a mid-request
 			// rename would otherwise desync result matching + the pushing set.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -838,7 +838,7 @@ export class SyncEngine {
 	): void {
 		if (!noteId || !this.crdtEnrollment) return;
 		if (this.isNoteConfirmed(noteId)) return; // not a create — already live
-		if (!path.endsWith(".md")) return;
+		if (!this.isCrdtEligiblePath(path)) return;
 		if (exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)) return;
 		// Vault-channel fan-out: a cold (not-open-in-editor) send stays room-free —
 		// its edits ship over /updates and it RECEIVES future updates over the
@@ -1381,7 +1381,11 @@ export class SyncEngine {
 		// identical path, and createFileWithFolders degrades that collision to an
 		// in-place modify — silently clobbering the first preserved copy.
 		const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-		const conflictPath = `${normalized.replace(/\.md$/, "")} (conflict ${stamp}).md`;
+		// Preserve the note's own extension (.md or .canvas) so a canvas drift copy
+		// stays a canvas file, not a stray .md.
+		const ext = normalized.endsWith(".canvas") ? "canvas" : "md";
+		const base = normalized.replace(/\.(md|canvas)$/, "");
+		const conflictPath = `${base} (conflict ${stamp}).${ext}`;
 		await this.createFileWithFolders(conflictPath, localDisk);
 		this.syncState.set(normalizePath(conflictPath), { hash: fnv1a(localDisk) });
 		return conflictPath;
@@ -1414,7 +1418,7 @@ export class SyncEngine {
 			);
 			return;
 		}
-		if (!path.endsWith(".md")) return;
+		if (!this.isCrdtEligiblePath(path)) return;
 		const normalized = normalizePath(path);
 		// Already on disk — a content STEP2 created it, or the user already has it.
 		if (this.app.vault.getAbstractFileByPath(normalized)) return;
@@ -1449,7 +1453,7 @@ export class SyncEngine {
 	 *  the MOVE case only; a tombstone delete clears the byId entry (canonical
 	 *  null), where the isSynced gate is the backstop. */
 	private async materializeRelocated(path: string, noteId: string): Promise<void> {
-		if (!this.crdt || !path.endsWith(".md")) return;
+		if (!this.crdt || !this.isCrdtEligiblePath(path)) return;
 		// Defensive `typeof` (not `?.`) — CrdtManager always has isSynced, but many
 		// existing unit tests wire a partial `{ applyLocalEdit } as any` stand-in
 		// that doesn't, and a missing method must read as "not synced" rather than
@@ -1925,6 +1929,20 @@ export class SyncEngine {
 	 *  types are NOT eligible and stay on the REST/attachment path. */
 	isCrdtEligible(file: TAbstractFile): boolean {
 		return file instanceof TFile && (file.extension === "md" || file.extension === "canvas");
+	}
+
+	/** Path-string variant of isCrdtEligible for the pull/apply path, which works
+	 *  with normalized paths (from a NoteChange), not TFile handles. */
+	isCrdtEligiblePath(path: string): boolean {
+		return path.endsWith(".md") || path.endsWith(".canvas");
+	}
+
+	/** True for a canvas note path. Canvas is CRDT but STRUCTURAL: its authoritative
+	 *  content lives in the Yjs doc, never notes.content (which the backend keeps
+	 *  vestigial for canvas), so the pull path must converge it over the Yjs
+	 *  handshake, never by writing the seq-feed `content`. */
+	private isCanvasPath(path: string): boolean {
+		return path.endsWith(".canvas");
 	}
 
 	/** Check if a file should be synced (markdown, canvas, or binary attachment). */
@@ -4470,7 +4488,7 @@ export class SyncEngine {
 			// Keyed by the DELETE's target id (the recreate case returned above, so
 			// here targetId == currentId or one is null): clear the path mapping and
 			// tear down the room for that id.
-			if (normalized.endsWith(".md")) {
+			if (this.isCrdtEligiblePath(normalized)) {
 				this.noteIdMap?.delete(normalized);
 				const roomId = targetId ?? currentId;
 				if (roomId) {
@@ -4500,7 +4518,7 @@ export class SyncEngine {
 					);
 				} else if (
 					this.crdt &&
-					event.path.endsWith(".md") &&
+					this.isCrdtEligiblePath(event.path) &&
 					(event.id ?? this.noteIdMap?.get(event.path))
 				) {
 					// C1: CRDT owns markdown content for this session — the crdt: topic
@@ -4546,7 +4564,13 @@ export class SyncEngine {
 					} else {
 						this.noteIdMap?.set(event.path, noteId);
 						this.confirmNoteId(noteId);
-						if (this.isLiveBound(normalizePath(event.path))) {
+						// Canvas enrolls even when idle — it converges over the Yjs
+						// handshake ONLY (no seq-feed content fallback), so a room is the
+						// sole way to pull its state; markdown stays idle-room-free (fan-out).
+						if (
+							this.isCanvasPath(normalizePath(event.path)) ||
+							this.isLiveBound(normalizePath(event.path))
+						) {
 							this.crdtEnrollment?.enroll(noteId);
 						}
 						// SEED the CAS base from the event when none exists — the CRDT
@@ -5275,7 +5299,7 @@ export class SyncEngine {
 				// (crdtNoteId null) or attachment is a no-op, so the non-CRDT trash
 				// path is unchanged. Clears the map too (idempotent with
 				// applySyncChange's deferred clear).
-				if (crdtNoteId && normalized.endsWith(".md")) {
+				if (crdtNoteId && this.isCrdtEligiblePath(normalized)) {
 					this.noteIdMap?.delete(normalized);
 					await this.crdt?.removeDoc(crdtNoteId);
 					this.crdtEnrollment?.reset(crdtNoteId);
@@ -5298,7 +5322,7 @@ export class SyncEngine {
 		// /notes/changes path, or a note discovered without ever learning an
 		// id — src/sync.ts's discovery branch a few lines down never calls
 		// noteIdMap.set).
-		const crdtOwnsBody = !!(this.crdt && normalized.endsWith(".md"));
+		const crdtOwnsBody = !!(this.crdt && this.isCrdtEligiblePath(normalized));
 		const noteId = this.noteIdMap?.get(normalized) ?? null;
 
 		// Anti-stale guard (review 2026-07-15, data-loss race): a push landing
@@ -5347,6 +5371,22 @@ export class SyncEngine {
 		// the block falls through to the legacy conflict flow below instead of
 		// silently backfilling over the local edit.
 		if (crdtOwnsBody) {
+			// Canvas converges via the Yjs handshake ONLY. Its authoritative content
+			// lives in the Yjs doc; the seq-feed `content` is vestigial for canvas
+			// (the backend keeps notes.content stale, Phase B, and its deliver-out +
+			// fan-out are .md-gated), so we must NEVER write `content` to disk here —
+			// that would stamp an empty/stale canvas over the real one. Enroll to pull
+			// the state over STEP1/STEP2 (the manager projects it via projectCanvas);
+			// a migrated REST-era canvas with no server Yjs state is seeded by the
+			// first client that opens it (the push path). Unlike markdown, canvas
+			// enrolls even when idle — it has no content-fallback delivery — but the
+			// room is released after convergence, and later live deltas ride the
+			// note_yjs_update fan-out room-free, so this is not an enrollment storm.
+			if (this.isCanvasPath(normalized)) {
+				if (noteId) this.crdtEnrollment?.enroll(noteId);
+				rlog().info("pull", `CRDT canvas: enroll for Yjs convergence ${change.path}`);
+				return false;
+			}
 			// noteId resolved above (shared with the anti-stale guard). This is
 			// populated for the merged-feed caller (applySyncChange learns `id`
 			// right before calling applyChange) but may be unknown for the
@@ -5687,10 +5727,11 @@ export class SyncEngine {
 					rlog().info("pull", `CRDT-managed: re-enroll for catch-up ${change.path}`);
 				}
 			}
-			// CRDT-managed markdown never falls through to the legacy conflict
-			// tail: the double-divergence case is handled inline above by the
-			// drift-copy (#306 Phase A). The tail below serves canvas + other
-			// non-CRDT notes only.
+			// A CRDT-managed note (markdown OR canvas since #306) never falls through
+			// to the legacy conflict tail: markdown double-divergence is handled inline
+			// by the drift-copy (#306 Phase A), and canvas converges over the Yjs
+			// handshake in the early branch above. The tail below serves only the
+			// legacy/oversized REST notes that remain outside the CRDT domain.
 			return false;
 		}
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -78,7 +78,7 @@ export function exceedsCrdtNoteLimit(content: string, maxBytes: number): boolean
 }
 
 export async function routeModify(
-	file: { isMarkdown: boolean; noteId: string; readContent: () => Promise<string> },
+	file: { crdtEligible: boolean; noteId: string; readContent: () => Promise<string> },
 	crdt: {
 		applyLocalEdit: (
 			noteId: string,
@@ -89,7 +89,10 @@ export async function routeModify(
 	},
 	maxBytes: number,
 ): Promise<string | null> {
-	if (!file.isMarkdown) return null;
+	// CRDT-eligible = markdown OR canvas (both ride the Yjs transport). The
+	// manager's docKind selects the schema (body Y.Text vs nodes/edges Y.Maps);
+	// this gate just keeps binary/attachment types off the CRDT path.
+	if (!file.crdtEligible) return null;
 	const content = await file.readContent();
 	// Oversized notes must NOT enter the Yjs doc. The channel transmits each
 	// update as a base64 crdt_msg (~+33%), so a multi-MB note becomes a
@@ -1007,11 +1010,11 @@ export class SyncEngine {
 		// Seed the body from disk under the effective id (mirrors the live genesis
 		// non-live-bound seed at sync.ts:2444). Cap-gated inside routeModify.
 		const file = this.crdt ? this.app.vault.getAbstractFileByPath(normalized) : null;
-		if (this.crdt && file instanceof TFile && this.isMarkdown(file)) {
+		if (this.crdt && file instanceof TFile && this.isCrdtEligible(file)) {
 			try {
 				const consumed = await routeModify(
 					{
-						isMarkdown: true,
+						crdtEligible: true,
 						noteId: effectiveId,
 						readContent: () => this.app.vault.cachedRead(file),
 					},
@@ -1917,6 +1920,13 @@ export class SyncEngine {
 		return file instanceof TFile && file.extension === "md";
 	}
 
+	/** CRDT-eligible = markdown OR canvas: both sync over the Yjs transport
+	 *  (the manager's docKind picks the per-type schema). Binary/attachment
+	 *  types are NOT eligible and stay on the REST/attachment path. */
+	isCrdtEligible(file: TAbstractFile): boolean {
+		return file instanceof TFile && (file.extension === "md" || file.extension === "canvas");
+	}
+
 	/** Check if a file should be synced (markdown, canvas, or binary attachment). */
 	isSyncable(file: TAbstractFile): file is TFile {
 		if (!(file instanceof TFile)) return false;
@@ -1965,7 +1975,7 @@ export class SyncEngine {
 		// — e.g. editing a note the moment after it was discovered/flushed — would
 		// be wrongly dropped here and never reach the CRDT path. So only apply the
 		// guard off the CRDT path (legacy writes, attachments).
-		const crdtManaged = !!this.crdt && this.isMarkdown(file);
+		const crdtManaged = !!this.crdt && this.isCrdtEligible(file);
 		if (!crdtManaged && this.recentlyFlushed.has(file.path)) {
 			rlog().info("sync", `Modify echo skip (recently flushed from CRDT): ${file.path}`);
 			return;
@@ -2463,7 +2473,7 @@ export class SyncEngine {
 				// the server already holds (crdtHead != null) routes over CRDT ops; a
 				// never-server-known note takes the genesis crdt_create path below.
 				// `confirmed` is a legacy diagnostic; it no longer drives routing.
-				if (file.extension === "md") {
+				if (this.isCrdtEligible(file)) {
 					rlog().info(
 						"push",
 						`route: ${file.path} crdt=${!!this.crdt} server=${this.hasServerNote(noteId)} confirmed=${noteId ? this.isNoteConfirmed(noteId) : false} live=${this.crdtLive?.() ?? true} id=${noteId ?? "none"}`,
@@ -2498,7 +2508,7 @@ export class SyncEngine {
 				if (this.crdt && noteId && this.hasServerNote(noteId)) {
 					const consumed = await routeModify(
 						{
-							isMarkdown: file.extension === "md",
+							crdtEligible: this.isCrdtEligible(file),
 							noteId,
 							// A LIVE read, not the frozen `content` above: routeModify
 							// forwards this as the manager's stale-snapshot reread, and a
@@ -2584,7 +2594,7 @@ export class SyncEngine {
 					// ponytail: no immediate delivery on decline (the old REST fallback is
 					// gone); acceptable because the gate makes this path unreachable.
 					if (
-						file.extension === "md" &&
+						this.isCrdtEligible(file) &&
 						!exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES) &&
 						this.isLiveBound(normalizePath(file.path))
 					) {
@@ -2611,7 +2621,7 @@ export class SyncEngine {
 					this.crdtCreate &&
 					this.crdt &&
 					noteId &&
-					file.extension === "md" &&
+					this.isCrdtEligible(file) &&
 					!this.hasServerNote(noteId) &&
 					(this.crdtLive?.() ?? true) &&
 					!exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)
@@ -2698,7 +2708,7 @@ export class SyncEngine {
 								// stale-snapshot guard.
 								consumed = await routeModify(
 									{
-										isMarkdown: true,
+										crdtEligible: true,
 										noteId: effectiveId,
 										readContent: () => this.app.vault.cachedRead(file),
 									},
@@ -2797,7 +2807,7 @@ export class SyncEngine {
 				// re-pushes over CRDT on reconnect. LWW (no version/base_hash → no
 				// 409/conflict surface); the server may still sanitize the path.
 				if (
-					file.extension === "md" &&
+					this.isCrdtEligible(file) &&
 					!exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)
 				) {
 					// The CRDT create branch above was skipped (crdt: topic not joined

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2063,7 +2063,7 @@ export class SyncEngine {
 		if (this.remotelyDeleted.has(file.path)) {
 			this.remotelyDeleted.delete(file.path);
 			rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`);
-			if (file.path.endsWith(".md") && crdtNoteId) {
+			if (this.isCrdtEligible(file) && crdtNoteId) {
 				await this.crdt?.removeDoc(crdtNoteId);
 				this.crdtEnrollment?.reset(crdtNoteId);
 			}
@@ -2074,29 +2074,32 @@ export class SyncEngine {
 			if (isBinary) {
 				await this.api.deleteAttachment(file.path); // attachments stay REST
 				this.goOnline();
-			} else if (file.path.endsWith(".md")) {
-				// CRDT-sole md delete path (REST removed). With a resolvable note_id,
-				// enqueue a durable crdt_delete: the queue holds it until the crdt:
-				// topic is joined and retries transient failures. Enqueue never throws,
-				// so the CRDT teardown below always runs, and there is no goOnline()
-				// here — a local durable hand-off, not a network round-trip. With NO
-				// note_id the note was never synced remotely, so there is nothing to
-				// delete on the server: do nothing rather than fall back to REST.
+			} else if (this.isCrdtEligible(file)) {
+				// CRDT-sole delete path (markdown AND canvas since #306; REST removed).
+				// With a resolvable note_id, enqueue a durable crdt_delete: the queue
+				// holds it until the crdt: topic is joined and retries transient
+				// failures. Enqueue never throws, so the CRDT teardown below always
+				// runs, and there is no goOnline() here — a local durable hand-off, not
+				// a network round-trip. With NO note_id the note was never synced
+				// remotely, so there is nothing to delete on the server: do nothing
+				// rather than fall back to REST.
 				if (crdtNoteId) {
 					this.crdtEnqueue?.({ kind: "delete", docId: crdtNoteId, path: file.path });
 				}
 			} else {
-				// Canvas / other non-md syncable text is not CRDT-managed — still LWW
-				// REST (outside the CRDT-only md collapse).
+				// Defensive fallback: no non-binary syncable type is CRDT-ineligible
+				// today (md + canvas both ride CRDT), so this is unreachable for
+				// current syncable text — kept only so a future REST-only note type
+				// still deletes cleanly.
 				await this.api.deleteNote(file.path);
 				this.goOnline();
 			}
 			// Tear down the CRDT doc so a note recreated at the same path starts
 			// fresh — no ghost lineage that would resurrect stale content (P1-3).
-			// Gate on .md (not !isBinary) so .canvas files never hit removeDoc:
-			// canvas files are syncable text but not CRDT-managed. Also gate on a
-			// known id — nothing to tear down if this note never had a CRDT room.
-			if (file.path.endsWith(".md") && crdtNoteId) {
+			// Gate on CRDT-eligibility (md OR canvas since #306, not !isBinary) so
+			// attachments never hit removeDoc. Also gate on a known id — nothing to
+			// tear down if this note never had a CRDT room.
+			if (this.isCrdtEligible(file) && crdtNoteId) {
 				await this.crdt?.removeDoc(crdtNoteId);
 				this.crdtEnrollment?.reset(crdtNoteId);
 			}
@@ -2104,7 +2107,7 @@ export class SyncEngine {
 			// 404 means already deleted — treat as success; still tear down CRDT.
 			if (isHttpStatus(e, 404)) {
 				this.goOnline();
-				if (file.path.endsWith(".md") && crdtNoteId) {
+				if (this.isCrdtEligible(file) && crdtNoteId) {
 					await this.crdt?.removeDoc(crdtNoteId);
 					this.crdtEnrollment?.reset(crdtNoteId);
 				}
@@ -2147,8 +2150,10 @@ export class SyncEngine {
 				if (isBinary) {
 					await this.api.deleteAttachment(oldPath);
 					this.goOnline();
-				} else if (oldPath.endsWith(".md")) {
-					// Phase E2 (rename-as-move): NO tombstone. The pushFile below
+				} else if (this.isCrdtEligible(file)) {
+					// Phase E2 (rename-as-move): NO tombstone (markdown AND canvas since
+					// #306 — a rename keeps the extension, so gating on the new file's
+					// eligibility is equivalent to the old path's). The pushFile below
 					// sends `crdt_create` for the SAME id at the new path and the
 					// backend relocates the live row in place
 					// (genesis_relocate_live -> move_note, :announce_moved fan-out);
@@ -2159,7 +2164,8 @@ export class SyncEngine {
 					// recreate-after-delete, and the delete+create pair could
 					// coalesce on the docId-keyed CrdtOpQueue (the test_10 class).
 				} else {
-					// Canvas / other non-md syncable text stays LWW REST (not CRDT-managed).
+					// Defensive fallback (unreachable for current syncable text — md +
+					// canvas both rename-as-move above; kept for a future REST-only type).
 					await this.api.deleteNote(oldPath);
 					this.goOnline();
 				}

--- a/tests/crdt/canvas-codec.test.ts
+++ b/tests/crdt/canvas-codec.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import * as Y from "yjs";
+import { edgesOf, nodesOf, projectCanvas, seedCanvasInto } from "../../src/crdt/canvas-codec";
+
+// A minimal but realistic Obsidian .canvas document. Nodes/edges are keyed by a
+// stable `id`; that stability is what lets concurrent edits merge per-element
+// instead of char-diffing JSON (which would corrupt it).
+const CANVAS = JSON.stringify({
+	nodes: [
+		{ id: "n1", type: "text", text: "hello", x: 0, y: 0, width: 100, height: 60 },
+		{ id: "n2", type: "text", text: "world", x: 200, y: 0, width: 100, height: 60 },
+	],
+	edges: [{ id: "e1", fromNode: "n1", fromSide: "right", toNode: "n2", toSide: "left" }],
+});
+
+describe("canvas-codec", () => {
+	test("seed + project round-trips the canvas data (structural identity)", () => {
+		const doc = new Y.Doc();
+		expect(seedCanvasInto(doc, CANVAS)).toBe(true);
+
+		// Data identity — whitespace may differ, the parsed structure must not.
+		expect(JSON.parse(projectCanvas(doc))).toEqual(JSON.parse(CANVAS));
+		// Nodes are keyed structurally, order preserved.
+		expect(nodesOf(doc).map((n) => n.id)).toEqual(["n1", "n2"]);
+		expect(edgesOf(doc).map((e) => e.id)).toEqual(["e1"]);
+	});
+
+	test("project is idempotent (project∘seed∘project == project)", () => {
+		const doc = new Y.Doc();
+		seedCanvasInto(doc, CANVAS);
+		const once = projectCanvas(doc);
+		const doc2 = new Y.Doc();
+		seedCanvasInto(doc2, once);
+		expect(projectCanvas(doc2)).toBe(once);
+	});
+
+	test("concurrent per-element edits both survive (the whole point of structural)", () => {
+		const a = new Y.Doc();
+		seedCanvasInto(a, CANVAS);
+
+		// b starts from a's state (shared history), then each edits independently.
+		const b = new Y.Doc();
+		Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+
+		// a moves n1; b recolors n2 and adds n3 — disjoint elements.
+		seedCanvasInto(
+			a,
+			JSON.stringify({
+				nodes: [
+					{
+						id: "n1",
+						type: "text",
+						text: "hello",
+						x: 999,
+						y: 999,
+						width: 100,
+						height: 60,
+					},
+					{ id: "n2", type: "text", text: "world", x: 200, y: 0, width: 100, height: 60 },
+				],
+				edges: [
+					{ id: "e1", fromNode: "n1", fromSide: "right", toNode: "n2", toSide: "left" },
+				],
+			}),
+		);
+		seedCanvasInto(
+			b,
+			JSON.stringify({
+				nodes: [
+					{ id: "n1", type: "text", text: "hello", x: 0, y: 0, width: 100, height: 60 },
+					{
+						id: "n2",
+						type: "text",
+						text: "world",
+						x: 200,
+						y: 0,
+						width: 100,
+						height: 60,
+						color: "4",
+					},
+					{ id: "n3", type: "text", text: "new", x: 400, y: 0, width: 100, height: 60 },
+				],
+				edges: [
+					{ id: "e1", fromNode: "n1", fromSide: "right", toNode: "n2", toSide: "left" },
+				],
+			}),
+		);
+
+		// Merge both ways.
+		Y.applyUpdate(a, Y.encodeStateAsUpdate(b));
+		Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+
+		const nodes = nodesOf(a);
+		const byId = Object.fromEntries(nodes.map((n) => [n.id, n]));
+		expect(byId.n1.x).toBe(999); // a's move survived
+		expect(byId.n2.color).toBe("4"); // b's recolor survived
+		expect(byId.n3).toBeDefined(); // b's add survived
+		// a and b converged.
+		expect(projectCanvas(a)).toBe(projectCanvas(b));
+	});
+
+	test("removing a node deletes it from the map and order", () => {
+		const doc = new Y.Doc();
+		seedCanvasInto(doc, CANVAS);
+		seedCanvasInto(
+			doc,
+			JSON.stringify({
+				nodes: [
+					{ id: "n1", type: "text", text: "hello", x: 0, y: 0, width: 100, height: 60 },
+				],
+				edges: [],
+			}),
+		);
+		expect(nodesOf(doc).map((n) => n.id)).toEqual(["n1"]);
+		expect(edgesOf(doc)).toEqual([]);
+	});
+
+	test("preserves unknown top-level keys via canvas_meta", () => {
+		const withMeta = JSON.stringify({ nodes: [], edges: [], someFutureKey: { a: 1 } });
+		const doc = new Y.Doc();
+		seedCanvasInto(doc, withMeta);
+		expect(JSON.parse(projectCanvas(doc))).toEqual(JSON.parse(withMeta));
+	});
+
+	test("malformed / non-canvas JSON returns false and leaves the doc untouched", () => {
+		const doc = new Y.Doc();
+		expect(seedCanvasInto(doc, "{not json")).toBe(false);
+		expect(seedCanvasInto(doc, JSON.stringify({ nodes: "nope" }))).toBe(false);
+		// An element without a stable id can't merge structurally — reject.
+		expect(seedCanvasInto(doc, JSON.stringify({ nodes: [{ type: "text" }], edges: [] }))).toBe(
+			false,
+		);
+		expect(nodesOf(doc)).toEqual([]);
+	});
+});

--- a/tests/crdt/canvas-manager.test.ts
+++ b/tests/crdt/canvas-manager.test.ts
@@ -61,6 +61,20 @@ test("hasHistory reflects canvas structure, not the (always-empty) body Y.Text",
 	await mgr.destroy();
 });
 
+test("encodeGenesisUpdate(canvas) seeds a peer STRUCTURALLY, not into the markdown body", () => {
+	// The batch-genesis path (crdt_create_batch) is the ONE encode site that
+	// bypasses docKind, so it must pass kind="canvas" or a peer applies the frame
+	// as an empty {nodes,edges} and the canvas silently never materializes (#306).
+	const { mgr } = makeCanvasManager("canvas-genesis");
+	const frame = mgr.encodeGenesisUpdate(board([NODE]), "canvas");
+
+	const peer = new Y.Doc();
+	Y.applyUpdate(peer, frame);
+	expect(peer.getMap("nodes").has("n1")).toBe(true);
+	// The markdown body Y.Text must be empty — the JSON was NOT char-ingested.
+	expect(peer.getText("content").toString()).toBe("");
+});
+
 test("projectedText returns the canvas JSON for a .canvas doc", async () => {
 	const { mgr } = makeCanvasManager("canvas-project");
 	mgr.markSynced("board.canvas");

--- a/tests/crdt/canvas-manager.test.ts
+++ b/tests/crdt/canvas-manager.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import "fake-indexeddb/auto";
+import * as Y from "yjs";
+import { CrdtManager } from "../../src/crdt/manager";
+
+// The manager learns a doc's kind once, via the docKind callback (sync.ts wires
+// it from the note's path). A ".canvas" note must use the structural schema
+// (Y.Map nodes/edges), never the markdown content Y.Text.
+function makeCanvasManager(prefix: string) {
+	const flushed: Record<string, string> = {};
+	const mgr = new CrdtManager({
+		dbPrefix: prefix,
+		onUpdate: () => {},
+		onFlushToDisk: async (p, c) => {
+			flushed[p] = c;
+		},
+		docKind: (id) => (id.endsWith(".canvas") ? "canvas" : "note"),
+	});
+	return { mgr, flushed };
+}
+
+const board = (nodes: unknown[], edges: unknown[] = []) => JSON.stringify({ nodes, edges });
+const NODE = { id: "n1", type: "text", text: "hi", x: 0, y: 0, width: 100, height: 60 };
+
+test("applyLocalEdit on a .canvas note seeds nodes map, NOT the markdown content Y.Text", async () => {
+	const { mgr } = makeCanvasManager("canvas-seed");
+	mgr.markSynced("board.canvas");
+	await mgr.applyLocalEdit("board.canvas", board([NODE]));
+
+	const doc = await mgr.getDoc("board.canvas");
+	expect(doc.getMap("nodes").has("n1")).toBe(true);
+	// The markdown body must stay empty — the JSON was NOT char-ingested.
+	expect(doc.getText("content").toString()).toBe("");
+	await mgr.destroy();
+});
+
+test("remote update on a .canvas note flushes canvas JSON (projectCanvas) to disk", async () => {
+	const { mgr, flushed } = makeCanvasManager("canvas-flush");
+	mgr.markSynced("board.canvas");
+	await mgr.applyLocalEdit("board.canvas", board([NODE]));
+
+	// Peer built from the same state moves n1, sends only the delta back →
+	// triggers the REMOTE_ORIGIN flush listener.
+	const peer = new Y.Doc();
+	Y.applyUpdate(peer, await mgr.encodeStateAsUpdate("board.canvas"));
+	peer.getMap("nodes").set("n1", { ...NODE, x: 50, y: 50 });
+	const delta = Y.encodeStateAsUpdate(peer, await mgr.encodeStateVector("board.canvas"));
+	await mgr.applyRemoteUpdate("board.canvas", delta);
+
+	const written = JSON.parse(flushed["board.canvas"]);
+	expect(written.nodes[0].x).toBe(50);
+	await mgr.destroy();
+});
+
+test("hasHistory reflects canvas structure, not the (always-empty) body Y.Text", async () => {
+	const { mgr } = makeCanvasManager("canvas-history");
+	mgr.markSynced("board.canvas");
+	expect(await mgr.hasHistory("board.canvas")).toBe(false);
+	await mgr.applyLocalEdit("board.canvas", board([NODE]));
+	expect(await mgr.hasHistory("board.canvas")).toBe(true);
+	await mgr.destroy();
+});
+
+test("projectedText returns the canvas JSON for a .canvas doc", async () => {
+	const { mgr } = makeCanvasManager("canvas-project");
+	mgr.markSynced("board.canvas");
+	await mgr.applyLocalEdit("board.canvas", board([NODE]));
+	expect(JSON.parse(await mgr.projectedText("board.canvas"))).toEqual({
+		nodes: [NODE],
+		edges: [],
+	});
+	await mgr.destroy();
+});

--- a/tests/sync-crdt-gate.test.ts
+++ b/tests/sync-crdt-gate.test.ts
@@ -399,11 +399,13 @@ describe("C1 — handleStreamEvent: CRDT gate for markdown content", () => {
 		expect(mockApi.getAttachment).toHaveBeenCalledWith("Assets/img.png");
 	});
 
-	test("non-markdown note upsert still processes via legacy path when CRDT active", async () => {
+	test("a canvas upsert with NO note_id falls through to the legacy getNote path", async () => {
 		const engine = createEngine();
 		engine.setCrdtManager({ applyLocalEdit: mock(async () => {}) } as any);
 
-		// canvas file — not .md — should still go through legacy applyChange
+		// A canvas upsert carrying no id (and no sidecar mapping) can't key a CRDT
+		// room, so it falls through to the legacy getNote fetch (the same fallback
+		// markdown takes when it has no resolvable id).
 		(mockApi.getNote as any).mockResolvedValueOnce({
 			path: "Notes/board.canvas",
 			title: "board",
@@ -420,8 +422,26 @@ describe("C1 — handleStreamEvent: CRDT gate for markdown content", () => {
 			timestamp: Date.now(),
 		});
 
-		// canvas fetch should happen (legacy path)
 		expect(mockApi.getNote).toHaveBeenCalledWith("Notes/board.canvas");
+	});
+
+	test("a canvas upsert WITH a note_id takes the CRDT branch (id bookkeeping, no legacy getNote) since #306", async () => {
+		const engine = createEngine();
+		engine.setCrdtManager({ applyLocalEdit: mock(async () => {}) } as any);
+		const enroll = mock((_p: string) => {});
+		engine.setCrdtEnrollment({ enroll } as any);
+
+		await engine.handleStreamEvent({
+			event_type: "upsert",
+			path: "Notes/board.canvas",
+			id: "id-board",
+			timestamp: Date.now(),
+		} as never);
+
+		// CRDT owns canvas now — no legacy content fetch; the id is confirmed and the
+		// note enrolled (canvas enrolls even when idle, to pull its Yjs state).
+		expect(mockApi.getNote).not.toHaveBeenCalled();
+		expect(enroll).toHaveBeenCalledWith("id-board");
 	});
 });
 
@@ -449,6 +469,40 @@ describe("C1 — applyChange: CRDT gate skips disk write for markdown", () => {
 		expect(result).toBe(false);
 		expect(mockApp.vault.modify).not.toHaveBeenCalled();
 		expect(mockApp.vault.create).not.toHaveBeenCalled();
+	});
+
+	test("applyChange for a canvas note enrolls for Yjs convergence and NEVER writes the vestigial seq-feed content (#306)", async () => {
+		const engine = createEngine();
+		const enroll = mock((_p: string) => {});
+		const applyLocalEdit = mock(async () => null);
+		engine.setCrdtManager({ applyLocalEdit } as any);
+		engine.setCrdtEnrollment({ enroll } as any);
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("Notes/board.canvas", "id-board");
+		engine.setNoteIdMap(noteIdMap);
+		// getFileByPath null → discovery. Canvas converges over the Yjs handshake
+		// ONLY, so it must enroll (even idle) and must NOT write the vestigial
+		// seq-feed `content` (the backend keeps notes.content stale for canvas).
+
+		const result = await engine.applyChange({
+			path: "Notes/board.canvas",
+			title: "board",
+			content: '{"nodes":[{"id":"STALE","type":"text"}],"edges":[]}',
+			folder: "Notes",
+			tags: [],
+			mtime: Date.now() / 1000,
+			updated_at: new Date().toISOString(),
+			deleted: false,
+			version: 1,
+			id: "id-board",
+		} as never);
+
+		expect(result).toBe(false);
+		expect(enroll).toHaveBeenCalledWith("id-board");
+		// The vestigial content is NEVER materialized to disk, nor seeded into a doc.
+		expect(mockApp.vault.create).not.toHaveBeenCalled();
+		expect(mockApp.vault.modify).not.toHaveBeenCalled();
+		expect(applyLocalEdit).not.toHaveBeenCalled();
 	});
 
 	test("applyChange materializes a not-yet-local markdown note WITHOUT enrolling it (cold discovery, room-free)", async () => {

--- a/tests/sync-crdt-gate.test.ts
+++ b/tests/sync-crdt-gate.test.ts
@@ -632,10 +632,13 @@ describe("I1 — CrdtManager destroy on re-setup", () => {
 		// Simulate teardown: remove CRDT manager (what setupNoteStream now does)
 		engine.setCrdtManager(null as any);
 
-		// A note OUTSIDE the CRDT domain (.canvas) still takes the kept LWW REST
-		// path. (In-cap markdown no longer REST-falls-back — CRDT is its sole
-		// path — so it can't stand in for the legacy-path regression here.)
-		const file = new TFile("note.canvas");
+		// A note OUTSIDE the CRDT domain still takes the kept LWW REST path. Since
+		// #306 both md and canvas are CRDT-sole, so the only REST note left is an
+		// OVERSIZED one (> the CRDT transport cap) — use that for the regression.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("note.md");
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
 
@@ -649,11 +652,15 @@ describe("I1 — CrdtManager destroy on re-setup", () => {
 // ---------------------------------------------------------------------------
 
 describe("I2 — null vaultId: CRDT unset, legacy path active", () => {
-	test("without CRDT manager set, a non-CRDT note modify goes through pushNote (not dropped)", async () => {
+	test("without CRDT manager set, a legacy-path note modify goes through pushNote (not dropped)", async () => {
 		const engine = createEngine();
-		// No setCrdtManager call — simulates vaultId=null path where CRDT is never wired
-
-		const file = new TFile("note.canvas");
+		// No setCrdtManager call — simulates vaultId=null path where CRDT is never wired.
+		// Since #306 both md and canvas are CRDT-eligible; the legacy REST push now
+		// only serves OVERSIZED notes (> the CRDT transport cap), so use one here.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("note.md");
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
 
@@ -712,12 +719,15 @@ describe("I2 — null vaultId: CRDT unset, legacy path active", () => {
 // ---------------------------------------------------------------------------
 
 describe("Graceful degradation: channel join gate — CRDT not connected", () => {
-	test("with crdt NOT connected (manager null), a non-CRDT note edit goes through pushNote (legacy)", async () => {
+	test("with crdt NOT connected (manager null), an oversized note edit goes through pushNote (legacy)", async () => {
 		const engine = createEngine();
 		// Simulates: vaultId known but crdt: topic join has not been acknowledged yet
-		// (or backend errored on join) — manager is null, legacy path active.
-
-		const file = new TFile("note.canvas");
+		// (or backend errored on join) — manager is null, legacy path active. Since
+		// #306 the legacy REST push only serves oversized notes (> CRDT cap).
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("note.md");
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
 
@@ -783,7 +793,11 @@ describe("Graceful degradation: channel join gate — CRDT not connected", () =>
 		// Simulate channel disconnect: clear manager (mirrors onStatusChange false handler)
 		engine.setCrdtManager(null);
 
-		const file = new TFile("note.canvas");
+		// Since #306 the legacy REST push only serves oversized notes (> CRDT cap).
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("note.md");
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
 
@@ -896,14 +910,18 @@ describe("P0-2 — flushFromCrdt: no-ops when syncBlocked", () => {
 		engine.setSyncBlocked(true);
 
 		(mockApp.vault.getAbstractFileByPath as any).mockReturnValue(null);
-		await engine.flushFromCrdt("Notes/echo-test.canvas", "content");
+		await engine.flushFromCrdt("Notes/echo-test.md", "content");
 
 		// Now unblock and verify handleModify proceeds (not echo-suppressed).
-		// A .canvas note takes the kept LWW REST path, so a non-suppressed edit
-		// is observable as a pushNote call (in-cap md no longer REST-pushes).
+		// Since #306 both md and canvas are CRDT-sole; the legacy REST path (where
+		// recentlyFlushed matters) only serves oversized notes, so a non-suppressed
+		// edit is observable as a pushNote call on an oversized note.
 		engine.setSyncBlocked(false);
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 
-		const file = new TFile("Notes/echo-test.canvas");
+		const file = new TFile("Notes/echo-test.md");
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
 

--- a/tests/sync-crdt-route.test.ts
+++ b/tests/sync-crdt-route.test.ts
@@ -34,7 +34,7 @@ describe("routeModify helper", () => {
 		const applyLocalEdit = mock(async () => "body");
 		const pushNote = mock(async () => ({ note: {}, chunks_indexed: 1 }));
 		const result = await routeModify(
-			{ isMarkdown: true, noteId: "id-n", readContent: async () => "body" },
+			{ crdtEligible: true, noteId: "id-n", readContent: async () => "body" },
 			{ applyLocalEdit } as any,
 			BIG,
 		);
@@ -62,7 +62,7 @@ describe("routeModify helper", () => {
 				await reread!(),
 		);
 		const result = await routeModify(
-			{ isMarkdown: true, noteId: "id-n", readContent },
+			{ crdtEligible: true, noteId: "id-n", readContent },
 			{ applyLocalEdit } as any,
 			BIG,
 		);
@@ -86,7 +86,7 @@ describe("routeModify helper", () => {
 			},
 		);
 		const result = await routeModify(
-			{ isMarkdown: true, noteId: "id-n", readContent },
+			{ crdtEligible: true, noteId: "id-n", readContent },
 			{ applyLocalEdit } as any,
 			10,
 		);
@@ -97,7 +97,7 @@ describe("routeModify helper", () => {
 		const applyLocalEdit = mock(async () => null);
 		const pushNote = mock(async () => ({ note: {}, chunks_indexed: 1 }));
 		const result = await routeModify(
-			{ isMarkdown: false, noteId: "id-img", readContent: async () => "" },
+			{ crdtEligible: false, noteId: "id-img", readContent: async () => "" },
 			{ applyLocalEdit } as any,
 			BIG,
 		);
@@ -112,7 +112,7 @@ describe("routeModify helper", () => {
 		// killing the socket. Must fall through to the legacy push path instead.
 		const huge = "x".repeat(5 * 1024 * 1024);
 		const result = await routeModify(
-			{ isMarkdown: true, noteId: "id-big", readContent: async () => huge },
+			{ crdtEligible: true, noteId: "id-big", readContent: async () => huge },
 			{ applyLocalEdit } as any,
 			4 * 1024 * 1024,
 		);
@@ -126,7 +126,7 @@ describe("routeModify helper", () => {
 		// A naive .length check (code units) would wrongly let it through.
 		const emoji = "😀".repeat(2 * 1024 * 1024);
 		const result = await routeModify(
-			{ isMarkdown: true, noteId: "id-emoji", readContent: async () => emoji },
+			{ crdtEligible: true, noteId: "id-emoji", readContent: async () => emoji },
 			{ applyLocalEdit } as any,
 			6 * 1024 * 1024,
 		);
@@ -396,17 +396,22 @@ describe("SyncEngine handleModify with CrdtManager", () => {
 		expect(applyLocalEdit).not.toHaveBeenCalled();
 	});
 
-	test(".canvas modify uses legacy pushNote, NOT applyLocalEdit, even when CRDT is wired", async () => {
-		const engine = createEngine();
-		const applyLocalEdit = mock(async () => {});
+	test(".canvas modify routes through CRDT applyLocalEdit (not legacy pushNote) since #306", async () => {
+		// Canvas now rides the CRDT transport like markdown: a server-known .canvas
+		// note routes its edit through applyLocalEdit, never api.pushNote.
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("Canvases/board.canvas", "id-board");
+		const engine = createEngine(noteIdMap);
+		const applyLocalEdit = mock(async (_id: string, c: string) => c);
 		engine.setCrdtManager({ applyLocalEdit } as any);
+		markConfirmed(engine, "id-board");
 
 		const file = new TFile("Canvases/board.canvas");
 		engine.handleModify(file);
 		await flush();
 
-		expect(applyLocalEdit).not.toHaveBeenCalled();
-		expect(mockApi.pushNote).toHaveBeenCalledTimes(1);
+		expect(applyLocalEdit).toHaveBeenCalledTimes(1);
+		expect(mockApi.pushNote).not.toHaveBeenCalled();
 	});
 
 	test(".md modify still routes through CRDT applyLocalEdit when CRDT is wired", async () => {
@@ -585,19 +590,21 @@ describe("SyncEngine.flushFromCrdt echo suppression", () => {
 		// (CRDT disk-write echoes), NOT recentlyPushed — which is also set after
 		// every legacy push. Folding them together silently dropped real user
 		// edits within the 5 s post-push cooldown, breaking conflict detection.
-		// Uses a .canvas fixture: the cooldown/echo-guard logic is transport-
-		// agnostic and .canvas exercises the kept LWW REST push path (markdown is
-		// CRDT-sole and no longer REST-pushes).
+		// The cooldown/echo-guard logic is transport-agnostic; since #306 both
+		// markdown AND canvas are CRDT-sole, so we exercise the remaining LWW REST
+		// push path with an OVERSIZED note (> the CRDT transport cap).
 		const engine = createEngine();
-		const file = new TFile("note.canvas");
+		const file = new TFile("note.md");
+		const big = (c: string) => c.repeat(5 * 1024 * 1024);
 
-		// First edit → pushes → marks recentlyPushed in the push finally.
+		// First edit → oversized → REST-pushes → marks recentlyPushed in the finally.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(big("a"));
 		engine.handleModify(file);
 		await flush();
 		expect(mockApi.pushNote).toHaveBeenCalledTimes(1);
 
 		// A real, diverging edit to the same file within the cooldown MUST push.
-		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue("edited body");
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(big("b"));
 		engine.handleModify(file);
 		await flush();
 		expect(mockApi.pushNote).toHaveBeenCalledTimes(2);
@@ -916,25 +923,28 @@ describe("offline CRDT capture — queue behaviour", () => {
 		expect(mockApi.pushNote).not.toHaveBeenCalled();
 	});
 
-	test("(b) non-md edit + network failure → queue entry EXISTS", async () => {
-		// The offline-queue-on-failure path is transport-agnostic. Markdown is now
-		// CRDT-sole (a declined md edit no longer falls through to REST), so this
-		// uses a .canvas fixture — the kept LWW REST push fails offline and must
-		// enqueue so the note retries on reconnect.
+	test("(b) oversized-note edit + network failure → queue entry EXISTS", async () => {
+		// The offline-queue-on-failure path is transport-agnostic. Since #306 BOTH
+		// markdown and canvas are CRDT-sole (a declined edit no longer falls through
+		// to REST), so this exercises the kept LWW REST push with an OVERSIZED note
+		// (> the CRDT transport cap) — it fails offline and must enqueue for retry.
 		const engine = createEngine();
 		const applyLocalEdit = mock(async () => null);
 		engine.setCrdtManager({ applyLocalEdit } as any);
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 
 		// Stub pushNote to simulate a connection-lost error
 		(mockApi.pushNote as ReturnType<typeof mock>).mockRejectedValueOnce(networkError());
 
-		const file = new TFile("note.canvas");
+		const file = new TFile("note.md");
 		engine.handleModify(file);
 		await flush(100);
 
 		// The edit must be queued for retry on reconnect
 		expect(engine.queue.size).toBe(1);
-		expect(engine.queue.all()[0]?.path).toBe("note.canvas");
+		expect(engine.queue.all()[0]?.path).toBe("note.md");
 	});
 
 	test("(c) non-md file (attachment) + network failure → queue entry EXISTS", async () => {

--- a/tests/sync-note-id.test.ts
+++ b/tests/sync-note-id.test.ts
@@ -165,38 +165,45 @@ describe("handleRename re-keys the map, id unchanged", () => {
 });
 
 describe("rename/delete drop stale sync-state (echo-suppression on recreate)", () => {
-	// Uses a .canvas fixture: markdown notes no longer REST-push via pushFile
-	// (CRDT-sole), so a .md edit records no sync-state entry to assert against.
-	// The sync-state cleanup on rename/delete is transport-agnostic — the kept
-	// LWW REST path for .canvas exercises the exact same syncState bookkeeping.
+	// Uses an OVERSIZED .md fixture: in-cap markdown/canvas notes no longer
+	// REST-push via pushFile (CRDT-sole), so they record no sync-state entry to
+	// assert against. An oversized note (> the CRDT transport cap) is the only
+	// remaining REST-push path; the sync-state cleanup on rename/delete is
+	// transport-agnostic and exercises the exact same syncState bookkeeping.
 	test("handleRename removes the old path's sync-state entry", async () => {
 		const engine = createEngine();
 		engine.setNoteIdMap(new NoteIdMap());
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 
-		// Push a.canvas so it gets a sync-state entry (recorded content hash).
-		engine.handleModify(new TFile("a.canvas"));
+		// Push a.md so it gets a sync-state entry (recorded content hash).
+		engine.handleModify(new TFile("a.md"));
 		await flush();
-		expect(engine.exportSyncState()["a.canvas"]).toBeDefined();
+		expect(engine.exportSyncState()["a.md"]).toBeDefined();
 
-		// Rename a.canvas -> b.canvas. The old path no longer holds a note, so its
-		// stale sync-state must be dropped (else a later create at a.canvas with
-		// the same content echo-suppresses and never syncs).
-		await engine.handleRename(new TFile("b.canvas"), "a.canvas");
+		// Rename a.md -> b.md. The old path no longer holds a note, so its stale
+		// sync-state must be dropped (else a later create at a.md with the same
+		// content echo-suppresses and never syncs).
+		await engine.handleRename(new TFile("b.md"), "a.md");
 
-		expect(engine.exportSyncState()["a.canvas"]).toBeUndefined();
+		expect(engine.exportSyncState()["a.md"]).toBeUndefined();
 	});
 
 	test("handleDelete removes the deleted path's sync-state entry", async () => {
 		const engine = createEngine();
 		engine.setNoteIdMap(new NoteIdMap());
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 
-		engine.handleModify(new TFile("a.canvas"));
+		engine.handleModify(new TFile("a.md"));
 		await flush();
-		expect(engine.exportSyncState()["a.canvas"]).toBeDefined();
+		expect(engine.exportSyncState()["a.md"]).toBeDefined();
 
-		await engine.handleDelete(new TFile("a.canvas"));
+		await engine.handleDelete(new TFile("a.md"));
 
-		expect(engine.exportSyncState()["a.canvas"]).toBeUndefined();
+		expect(engine.exportSyncState()["a.md"]).toBeUndefined();
 	});
 });
 

--- a/tests/sync-plan.test.ts
+++ b/tests/sync-plan.test.ts
@@ -762,12 +762,12 @@ describe("SyncEngine.pushAll with progress", () => {
 	});
 
 	test("logs errors to syncLog when push fails", async () => {
-		// .canvas takes the kept LWW single-note REST path (md is CRDT-sole and
-		// never REST-pushes); the push-failure → syncLog logging under test is
-		// transport-agnostic.
-		const file = makeTFile("notes/fail.canvas");
+		// An oversized .md takes the kept LWW single-note REST path (in-cap md/canvas
+		// are CRDT-sole and never REST-push); the push-failure → syncLog logging under
+		// test is transport-agnostic.
+		const file = makeTFile("notes/fail.md");
 		mockApp.vault.getFiles.mockReturnValue([file]);
-		mockApp.vault.cachedRead.mockResolvedValue("# Content");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockRejectedValue(new Error("500 Internal Server Error"));
 
 		const engine = createEngine();
@@ -778,7 +778,7 @@ describe("SyncEngine.pushAll with progress", () => {
 
 		const errors = engine.syncLog.entries().filter((e) => e.result === "error");
 		expect(errors).toHaveLength(1);
-		expect(errors[0].path).toBe("notes/fail.canvas");
+		expect(errors[0].path).toBe("notes/fail.md");
 		expect(errors[0].error).toContain("500");
 	});
 });

--- a/tests/sync-postpull-defer.test.ts
+++ b/tests/sync-postpull-defer.test.ts
@@ -75,10 +75,13 @@ describe("bounded post-pull push deferral (#244)", () => {
 		void engine.pullAll();
 		await flush(5);
 
-		// .canvas so the drained push takes the kept LWW REST path (md is
-		// CRDT-sole and never REST-pushes) — the deferral mechanism under test
-		// is transport-agnostic.
-		const file = new TFile("user-edit.canvas");
+		// Oversized .md so the drained push takes the kept LWW REST path (in-cap
+		// md/canvas are CRDT-sole and never REST-push) — the deferral mechanism
+		// under test is transport-agnostic.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("user-edit.md");
 		(mockApp.vault.getFileByPath as ReturnType<typeof mock>).mockReturnValue(file);
 		engine.handleModify(file);
 
@@ -90,9 +93,7 @@ describe("bounded post-pull push deferral (#244)", () => {
 		// Past the bound: the drain fires even though the pull never ended.
 		await flush(50);
 		expect(mockApi.pushNote).toHaveBeenCalledTimes(1);
-		expect((mockApi.pushNote as ReturnType<typeof mock>).mock.calls[0][0]).toBe(
-			"user-edit.canvas",
-		);
+		expect((mockApi.pushNote as ReturnType<typeof mock>).mock.calls[0][0]).toBe("user-edit.md");
 
 		engine.destroy();
 	});

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -291,16 +291,27 @@ describe("SyncEngine.handleModify", () => {
 });
 
 describe("SyncEngine.handleDelete", () => {
-	test("calls API to delete a non-md note (canvas stays REST)", async () => {
-		// CRDT-authoritative rewire: md deletes go over the socket (see the
-		// "CRDT-authoritative delete rewire" block). Canvas is not CRDT-managed, so
-		// it still uses the LWW REST delete.
+	test("canvas delete goes over the socket (crdt_delete), NOT REST, since #306", async () => {
+		// CRDT-authoritative delete: since #306 canvas rides CRDT like markdown, so a
+		// canvas delete with a resolvable note_id enqueues a durable crdt_delete and
+		// never calls api.deleteNote.
 		const engine = createEngine();
-		const file = new TFile("Notes/Old.canvas");
+		const enqueued: Array<{ kind: string; docId: string }> = [];
+		engine.setCrdtManager({ applyLocalEdit: mock(async () => null) } as any);
+		engine.setCrdtEnqueue((op) => enqueued.push(op));
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("Notes/Old.canvas", "id-canvas-del");
+		engine.setNoteIdMap(noteIdMap);
 
+		const file = new TFile("Notes/Old.canvas");
 		await engine.handleDelete(file);
 
-		expect(mockApi.deleteNote).toHaveBeenCalledWith("Notes/Old.canvas");
+		expect(mockApi.deleteNote).not.toHaveBeenCalled();
+		expect(enqueued).toContainEqual({
+			kind: "delete",
+			docId: "id-canvas-del",
+			path: "Notes/Old.canvas",
+		});
 	});
 
 	test("cancels pending push on delete", async () => {
@@ -320,25 +331,35 @@ describe("SyncEngine.handleDelete", () => {
 });
 
 describe("SyncEngine.handleRename", () => {
-	test("oversized-note rename deletes old path and pushes new path (LWW REST)", async () => {
+	test("canvas rename is tombstone-less rename-as-move like markdown (no delete) since #306", async () => {
+		// Since #306 canvas rides CRDT, so a canvas rename takes the SAME
+		// tombstone-less rename-as-move path as markdown: NO deleteNote(old), one
+		// crdt_create for the SAME id at the new path (the backend relocates).
 		const engine = createEngine();
-		// Oversized .canvas: rename's old-path delete is gated on the .md extension
-		// (in-cap md goes tombstone-less rename-as-move over CRDT), so to keep BOTH
-		// the REST deleteNote(old) AND the REST pushNote(new) we need a note that is
-		// non-md (canvas → REST delete) AND oversized (> the CRDT cap → REST push).
-		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
-			"a".repeat(5 * 1024 * 1024),
-		);
-		const file = new TFile("Notes/Renamed.canvas", Date.now());
+		const crdtDelete = mock().mockResolvedValue({ doc_id: "id-canvas-move" });
+		const crdtCreate = mock().mockResolvedValue("id-canvas-move");
+		const enqueued: Array<{ kind: string; docId: string }> = [];
+		engine.setCrdtManager({
+			applyLocalEdit: mock(async (_id: string, c: string) => c),
+		} as any);
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue('{"nodes":[],"edges":[]}');
+		engine.setCrdtDelete(crdtDelete);
+		engine.setCrdtCreate(crdtCreate);
+		engine.setCrdtLiveCheck(() => true);
+		engine.setCrdtEnqueue((op) => enqueued.push(op));
 
-		await engine.handleRename(file, "Notes/Original.canvas");
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("Notes/Old.canvas", "id-canvas-move");
+		engine.setNoteIdMap(noteIdMap);
+		(engine as unknown as { confirmNoteId(id: string): void }).confirmNoteId("id-canvas-move");
 
-		expect(mockApi.deleteNote).toHaveBeenCalledWith("Notes/Original.canvas");
-		expect(mockApi.pushNote).toHaveBeenCalledWith(
-			"Notes/Renamed.canvas",
-			expect.any(String),
-			expect.any(Number),
-		);
+		const file = new TFile("Notes/New.canvas", Date.now());
+		await engine.handleRename(file, "Notes/Old.canvas");
+
+		expect(mockApi.deleteNote).not.toHaveBeenCalled();
+		expect(crdtDelete).not.toHaveBeenCalled();
+		expect(enqueued.some((op) => op.kind === "delete")).toBe(false);
+		expect(crdtCreate).toHaveBeenCalledWith("id-canvas-move", "Notes/New.canvas");
 	});
 
 	test("md rename never emits a delete op — one create with the SAME id at the new path (Phase E2)", async () => {
@@ -1963,19 +1984,20 @@ describe("SyncEngine offline queue integration", () => {
 	});
 
 	test("failed delete queues the delete and goes offline", async () => {
-		// A REST delete (canvas — md now goes over the durable CRDT socket, which
-		// never throws) that fails goes offline and queues the delete for retry.
-		(mockApi.deleteNote as jest.Mock).mockRejectedValueOnce(new Error("network"));
+		// A REST delete that fails goes offline and queues for retry. Since #306
+		// both md and canvas deletes go over the durable CRDT socket (which never
+		// throws), the only REST delete left is an ATTACHMENT (binary).
+		(mockApi.deleteAttachment as jest.Mock).mockRejectedValueOnce(new Error("network"));
 
 		const engine = createEngine();
-		const file = new TFile("Notes/Deleted.canvas");
+		const file = new TFile("Notes/Deleted.png");
 
 		await engine.handleDelete(file);
 
 		expect(engine.isOffline()).toBe(true);
 		expect(engine.queue.size).toBe(1);
 		const entry = engine.queue.all()[0];
-		expect(entry.path).toBe("Notes/Deleted.canvas");
+		expect(entry.path).toBe("Notes/Deleted.png");
 		expect(entry.action).toBe("delete");
 	});
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -3225,7 +3225,11 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 		// have been pushed via the post-sync drain.
 		await new Promise((r) => setTimeout(r, 50));
 
-		expect(mockApi.pushNote).toHaveBeenCalledWith("Notes/DuringPull.md", big, expect.any(Number));
+		expect(mockApi.pushNote).toHaveBeenCalledWith(
+			"Notes/DuringPull.md",
+			big,
+			expect.any(Number),
+		);
 	});
 });
 

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -231,8 +231,11 @@ describe("SyncEngine.isMarkdown", () => {
 describe("SyncEngine.handleModify", () => {
 	test("debounces and pushes after delay", async () => {
 		const engine = createEngine({ debounceMs: 50 });
-		// .canvas (non-md) so the kept LWW REST push fires; md now converges over CRDT.
-		const file = new TFile("Notes/Test.canvas", Date.now());
+		// Oversized .md so it exceeds the CRDT transport cap and takes the kept
+		// LWW REST push; in-cap md/canvas now converge over CRDT.
+		const big = "a".repeat(5 * 1024 * 1024);
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(big);
+		const file = new TFile("Notes/Test.md", Date.now());
 
 		engine.handleModify(file);
 
@@ -242,11 +245,7 @@ describe("SyncEngine.handleModify", () => {
 		// Wait for debounce
 		await new Promise((r) => setTimeout(r, 100));
 
-		expect(mockApi.pushNote).toHaveBeenCalledWith(
-			"Notes/Test.canvas",
-			"# Test\n\nContent",
-			expect.any(Number),
-		);
+		expect(mockApi.pushNote).toHaveBeenCalledWith("Notes/Test.md", big, expect.any(Number));
 	});
 
 	test("ignores non-markdown files", async () => {
@@ -271,8 +270,11 @@ describe("SyncEngine.handleModify", () => {
 
 	test("coalesces rapid edits", async () => {
 		const engine = createEngine({ debounceMs: 50 });
-		// .canvas so the LWW REST push fires (md converges over CRDT now).
-		const file = new TFile("Notes/Test.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires (in-cap notes converge over CRDT).
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("Notes/Test.md", Date.now());
 
 		// Fire 5 modify events in rapid succession
 		engine.handleModify(file);
@@ -318,9 +320,15 @@ describe("SyncEngine.handleDelete", () => {
 });
 
 describe("SyncEngine.handleRename", () => {
-	test("canvas rename deletes old path and pushes new path (LWW REST)", async () => {
+	test("oversized-note rename deletes old path and pushes new path (LWW REST)", async () => {
 		const engine = createEngine();
-		// .canvas stays on the kept LWW REST route (not CRDT-managed).
+		// Oversized .canvas: rename's old-path delete is gated on the .md extension
+		// (in-cap md goes tombstone-less rename-as-move over CRDT), so to keep BOTH
+		// the REST deleteNote(old) AND the REST pushNote(new) we need a note that is
+		// non-md (canvas → REST delete) AND oversized (> the CRDT cap → REST push).
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 		const file = new TFile("Notes/Renamed.canvas", Date.now());
 
 		await engine.handleRename(file, "Notes/Original.canvas");
@@ -458,21 +466,21 @@ describe("SyncEngine.applySyncChange (apply behavior)", () => {
 		// Local file content differs from syncedHash (or no syncState entry) —
 		// user has unsaved edits or recreated the path after another device
 		// deleted it. Plugin must NOT trash the file; it pushes the resurrection.
-		// .canvas so the resurrection re-push takes the kept LWW REST route
+		// Oversized .md so the resurrection re-push takes the kept LWW REST route
 		// (the guard itself — hash/syncState based — is transport-agnostic).
-		const existingFile = new TFile("Notes/Resurrected.canvas");
+		const existingFile = new TFile("Notes/Resurrected.md");
 		(mockApp.vault.getFileByPath as jest.Mock).mockReturnValueOnce(existingFile);
-		mockApp.vault.cachedRead.mockResolvedValueOnce("# resurrected\nnew local edit\n");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		// No syncState entry → first-write semantics, definitely unsynced.
 		(mockApi.pushNote as jest.Mock).mockResolvedValueOnce({
-			note: { path: "Notes/Resurrected.canvas", version: 1 },
+			note: { path: "Notes/Resurrected.md", version: 1 },
 		});
 
 		await engine.applySyncChange(
 			syncNoteEntry({
 				id: "res",
 				seq: 7,
-				path: "Notes/Resurrected.canvas",
+				path: "Notes/Resurrected.md",
 				title: "",
 				content: "",
 				folder: "",
@@ -740,12 +748,12 @@ describe("SyncEngine.applySyncChange (apply behavior)", () => {
 		const { engine } = makeCrdtDeleteEngine();
 		// No id mapping → not CRDT-managed → legacy resurrection protection.
 		engine.setNoteIdMap(new NoteIdMap());
-		// .canvas so the resurrection re-push takes the REST route (asserts pushNote).
-		const path = "Notes/Legacy.canvas";
+		// Oversized .md so the resurrection re-push takes the REST route (asserts pushNote).
+		const path = "Notes/Legacy.md";
 
 		const existingFile = new TFile(path);
 		(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(existingFile);
-		mockApp.vault.cachedRead.mockResolvedValue("# legacy\nnew local edit\n");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockResolvedValueOnce({ note: { path, version: 1 } });
 
 		await engine.applySyncChange(
@@ -1207,8 +1215,11 @@ describe("SyncEngine.handleStreamEvent", () => {
 		);
 
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so the LWW REST push fires and holds the path in the pushing set.
-		const file = new TFile("Notes/Active.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires and holds the path in the pushing set.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("Notes/Active.md", Date.now());
 
 		// Trigger push (debounce fires after 10ms, pushFile starts)
 		engine.handleModify(file);
@@ -1219,7 +1230,7 @@ describe("SyncEngine.handleStreamEvent", () => {
 		// Now the file is in the pushing set — WebSocket event should be suppressed
 		await engine.handleStreamEvent({
 			event_type: "upsert",
-			path: "Notes/Active.canvas",
+			path: "Notes/Active.md",
 			timestamp: Date.now(),
 		});
 
@@ -1238,8 +1249,11 @@ describe("SyncEngine.handleStreamEvent", () => {
 		(mockApi.pushNote as jest.Mock).mockResolvedValue({ note: {}, chunks_indexed: 1 });
 
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so a real REST push completes and opens the cooldown window.
-		const file = new TFile("Notes/Cooldown.canvas", Date.now());
+		// Oversized .md so a real REST push completes and opens the cooldown window.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("Notes/Cooldown.md", Date.now());
 
 		// Trigger push and wait for it to complete
 		engine.handleModify(file);
@@ -1247,12 +1261,12 @@ describe("SyncEngine.handleStreamEvent", () => {
 
 		// Push is complete — path is no longer in pushing set
 		// But should still be in recentlyPushed cooldown
-		expect((engine as any).isRecentlyPushed("Notes/Cooldown.canvas")).toBe(true);
+		expect((engine as any).isRecentlyPushed("Notes/Cooldown.md")).toBe(true);
 
 		// WebSocket event arriving after push should still be suppressed
 		await engine.handleStreamEvent({
 			event_type: "upsert",
-			path: "Notes/Cooldown.canvas",
+			path: "Notes/Cooldown.md",
 			timestamp: Date.now(),
 		});
 
@@ -1367,8 +1381,11 @@ describe("SyncEngine.getStatus + onStatusChange", () => {
 		);
 
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so the LWW REST push fires (and can fail with the 502).
-		const file = new TFile("Notes/Fail.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires (and can fail with the 502).
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("Notes/Fail.md", Date.now());
 
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 100));
@@ -1378,7 +1395,7 @@ describe("SyncEngine.getStatus + onStatusChange", () => {
 		expect(status.state).not.toBe("offline");
 		expect(status.queued).toBe(1);
 		// The recorded issue surfaces the backend's message, not "status 502".
-		const issue = engine.issues.get("Notes/Fail.canvas");
+		const issue = engine.issues.get("Notes/Fail.md");
 		expect(issue?.message).toBe("failed to upload to storage backend");
 	});
 
@@ -1391,8 +1408,11 @@ describe("SyncEngine.getStatus + onStatusChange", () => {
 		);
 
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so the LWW REST push fires and tallies the failure.
-		engine.handleModify(new TFile("Notes/Fail.canvas", Date.now()));
+		// Oversized .md so the LWW REST push fires and tallies the failure.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		engine.handleModify(new TFile("Notes/Fail.md", Date.now()));
 		await new Promise((r) => setTimeout(r, 100));
 
 		const summary = engine.drainFailureSummary();
@@ -1924,8 +1944,11 @@ describe("SyncEngine offline queue integration", () => {
 		(mockApi.pushNote as jest.Mock).mockRejectedValueOnce(new Error("network"));
 
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so the LWW REST push fires (and fails → queues).
-		const file = new TFile("Notes/Offline.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires (and fails → queues).
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("Notes/Offline.md", Date.now());
 
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 100));
@@ -1933,7 +1956,7 @@ describe("SyncEngine offline queue integration", () => {
 		expect(engine.isOffline()).toBe(true);
 		expect(engine.queue.size).toBe(1);
 		const entry = engine.queue.all()[0];
-		expect(entry.path).toBe("Notes/Offline.canvas");
+		expect(entry.path).toBe("Notes/Offline.md");
 		expect(entry.action).toBe("upsert");
 		// Content-free queue entries — content is re-read on flush
 		expect(entry.content).toBeUndefined();
@@ -1961,8 +1984,11 @@ describe("SyncEngine offline queue integration", () => {
 		(mockApi.pushNote as jest.Mock).mockRejectedValueOnce(new Error("network"));
 
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so the LWW REST push path drives the offline→online transition.
-		const file = new TFile("Notes/Recovery.canvas", Date.now());
+		// Oversized .md so the LWW REST push path drives the offline→online transition.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
+		const file = new TFile("Notes/Recovery.md", Date.now());
 
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 100));
@@ -1971,7 +1997,7 @@ describe("SyncEngine offline queue integration", () => {
 		// Next push succeeds — also mock pushNote for queue flush
 		(mockApi.pushNote as jest.Mock).mockResolvedValue({ note: {}, chunks_indexed: 1 });
 
-		const file2 = new TFile("Notes/Online.canvas", Date.now());
+		const file2 = new TFile("Notes/Online.md", Date.now());
 		engine.handleModify(file2);
 		await new Promise((r) => setTimeout(r, 200));
 
@@ -2380,9 +2406,12 @@ describe("SyncEngine pull accuracy", () => {
 		// Pull will update lastSync to a newer server_time
 
 		// A file modified between old lastSync and new server_time.
-		// .canvas so pushModifiedFiles' selected file takes the LWW REST route.
+		// Oversized .md so pushModifiedFiles' selected file takes the LWW REST route.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 		const modifiedFile = new TFile(
-			"Notes/Modified.canvas",
+			"Notes/Modified.md",
 			new Date("2026-02-15T00:00:00Z").getTime(),
 		);
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValueOnce([modifiedFile]);
@@ -2392,7 +2421,7 @@ describe("SyncEngine pull accuracy", () => {
 		// pushModifiedFiles should use the OLD lastSync (prePullSync), not the new one
 		// The file was modified at Feb 15, which is after Jan 1 (old lastSync)
 		expect(mockApi.pushNote).toHaveBeenCalledWith(
-			"Notes/Modified.canvas",
+			"Notes/Modified.md",
 			expect.any(String),
 			expect.any(Number),
 		);
@@ -2405,16 +2434,19 @@ describe("SyncEngine pull accuracy", () => {
 		// long ago — well before the server_time pull will set lastSync to.
 		const engine = createEngine();
 		// Do NOT call setLastSync — lastSync is "" (first connect / fresh install)
-		// .canvas so the tracked file re-pushes over the LWW REST route.
+		// Oversized .md so the tracked file re-pushes over the LWW REST route.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"a".repeat(5 * 1024 * 1024),
+		);
 		engine.importSyncState({
-			"Notes/Tracked.canvas": { hash: 12345 },
+			"Notes/Tracked.md": { hash: 12345 },
 		});
 
 		// Pull returns no changes but advances lastSync to a recent server_time.
 
 		// Tracked local file modified Feb 15 — BEFORE the post-pull server_time.
 		const trackedFile = new TFile(
-			"Notes/Tracked.canvas",
+			"Notes/Tracked.md",
 			new Date("2026-02-15T00:00:00Z").getTime(),
 		);
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValueOnce([trackedFile]);
@@ -2425,7 +2457,7 @@ describe("SyncEngine pull accuracy", () => {
 		// The tracked file must still be pushed; it must NOT be gated by the
 		// post-pull server_time (which would skip every file modified before now).
 		expect(mockApi.pushNote).toHaveBeenCalledWith(
-			"Notes/Tracked.canvas",
+			"Notes/Tracked.md",
 			expect.any(String),
 			expect.any(Number),
 		);
@@ -2758,9 +2790,9 @@ describe("ready gate", () => {
 	test("events work after setReady", async () => {
 		const engine = createEngine({ debounceMs: 10 }, { ready: false });
 		engine.setReady();
-		// .canvas so the ready-gate release drives a real REST push.
-		const file = new TFile("Notes/Test.canvas", Date.now());
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValueOnce("content");
+		// Oversized .md so the ready-gate release drives a real REST push.
+		const file = new TFile("Notes/Test.md", Date.now());
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
@@ -2775,16 +2807,16 @@ describe("content-free queue entries", () => {
 	test("failed push enqueues without content", async () => {
 		const engine = createEngine({ debounceMs: 10 });
 		(mockApi.pushNote as jest.Mock).mockRejectedValueOnce(new Error("offline"));
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValueOnce("file content");
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 
-		// .canvas so the LWW REST push fires (and fails → enqueues content-free).
-		const file = new TFile("Notes/Test.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires (and fails → enqueues content-free).
+		const file = new TFile("Notes/Test.md", Date.now());
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 50));
 
 		const entries = engine.queue.all();
 		expect(entries).toHaveLength(1);
-		expect(entries[0].path).toBe("Notes/Test.canvas");
+		expect(entries[0].path).toBe("Notes/Test.md");
 		expect(entries[0].action).toBe("upsert");
 		expect(entries[0].content).toBeUndefined();
 		expect(entries[0].contentBase64).toBeUndefined();
@@ -2965,10 +2997,10 @@ describe("push concurrency limit", () => {
 			);
 		});
 
-		// Fire 10 modify events (.canvas → real REST pushes for the slot limiter).
+		// Fire 10 modify events (oversized .md → real REST pushes for the slot limiter).
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		for (let i = 0; i < 10; i++) {
-			const file = new TFile(`Notes/File${i}.canvas`, Date.now());
-			(mockApp.vault.cachedRead as jest.Mock).mockResolvedValueOnce(`content ${i}`);
+			const file = new TFile(`Notes/File${i}.md`, Date.now());
 			engine.handleModify(file);
 		}
 
@@ -3002,10 +3034,10 @@ describe("push concurrency limit", () => {
 			);
 		});
 
-		// Fire 10 modify events (.canvas → real REST pushes for the slot limiter).
+		// Fire 10 modify events (oversized .md → real REST pushes for the slot limiter).
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		for (let i = 0; i < 10; i++) {
-			const file = new TFile(`Notes/File${i}.canvas`, Date.now());
-			(mockApp.vault.cachedRead as jest.Mock).mockResolvedValueOnce(`content ${i}`);
+			const file = new TFile(`Notes/File${i}.md`, Date.now());
 			engine.handleModify(file);
 		}
 
@@ -3024,18 +3056,19 @@ describe("push concurrency limit", () => {
 describe("SyncEngine.pushAll echo suppression fix", () => {
 	test("pushAll() pushes files even when syncState hashes match", async () => {
 		const engine = createEngine();
-		// .canvas so pushAll's force=true push actually fires the LWW REST route.
-		const file = new TFile("Notes/Existing.canvas", Date.now());
+		// Oversized .md so pushAll's force=true push actually fires the LWW REST route.
+		const big = "a".repeat(5 * 1024 * 1024);
+		const file = new TFile("Notes/Existing.md", Date.now());
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValue([file]);
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# Existing\n\nContent");
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue(big);
 
 		// Seed syncState by applying the note (as a catch-up op does), so the next
 		// pushAll must force past the matching hash.
 		(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(null);
 		await engine.applyChange({
-			path: "Notes/Existing.canvas",
+			path: "Notes/Existing.md",
 			title: "Existing",
-			content: "# Existing\n\nContent",
+			content: big,
 			folder: "Notes",
 			tags: [],
 			mtime: 1709345678,
@@ -3046,27 +3079,23 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 		jest.clearAllMocks();
 		(mockApi.ping as jest.Mock).mockResolvedValue({ ok: true });
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValue([file]);
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# Existing\n\nContent");
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue(big);
 		(mockApi.pushNote as jest.Mock).mockResolvedValue({ note: {}, chunks_indexed: 1 });
 
 		const pushed = await engine.pushAll();
 
 		// Should push despite hash match because pushAll uses force=true
 		expect(pushed).toBe(1);
-		expect(mockApi.pushNote).toHaveBeenCalledWith(
-			"Notes/Existing.canvas",
-			"# Existing\n\nContent",
-			expect.any(Number),
-		);
+		expect(mockApi.pushNote).toHaveBeenCalledWith("Notes/Existing.md", big, expect.any(Number));
 	});
 
 	test("pushAll() reports skipped count when some files fail", async () => {
 		const engine = createEngine();
-		// .canvas so both notes take the LWW REST route (one ok, one fails).
-		const file1 = new TFile("Notes/Good.canvas", Date.now());
-		const file2 = new TFile("Notes/Bad.canvas", Date.now());
+		// Oversized .md so both notes take the LWW REST route (one ok, one fails).
+		const file1 = new TFile("Notes/Good.md", Date.now());
+		const file2 = new TFile("Notes/Bad.md", Date.now());
 		(mockApp.vault.getFiles as jest.Mock).mockReturnValue([file1, file2]);
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("content");
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.ping as jest.Mock).mockResolvedValue({ ok: true });
 		(mockApi.pushNote as jest.Mock)
 			.mockResolvedValueOnce({ note: {}, chunks_indexed: 1 })
@@ -3080,9 +3109,9 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 
 	test("pushFile(force=true) bypasses echo suppression", async () => {
 		const engine = createEngine();
-		// .canvas so pushFile exercises the LWW REST route + its force bypass.
-		const file = new TFile("Notes/Force.canvas", Date.now());
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# Force\n\nContent");
+		// Oversized .md so pushFile exercises the LWW REST route + its force bypass.
+		const file = new TFile("Notes/Force.md", Date.now());
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockResolvedValue({ note: {}, chunks_indexed: 1 });
 
 		// Simulate a synced hash by doing a normal push first
@@ -3153,9 +3182,10 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 
 	test("handleModify during a sync queues for post-sync push (#244)", async () => {
 		const engine = createEngine({ debounceMs: 10 });
-		// .canvas so the post-sync drain pushes via the LWW REST route.
-		const file = new TFile("Notes/DuringPull.canvas", Date.now());
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# User edit during pull");
+		// Oversized .md so the post-sync drain pushes via the LWW REST route.
+		const big = "a".repeat(5 * 1024 * 1024);
+		const file = new TFile("Notes/DuringPull.md", Date.now());
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue(big);
 		(mockApi.pushNote as jest.Mock).mockResolvedValue({ note: {}, chunks_indexed: 1 });
 		(mockApp.vault.getFileByPath as jest.Mock).mockReturnValue(file);
 
@@ -3173,23 +3203,20 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 		// have been pushed via the post-sync drain.
 		await new Promise((r) => setTimeout(r, 50));
 
-		expect(mockApi.pushNote).toHaveBeenCalledWith(
-			"Notes/DuringPull.canvas",
-			"# User edit during pull",
-			expect.any(Number),
-		);
+		expect(mockApi.pushNote).toHaveBeenCalledWith("Notes/DuringPull.md", big, expect.any(Number));
 	});
 });
 
 describe("Path sanitization on push", () => {
 	test("renames local file when server returns sanitized path", async () => {
-		// Server sanitizes "test?.canvas" → "test.canvas". .canvas so the kept
+		// Server sanitizes "test?.md" → "test.md". Oversized .md so the kept
 		// LWW REST path (which still sanitize-renames) runs.
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockResolvedValueOnce({
 			note: {
 				id: "note-1",
 				user_id: "user-1",
-				path: "Notes/test.canvas",
+				path: "Notes/test.md",
 				title: "test",
 				folder: "Notes",
 				tags: [],
@@ -3200,10 +3227,10 @@ describe("Path sanitization on push", () => {
 			chunks_indexed: 1,
 		});
 
-		const file = new TFile("Notes/test?.canvas", Date.now());
+		const file = new TFile("Notes/test?.md", Date.now());
 		// vault needs to find the file for rename
 		(mockApp.vault.getFileByPath as jest.Mock).mockImplementation((p: string) => {
-			if (p === "Notes/test?.canvas") return file;
+			if (p === "Notes/test?.md") return file;
 			return null;
 		});
 
@@ -3212,13 +3239,13 @@ describe("Path sanitization on push", () => {
 		await new Promise((r) => setTimeout(r, 100));
 
 		// Should have renamed the local file to match server's sanitized path
-		expect(mockApp.vault.rename).toHaveBeenCalledWith(file, "Notes/test.canvas");
+		expect(mockApp.vault.rename).toHaveBeenCalledWith(file, "Notes/test.md");
 	});
 
 	test("does not revert a local rename that lands while the push is in flight (#245)", async () => {
-		// .canvas so the kept LWW REST path (the only sanitize-rename surface) runs.
-		const file = new TFile("Notes/RenameOld.canvas", Date.now());
-		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("# body");
+		// Oversized .md so the kept LWW REST path (the only sanitize-rename surface) runs.
+		const file = new TFile("Notes/RenameOld.md", Date.now());
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApp.vault.getFileByPath as jest.Mock).mockImplementation((p: string) =>
 			p === file.path ? file : null,
 		);
@@ -3226,7 +3253,7 @@ describe("Path sanitization on push", () => {
 			// The user renames the file while the push request is in flight.
 			// TFile.path is live, so by reply time it no longer matches the
 			// path that was pushed.
-			file.path = "Notes/RenameNew.canvas";
+			file.path = "Notes/RenameNew.md";
 			return {
 				note: {
 					id: "note-1",
@@ -3251,7 +3278,7 @@ describe("Path sanitization on push", () => {
 		// renaming back would silently revert the user's rename (issue #245,
 		// run 29392015897).
 		expect(mockApp.vault.rename).not.toHaveBeenCalled();
-		expect(file.path).toBe("Notes/RenameNew.canvas");
+		expect(file.path).toBe("Notes/RenameNew.md");
 
 		// Echo-suppression window must open under the path we SENT, not the live
 		// path: the self-echo arrives as an upsert for RenameOld. Marking the live
@@ -3259,8 +3286,8 @@ describe("Path sanitization on push", () => {
 		// and swallow a genuine remote update to RenameNew (Engram#944 class).
 		const recentlyPushed = (engine as unknown as { recentlyPushed: Map<string, number> })
 			.recentlyPushed;
-		expect(recentlyPushed.has("Notes/RenameOld.canvas")).toBe(true);
-		expect(recentlyPushed.has("Notes/RenameNew.canvas")).toBe(false);
+		expect(recentlyPushed.has("Notes/RenameOld.md")).toBe(true);
+		expect(recentlyPushed.has("Notes/RenameNew.md")).toBe(false);
 	});
 
 	test("does not rename when server path matches original", async () => {
@@ -3289,12 +3316,13 @@ describe("Path sanitization on push", () => {
 	});
 
 	test("handles multiple illegal chars in filename", async () => {
-		// .canvas so the kept LWW REST path (the sanitize-rename surface) runs.
+		// Oversized .md so the kept LWW REST path (the sanitize-rename surface) runs.
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockResolvedValueOnce({
 			note: {
 				id: "note-1",
 				user_id: "user-1",
-				path: "Notes/What Why How.canvas",
+				path: "Notes/What Why How.md",
 				title: "What Why How",
 				folder: "Notes",
 				tags: [],
@@ -3305,9 +3333,9 @@ describe("Path sanitization on push", () => {
 			chunks_indexed: 1,
 		});
 
-		const file = new TFile("Notes/What? Why: How*.canvas", Date.now());
+		const file = new TFile("Notes/What? Why: How*.md", Date.now());
 		(mockApp.vault.getFileByPath as jest.Mock).mockImplementation((p: string) => {
-			if (p === "Notes/What? Why: How*.canvas") return file;
+			if (p === "Notes/What? Why: How*.md") return file;
 			return null;
 		});
 
@@ -3315,7 +3343,7 @@ describe("Path sanitization on push", () => {
 		engine.handleModify(file);
 		await new Promise((r) => setTimeout(r, 100));
 
-		expect(mockApp.vault.rename).toHaveBeenCalledWith(file, "Notes/What Why How.canvas");
+		expect(mockApp.vault.rename).toHaveBeenCalledWith(file, "Notes/What Why How.md");
 	});
 });
 
@@ -3652,11 +3680,11 @@ describe("SyncEngine IssueStore integration", () => {
 
 	test("401 auth failure records issue and skips offline queue", async () => {
 		const engine = createEngine();
-		// .canvas so the LWW REST push fires and surfaces the 401 issue.
-		const file = new TFile("Notes/forbidden.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires and surfaces the 401 issue.
+		const file = new TFile("Notes/forbidden.md", Date.now());
 		(file as any).stat = { mtime: Date.now(), size: 100 };
 		mockApp.vault.getFiles.mockReturnValue([file]);
-		mockApp.vault.cachedRead.mockResolvedValue("# Hi");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockRejectedValueOnce(
 			Object.assign(new Error("Unauthorized"), { status: 401 }),
 		);
@@ -3673,11 +3701,11 @@ describe("SyncEngine IssueStore integration", () => {
 
 	test("non-terminal failure (500) records issue AND queues for retry", async () => {
 		const engine = createEngine();
-		// .canvas so the LWW REST push fires (500 → issue + retry queue).
-		const file = new TFile("Notes/flaky.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires (500 → issue + retry queue).
+		const file = new TFile("Notes/flaky.md", Date.now());
 		(file as any).stat = { mtime: Date.now(), size: 100 };
 		mockApp.vault.getFiles.mockReturnValue([file]);
-		mockApp.vault.cachedRead.mockResolvedValue("# Hi");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockRejectedValueOnce(
 			Object.assign(new Error("Internal Server Error"), { status: 500 }),
 		);
@@ -3691,15 +3719,15 @@ describe("SyncEngine IssueStore integration", () => {
 
 	test("successful push clears any prior issue for the same path", async () => {
 		const engine = createEngine();
-		// .canvas so the LWW REST push fires and clears the prior issue on success.
-		const file = new TFile("Notes/recovers.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires and clears the prior issue on success.
+		const file = new TFile("Notes/recovers.md", Date.now());
 		(file as any).stat = { mtime: Date.now(), size: 100 };
 		mockApp.vault.getFiles.mockReturnValue([file]);
-		mockApp.vault.cachedRead.mockResolvedValue("# Hi");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 
 		// Pre-seed an issue (simulating an earlier failure that's now resolved)
 		engine.issues.record({
-			path: "Notes/recovers.canvas",
+			path: "Notes/recovers.md",
 			kind: "note",
 			category: "server",
 			status: 500,
@@ -3711,7 +3739,7 @@ describe("SyncEngine IssueStore integration", () => {
 		expect(engine.issues.count()).toBe(1);
 
 		(mockApi.pushNote as jest.Mock).mockResolvedValueOnce({
-			note: { path: "Notes/recovers.canvas", version: 1 },
+			note: { path: "Notes/recovers.md", version: 1 },
 			chunks_indexed: 1,
 		});
 		await (engine as any).pushFile(file, true);
@@ -3759,10 +3787,10 @@ describe("SyncEngine attachment pre-gate (client-side plan limits)", () => {
 
 	test("free text-only: a text note still uploads (notes not pre-gated)", async () => {
 		const engine = createEngine();
-		// .canvas is a text note (not an attachment) → not pre-gated, uploads via REST.
-		const file = new TFile("Notes/Test.canvas", Date.now());
+		// An oversized .md is a text note (not an attachment) → not pre-gated, uploads via REST.
+		const file = new TFile("Notes/Test.md", Date.now());
 		(file as any).stat = { mtime: Date.now(), size: 100 };
-		mockApp.vault.cachedRead.mockResolvedValue("# Hi");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		engine.applyPlanState({
 			tier: "free",
 			attachmentsTextOnly: true,
@@ -4053,17 +4081,17 @@ describe("SyncEngine attachment 402 (Free tier) handling", () => {
 
 	test("text-note push still completes in the same batch where attachments fail", async () => {
 		const engine = createEngine();
-		// .canvas so the note takes the LWW REST route alongside the failing attachment.
-		const note = new TFile("Notes/Hello.canvas", Date.now());
+		// Oversized .md so the note takes the LWW REST route alongside the failing attachment.
+		const note = new TFile("Notes/Hello.md", Date.now());
 		const attach = new TFile("Assets/logo.png", Date.now());
 		(note as any).stat = { mtime: Date.now(), size: 100 };
 		(attach as any).stat = { mtime: Date.now(), size: 1024 };
 
 		mockApp.vault.getFiles.mockReturnValue([note, attach]);
-		mockApp.vault.cachedRead.mockResolvedValue("# Hello");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		mockApp.vault.readBinary.mockResolvedValue(new ArrayBuffer(8));
 		(mockApi.pushNote as jest.Mock).mockResolvedValue({
-			note: { path: "Notes/Hello.canvas", version: 1 },
+			note: { path: "Notes/Hello.md", version: 1 },
 			chunks_indexed: 1,
 		});
 		(mockApi.pushAttachment as jest.Mock).mockRejectedValueOnce(makeAttachmentLimitedError());
@@ -4189,10 +4217,10 @@ describe("SyncEngine attachment 402 (Free tier) handling", () => {
 
 	test("a real failure (5xx) STILL calls console.error", async () => {
 		const engine = createEngine();
-		// .canvas so the LWW REST push fires and the 5xx surfaces to console.error.
-		const file = new TFile("Notes/x.canvas", Date.now());
+		// Oversized .md so the LWW REST push fires and the 5xx surfaces to console.error.
+		const file = new TFile("Notes/x.md", Date.now());
 		(file as any).stat = { mtime: Date.now(), size: 100 };
-		mockApp.vault.cachedRead.mockResolvedValue("# x");
+		mockApp.vault.cachedRead.mockResolvedValue("a".repeat(5 * 1024 * 1024));
 		(mockApi.pushNote as jest.Mock).mockRejectedValueOnce({ status: 502, message: "boom" });
 
 		const spy = jest.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## What

Plugin half of #306 "canvas as CRDT". Moves `.canvas` notes off the legacy REST/LWW + conflict path onto the same Yjs transport markdown uses, with a **structural** schema (per-element merge). Pairs with the merged backend PR engram#1107.

Spec: `2026-07-23-canvas-crdt-sync-design.md`. Plan: `docs/superpowers/plans/2026-07-24-canvas-crdt-phase-b-plugin.md`.

## Stages (each TDD, committed separately)

1. **Canvas codec** (`src/crdt/canvas-codec.ts`) — `seedCanvasInto`/`projectCanvas` over `Y.Map "nodes"`/`"edges"` (keyed by element id) + `Y.Array "nodes_order"`/`"edges_order"` + `Y.Map "canvas_meta"`. Stable ids → concurrent edits to different nodes both survive; same node is LWW; malformed JSON → keep-local. No char-diffing of JSON.
2. **Manager kind-threading** — the manager learns a doc's shape once via a new `opts.docKind(noteId)` callback (wired in `crdt/wiring.ts` from `noteIdMap.pathForId`), cached on the Entry. Branches the seed (`seedCanvasInto`), the remote-merge flush (`projectCanvas`), `hasHistory`/`projectedText`, genesis, and skips `flattenIfBloated` for canvas. Canvas needs no `seedOnce` gate (structural docs are immune to the #846 second-lineage doubling).
3. **Push** — `routeModify`'s `isMarkdown` → `crdtEligible`; new `isCrdtEligible` (md OR canvas) on every push gate. Canvas edits seed via `applyLocalEdit` / create via `crdt_create`; only OVERSIZED notes still hit `api.pushNote`.
4. **Delete + rename** — canvas delete → durable `crdt_delete` (+ doc teardown); canvas rename → tombstone-less rename-as-move (`crdt_create` at the new path). No more `api.deleteNote` for canvas.
5. **Pull** — canvas enters the `crdtOwnsBody` block (skips the legacy threeWayMerge/ConflictModal tail). **Canvas converges over the Yjs handshake ONLY**: its seq-feed `content` is vestigial (backend keeps `notes.content` stale; deliver-out + fan-out are `.md`-gated), so `applyChange` enrolls to pull the state via STEP1/STEP2 and NEVER writes that content. Canvas enrolls even when idle (no content fallback); the room releases after convergence. `writeDriftConflictCopy` preserves the note's extension.

## Test / verification

- Full plugin suite green (2274 pass, 0 fail), including new canvas codec round-trip/merge tests, manager kind tests, and canvas push/delete/rename/pull regressions.
- `biome ci`, `tsc`/`esbuild` build, `eslint` (lint:obsidian) all clean.
- ~40 tests that used a `.canvas` file as a REST-push stand-in were converted to oversized-`.md` fixtures (the only remaining REST-push case).

## Reviewer / merge notes

- **Do NOT merge until the paired cross-repo e2e-crdt run is green** — it validates cold-device canvas convergence (enroll pulls full Yjs state), which unit tests can't exercise end-to-end.
- Known edge: a canvas upsert with NO note_id still falls to the legacy `getNote` path (rare post-migration).
- Phase C (delete three-way-merge/diff/conflict-modal + the #310 getNote remainder + `onCorruption` Notice downgrade) is a separate follow-up, now unblocked since canvas no longer uses the legacy tail.

Refs #306.

🤖 Generated with [Claude Code](https://claude.com/claude-code)