### PR TITLE
fix(crdt): recover offline edits after switch-away

### DIFF
--- a/docs/context/crdt-offline-edit-switch-away-dataloss.md
+++ b/docs/context/crdt-offline-edit-switch-away-dataloss.md
@@ -1,0 +1,47 @@
+# Context Doc: CRDT offline edit lost after switching away from the note
+
+_Last verified: 2026-07-24_
+
+## Status
+Fixed (branch `fix/crdt-offline-edit-lost-on-rejoin`, commit `ed9dfb5`)
+
+## Symptom
+In Obsidian, moving between files and making edits - only *some* edits reach the server. Prod Loki tripwire (`metadata_category=client`):
+
+```
+[client:channel] sendCrdt refused (crdt topic not joined): joined=false
+```
+
+Always preceded by `heartbeat unanswered - closing dead socket` or `net::ERR_NETWORK_CHANGED` - i.e. the socket died, an edit was typed during the dead window, then dropped.
+
+## Root Cause
+An edit typed while the CRDT socket is down is refused by `channel.sendCrdt` (`src/channel.ts:351`, gates on the vault-wide `crdtJoined` flag, which is `false` whenever the socket is closed) and dropped. `crdtJoined` is a SINGLE vault-wide flag (topic `crdt:{user}:{vault}`), not per-doc.
+
+The rejoin recovery `reEnrollOpenCrdtNotes` (`src/main.ts:1625`) only re-enrolls notes still open in an editor leaf. So an edit made to a note, then SWITCHED AWAY FROM (editor closed) before the socket reconnects, is never re-solicited by the mutual STEP1 handshake - it is stranded on local disk, never reaching the server.
+
+#299's recovery only covered still-OPEN notes; this is the **switch-away gap**.
+
+## Recovery mechanism (why re-enroll is what matters)
+Offline-edit recovery rides the mutual handshake. On rejoin: re-enroll → `startSync` (`src/crdt/channel.ts:68`, does `mgr.getDoc` which reopens the doc from IndexedDB) → STEP1 → the faithful backend answers with its OWN STEP1 (`[step2, step1]`) → client replies STEP2 carrying the held struct → converges. The **re-enroll is the trigger**; a note with no open leaf never gets re-enrolled, so its held struct is never solicited.
+
+## False-diagnosis trap (the important lesson)
+An earlier repro ran against a checkout **9 commits behind origin/main** and "reproduced" the bug even for STILL-OPEN notes. That was a SIM-INFIDELITY artifact: the model server was pull-only and never solicited the held struct - the same infidelity that had originally mis-filed #299 as a real *backend* bug. The real backend was never pull-only; only the test double was.
+
+**Lesson:** verify repros against CURRENT `origin/main`, not a stale shared checkout. The plugin's shared checkout at `code-projects/engram-obsidian-sync` is often parked in detached HEAD behind `origin/main` - do real work in a worktree off `origin/main`.
+
+## The Fix
+- Track docIds whose `sendCrdt` was refused while unjoined - a `Set` in the shared send wrapper (`src/crdt/wiring.ts:302`).
+- Expose `reEnrollUnsent()` (`src/crdt/wiring.ts:444`).
+- Call it on the `crdt:` rejoin (`src/main.ts` `onCrdtTopicJoined` at 1653, after `reEnrollOpenCrdtNotes`; the call is at `src/main.ts:1693`). Mirrored in the sim at `tests/sim/replica.ts:608` (`onCrdtTopicJoined`).
+- Differential sim gate: `tests/sim/scenarios.ts:255` `offlineEditSwitchAwayRecovers` + `tests/sim/regressions.test.ts:121` "#299b". Asserts the edit reaches the **SERVER** (server row content), NOT `assertConverged` - a revert-on-reconnect would false-green a convergence check.
+
+## Secondary findings (follow-ups, NOT fixed here)
+- **Lag on file switch:** `crdtLiveViews.refresh()` (`src/crdt/live/live-views.ts:201`) fires 2–3× per open (active-leaf-change + file-open + layout-change handlers in `main.ts`), and re-binds ALL open leaves each time (O(open-leaves)); plus `healNoteOnOpen` (`src/main.ts:1382`) runs per open. This PR only coalesced the same-microtask duplicate refresh. Scoping the rebind to the focused leaf + healNoteOnOpen-per-open are deferred (need real-app profiling).
+- **Log noise:** the biggest Loki bloat is the full mTLS client cert (~5KB) attached to every shipped client log by the backend `Engram.Logs` re-emit - a BACKEND (engram repo) fix, not the plugin.
+
+## References
+- `src/channel.ts:351` - `sendCrdt` gate on `crdtJoined`
+- `src/crdt/wiring.ts:302,444` - refused-doc Set + `reEnrollUnsent`
+- `src/main.ts:1625,1653,1693` - `reEnrollOpenCrdtNotes`, `onCrdtTopicJoined`, `reEnrollUnsent` call
+- `src/crdt/channel.ts:68` - `startSync` (reopens doc from IndexedDB, sends STEP1)
+- `tests/sim/scenarios.ts:255`, `tests/sim/regressions.test.ts:121`, `tests/sim/replica.ts:608` - #299b gate

--- a/main.js
+++ b/main.js
@@ -22714,7 +22714,7 @@ var CrdtEnrollment = class {
 };
 
 // src/crdt/wiring.ts
-var DEFAULT_STRAND_HEAL_DEBOUNCE_MS = 750, STRAND_HEAL_MAX_ATTEMPTS = 5;
+var DEFAULT_STRAND_HEAL_DEBOUNCE_MS = 750, STRAND_HEAL_MAX_ATTEMPTS = 5, MAX_UNSENT_DOCS = 500;
 function partitionStrandedFlushes(pending, resolvePath, attempts, maxAttempts) {
   var _a;
   let toFlush = [], toRetry = [], toGiveUp = [];
@@ -22823,7 +22823,16 @@ function createCrdtWiring(deps) {
     manager,
     send: (docId, frame) => {
       let ok = deps.sendCrdt(docId, frame);
-      return ok === !1 ? unsentDocIds.add(docId) : unsentDocIds.delete(docId), ok;
+      if (ok === !1) {
+        if (!unsentDocIds.has(docId) && unsentDocIds.size >= MAX_UNSENT_DOCS)
+          for (let oldest of unsentDocIds) {
+            unsentDocIds.delete(oldest);
+            break;
+          }
+        unsentDocIds.add(docId);
+      } else
+        unsentDocIds.delete(docId);
+      return ok;
     },
     // An inbound STEP2 that leaves the doc empty is the server's authoritative
     // "genuinely empty note" signal — materialize the file off the handshake
@@ -22886,6 +22895,9 @@ function createCrdtWiring(deps) {
     clearStrandHealAttempts: () => strandHealAttempts.clear(),
     reEnrollUnsent: () => {
       for (let id2 of [...unsentDocIds]) enrollment.enroll(id2);
+    },
+    forgetUnsent: (docId) => {
+      unsentDocIds.delete(docId);
     },
     dispose
   };
@@ -23365,7 +23377,13 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian25.Plugin
       })
     ), this.registerEvent(
       this.app.vault.on("delete", (file) => {
-        file instanceof import_obsidian25.TFolder ? this.syncEngine.handleFolderDelete(file) : this.syncEngine.handleDelete(file);
+        var _a2;
+        if (file instanceof import_obsidian25.TFolder)
+          this.syncEngine.handleFolderDelete(file);
+        else {
+          let noteId = this.noteIdMap.get(file.path);
+          noteId && ((_a2 = this.crdtWiring) == null || _a2.forgetUnsent(noteId)), this.syncEngine.handleDelete(file);
+        }
       })
     ), this.registerEvent(
       this.app.vault.on("rename", (file, oldPath) => {

--- a/main.js
+++ b/main.js
@@ -1486,7 +1486,7 @@ function makeCrdtCatchupSender(channel, currentVaultId) {
     return channel.crdtCatchupSince(cursorSeq, limit, cursorId);
   };
 }
-var NoteChannel = class {
+var _NoteChannel = class _NoteChannel {
   constructor(baseUrl, apiKey, userId, vaultId = null, deviceId = null) {
     this.ws = null;
     this.ref = 0;
@@ -1509,6 +1509,12 @@ var NoteChannel = class {
      *  that does not serve the crdt: topic replies with an error (handled below),
      *  keeping this false — which allows the legacy pushNote path to remain active. */
     this.crdtJoined = !1;
+    /** Per-doc throttle for the "sendCrdt refused" warn. An offline window refuses
+     *  many frames per doc in a burst (STEP1 + each keystroke's update); logging
+     *  each one buried the signal. Log once per doc per window. The refused frame
+     *  is NOT lost — the doc is re-enrolled on rejoin (wiring reEnrollUnsent) and
+     *  the mutual handshake re-solicits its state, so this is a transient. */
+    this.lastRefusedWarnAt = /* @__PURE__ */ new Map();
     /**
      * The `ref` value sent with the crdt: topic phx_join frame.
      * Stored so handleMessage can distinguish a join-error reply (ref matches)
@@ -1651,11 +1657,16 @@ var NoteChannel = class {
    *  a frame with a stale/absent join_ref is silently dropped server-side
    *  (the plugin #179 failure shape), so refusing locally is the honest signal. */
   sendCrdt(docId, b64) {
+    var _a;
     let t = this.crdtTopic;
-    return !t || !this.crdtJoined ? (rlog().warn(
-      "channel",
-      `sendCrdt refused (crdt topic not joined): doc=${docId} joined=${this.crdtJoined}`
-    ), !1) : (this.send([this.crdtJoinRef, String(++this.ref), t, "crdt_msg", { doc_id: docId, b64 }]), !0);
+    if (!t || !this.crdtJoined) {
+      let now = Date.now();
+      return now - ((_a = this.lastRefusedWarnAt.get(docId)) != null ? _a : 0) >= _NoteChannel.REFUSED_WARN_THROTTLE_MS && (this.lastRefusedWarnAt.set(docId, now), rlog().warn(
+        "channel",
+        `sendCrdt refused (crdt topic not joined): doc=${docId} joined=${this.crdtJoined} \u2014 held, recovers on rejoin`
+      )), !1;
+    }
+    return this.send([this.crdtJoinRef, String(++this.ref), t, "crdt_msg", { doc_id: docId, b64 }]), !0;
   }
   /** Push a request frame on the crdt topic and resolve when the matching
    *  phx_reply (same ref) arrives. Rejects on error reply, timeout, or
@@ -2040,6 +2051,8 @@ var NoteChannel = class {
     }, base + jitter);
   }
 };
+_NoteChannel.REFUSED_WARN_THROTTLE_MS = 3e3;
+var NoteChannel = _NoteChannel;
 
 // src/crdt-op-dispatch.ts
 var TERMINAL_REASONS = /* @__PURE__ */ new Set([
@@ -22403,6 +22416,11 @@ var SAVE_NUDGE_DEBOUNCE_MS = 300, ViewerRefcount = class {
     this.controllers = /* @__PURE__ */ new Map();
     /** Fix wave 6: per-path trailing-debounce timers for `requestSaveForBoundPath`. */
     this.saveNudgeTimers = /* @__PURE__ */ new Map();
+    /** Coalesce guard: one file switch fires active-leaf-change + file-open
+     *  (± layout-change), each calling refresh(). Same-microtask duplicates
+     *  observe identical workspace state, so only the first need do the
+     *  O(open-leaves) rebind. Reset on the next microtask (see refresh). */
+    this.refreshCoalescing = !1;
     this.deps = deps, this.refcount = new ViewerRefcount((path) => {
       this.onLastViewerRelease(path).catch((e) => {
         var _a, _b;
@@ -22486,6 +22504,10 @@ var SAVE_NUDGE_DEBOUNCE_MS = 300, ViewerRefcount = class {
    *  Detaches frontmatter + reading hooks for views whose path changed before
    *  re-attaching, so the idempotency guard does not block the rebind. */
   refresh() {
+    if (this.refreshCoalescing) return;
+    this.refreshCoalescing = !0, queueMicrotask(() => {
+      this.refreshCoalescing = !1;
+    });
     let seen = /* @__PURE__ */ new Set();
     for (let leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
       let view = leaf.view;
@@ -22797,9 +22819,12 @@ function createCrdtWiring(deps) {
       var _a2;
       return (_a2 = noteIdMap.pathForId(noteId)) != null && _a2.endsWith(".canvas") ? "canvas" : "note";
     }
-  }), channel = new CrdtChannel({
+  }), unsentDocIds = /* @__PURE__ */ new Set(), channel = new CrdtChannel({
     manager,
-    send: (docId, frame) => deps.sendCrdt(docId, frame),
+    send: (docId, frame) => {
+      let ok = deps.sendCrdt(docId, frame);
+      return ok === !1 ? unsentDocIds.add(docId) : unsentDocIds.delete(docId), ok;
+    },
     // An inbound STEP2 that leaves the doc empty is the server's authoritative
     // "genuinely empty note" signal — materialize the file off the handshake
     // (not a timer) so a slow content STEP2 can never race a premature empty
@@ -22859,6 +22884,9 @@ function createCrdtWiring(deps) {
     onNoteYjsUpdate,
     drainStrandedFlushes,
     clearStrandHealAttempts: () => strandHealAttempts.clear(),
+    reEnrollUnsent: () => {
+      for (let id2 of [...unsentDocIds]) enrollment.enroll(id2);
+    },
     dispose
   };
 }
@@ -23847,7 +23875,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian25.Plugin
    * converged. CRDT socket only, no REST fallback.
    */
   async onCrdtTopicJoined() {
-    var _a, _b;
+    var _a, _b, _c;
     let now = Date.now();
     if (now - this.lastMapReconcileAt > _EngramSyncPlugin.RECONCILE_THROTTLE_MS) {
       this.lastMapReconcileAt = now;
@@ -23861,7 +23889,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian25.Plugin
         );
       }
     }
-    (_a = this.crdtEnrollment) == null || _a.resetAll(), (_b = this.crdtWiring) == null || _b.clearStrandHealAttempts(), this.reEnrollOpenCrdtNotes();
+    (_a = this.crdtEnrollment) == null || _a.resetAll(), (_b = this.crdtWiring) == null || _b.clearStrandHealAttempts(), this.reEnrollOpenCrdtNotes(), (_c = this.crdtWiring) == null || _c.reEnrollUnsent();
     try {
       await this.syncEngine.catchupViaSeqReplay();
     } catch (e) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -151,6 +151,13 @@ export class NoteChannel {
 	 *  that does not serve the crdt: topic replies with an error (handled below),
 	 *  keeping this false — which allows the legacy pushNote path to remain active. */
 	private crdtJoined = false;
+	/** Per-doc throttle for the "sendCrdt refused" warn. An offline window refuses
+	 *  many frames per doc in a burst (STEP1 + each keystroke's update); logging
+	 *  each one buried the signal. Log once per doc per window. The refused frame
+	 *  is NOT lost — the doc is re-enrolled on rejoin (wiring reEnrollUnsent) and
+	 *  the mutual handshake re-solicits its state, so this is a transient. */
+	private lastRefusedWarnAt = new Map<string, number>();
+	private static readonly REFUSED_WARN_THROTTLE_MS = 3000;
 	/**
 	 * The `ref` value sent with the crdt: topic phx_join frame.
 	 * Stored so handleMessage can distinguish a join-error reply (ref matches)
@@ -344,12 +351,20 @@ export class NoteChannel {
 	sendCrdt(docId: string, b64: string): boolean {
 		const t = this.crdtTopic;
 		if (!t || !this.crdtJoined) {
-			// A refused frame is a lost STEP1/update from the caller's view — say
-			// so, or a not-yet-joined window reads as a mystery deaf note later.
-			rlog().warn(
-				"channel",
-				`sendCrdt refused (crdt topic not joined): doc=${docId} joined=${this.crdtJoined}`,
-			);
+			// The frame is HELD, not lost: the doc is re-enrolled on rejoin and the
+			// mutual handshake re-solicits its state (wiring reEnrollUnsent). Throttle
+			// per doc so an offline burst logs once, not per refused frame.
+			const now = Date.now();
+			if (
+				now - (this.lastRefusedWarnAt.get(docId) ?? 0) >=
+				NoteChannel.REFUSED_WARN_THROTTLE_MS
+			) {
+				this.lastRefusedWarnAt.set(docId, now);
+				rlog().warn(
+					"channel",
+					`sendCrdt refused (crdt topic not joined): doc=${docId} joined=${this.crdtJoined} — held, recovers on rejoin`,
+				);
+			}
 			return false;
 		}
 		// join_ref MUST be the crdt: topic's join_ref. Phoenix routes channel

--- a/src/crdt/live/live-views.ts
+++ b/src/crdt/live/live-views.ts
@@ -94,6 +94,11 @@ export class CrdtLiveViews {
 	private readonly controllers = new Map<EditorView, EditorController>();
 	/** Fix wave 6: per-path trailing-debounce timers for `requestSaveForBoundPath`. */
 	private readonly saveNudgeTimers = new Map<string, number>();
+	/** Coalesce guard: one file switch fires active-leaf-change + file-open
+	 *  (± layout-change), each calling refresh(). Same-microtask duplicates
+	 *  observe identical workspace state, so only the first need do the
+	 *  O(open-leaves) rebind. Reset on the next microtask (see refresh). */
+	private refreshCoalescing = false;
 
 	constructor(deps: CrdtLiveViewsDeps) {
 		this.deps = deps;
@@ -194,6 +199,16 @@ export class CrdtLiveViews {
 	 *  Detaches frontmatter + reading hooks for views whose path changed before
 	 *  re-attaching, so the idempotency guard does not block the rebind. */
 	refresh(): void {
+		// Coalesce duplicate same-tick calls (see refreshCoalescing). The FIRST
+		// call runs synchronously as before; a duplicate within the same microtask
+		// checkpoint is skipped. Reset via queueMicrotask so any later-turn refresh
+		// (observing genuinely new workspace state) always runs — this never defers
+		// or drops a refresh, it only elides a redundant re-run of identical state.
+		if (this.refreshCoalescing) return;
+		this.refreshCoalescing = true;
+		queueMicrotask(() => {
+			this.refreshCoalescing = false;
+		});
 		const seen = new Set<EditorView>();
 		for (const leaf of this.deps.app.workspace.getLeavesOfType("markdown")) {
 			const view = leaf.view;

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -92,12 +92,20 @@ export interface CrdtWiring {
 	 *  notes so an edit made to a note that was then closed/switched-away-from
 	 *  still converges via the mutual STEP1 handshake (switch-away data-loss). */
 	reEnrollUnsent: () => void;
+	/** Drop a doc from the unsent-tracking set. Call when the note is deleted so a
+	 *  since-deleted note is never re-enrolled on the next rejoin (a spurious STEP1
+	 *  that could race delete-wins / resurrect the note). */
+	forgetUnsent: (docId: string) => void;
 	/** Clear the pending strand-heal timer (call from the plugin's onunload). */
 	dispose: () => void;
 }
 
 const DEFAULT_STRAND_HEAL_DEBOUNCE_MS = 750;
 const STRAND_HEAL_MAX_ATTEMPTS = 5;
+/** Cap on the unsent-doc tracking set. Mirrors CrdtOpQueue.MAX_QUEUE: bounds
+ *  memory across a long outage; past the cap the oldest tracked doc is evicted
+ *  (it reconverges via the normal reconnect catch-up either way). */
+const MAX_UNSENT_DOCS = 500;
 
 /** Pure retry/give-up decision for one strand-heal drain pass (e2e test_43
  *  burst mechanism, round 3 — see `drainStrandedFlushes`). Given the ids
@@ -313,8 +321,18 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		send: (docId, frame) => {
 			const ok = deps.sendCrdt(docId, frame);
 			// sendCrdt returns false ONLY on a refused (topic-not-joined) frame.
-			if (ok === false) unsentDocIds.add(docId);
-			else unsentDocIds.delete(docId);
+			if (ok === false) {
+				if (!unsentDocIds.has(docId) && unsentDocIds.size >= MAX_UNSENT_DOCS) {
+					// Evict the single oldest (Set preserves insertion order).
+					for (const oldest of unsentDocIds) {
+						unsentDocIds.delete(oldest);
+						break;
+					}
+				}
+				unsentDocIds.add(docId);
+			} else {
+				unsentDocIds.delete(docId);
+			}
 			return ok;
 		},
 		// An inbound STEP2 that leaves the doc empty is the server's authoritative
@@ -445,6 +463,9 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 			// Snapshot: enroll() → startSync succeeds → clears the id from the set;
 			// iterate a copy so that mutation can't skip entries mid-loop.
 			for (const id of [...unsentDocIds]) enrollment.enroll(id);
+		},
+		forgetUnsent: (docId) => {
+			unsentDocIds.delete(docId);
 		},
 		dispose,
 	};

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -87,6 +87,11 @@ export interface CrdtWiring {
 	 *  against the now-current map, not counters left over from before the drift
 	 *  was fixed (final review MINOR-6). */
 	clearStrandHealAttempts: () => void;
+	/** Re-enroll every doc whose live update was refused while the crdt: topic was
+	 *  unjoined (offline / mid-reconnect). Call on rejoin AFTER re-enrolling open
+	 *  notes so an edit made to a note that was then closed/switched-away-from
+	 *  still converges via the mutual STEP1 handshake (switch-away data-loss). */
+	reEnrollUnsent: () => void;
 	/** Clear the pending strand-heal timer (call from the plugin's onunload). */
 	dispose: () => void;
 }
@@ -294,9 +299,24 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		docKind: (noteId) => (noteIdMap.pathForId(noteId)?.endsWith(".canvas") ? "canvas" : "note"),
 	});
 
+	// Docs whose live update was refused because the crdt: topic was not joined
+	// (offline / mid-reconnect). Tracked so a note edited while the socket was
+	// down — then SWITCHED AWAY FROM before reconnect, so reEnrollOpenCrdtNotes
+	// (open leaves only) misses it — still gets re-enrolled on rejoin. The mutual
+	// STEP1 handshake then solicits the held struct and it converges (the #299
+	// recovery path, widened past still-open notes). Cleared once a later send
+	// for the doc succeeds (it reached the server).
+	const unsentDocIds = new Set<string>();
+
 	const channel = new CrdtChannel({
 		manager,
-		send: (docId, frame) => deps.sendCrdt(docId, frame),
+		send: (docId, frame) => {
+			const ok = deps.sendCrdt(docId, frame);
+			// sendCrdt returns false ONLY on a refused (topic-not-joined) frame.
+			if (ok === false) unsentDocIds.add(docId);
+			else unsentDocIds.delete(docId);
+			return ok;
+		},
 		// An inbound STEP2 that leaves the doc empty is the server's authoritative
 		// "genuinely empty note" signal — materialize the file off the handshake
 		// (not a timer) so a slow content STEP2 can never race a premature empty
@@ -421,6 +441,11 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		onNoteYjsUpdate,
 		drainStrandedFlushes,
 		clearStrandHealAttempts: () => strandHealAttempts.clear(),
+		reEnrollUnsent: () => {
+			// Snapshot: enroll() → startSync succeeds → clears the id from the set;
+			// iterate a copy so that mutation can't skip entries mid-loop.
+			for (const id of [...unsentDocIds]) enrollment.enroll(id);
+		},
 		dispose,
 	};
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1685,6 +1685,12 @@ export default class EngramSyncPlugin extends Plugin {
 		// counter left over from before the drift was fixed.
 		this.crdtWiring?.clearStrandHealAttempts();
 		this.reEnrollOpenCrdtNotes();
+		// reEnrollOpenCrdtNotes only re-enrolls notes still open in an editor. A
+		// note edited while the socket was down and then switched away from has no
+		// leaf, so its held offline edit would never be re-solicited. Re-enroll any
+		// doc whose live update was refused while unjoined so the mutual handshake
+		// recovers it (switch-away data-loss class).
+		this.crdtWiring?.reEnrollUnsent();
 		// Sole convergence path on (re)connect: replay the seq-ordered op-log from
 		// our persisted cursor. Every op missed while away is delivered IN ORDER
 		// with FULL content, so it can't pend the way the old state-vector delta

--- a/src/main.ts
+++ b/src/main.ts
@@ -629,6 +629,11 @@ export default class EngramSyncPlugin extends Plugin {
 				if (file instanceof TFolder) {
 					void this.syncEngine.handleFolderDelete(file);
 				} else {
+					// Resolve the note_id BEFORE handleDelete clears the map, and drop
+					// it from the unsent-tracking set so a note deleted while offline is
+					// not re-enrolled (a spurious STEP1 racing delete-wins) on rejoin.
+					const noteId = this.noteIdMap.get(file.path);
+					if (noteId) this.crdtWiring?.forgetUnsent(noteId);
 					void this.syncEngine.handleDelete(file);
 				}
 			}),

--- a/tests/crdt-live-views.test.ts
+++ b/tests/crdt-live-views.test.ts
@@ -230,3 +230,31 @@ describe("CrdtLiveViews.requestSaveForBoundPath (fix wave 6)", () => {
 		expect(requestSave).not.toHaveBeenCalled();
 	});
 });
+
+describe("CrdtLiveViews.refresh() coalescing", () => {
+	it("skips a duplicate same-microtask refresh(), runs again the next tick", async () => {
+		// getLeavesOfType is the first thing refresh() does; count it to see how
+		// many rebind passes actually ran. Empty list keeps the pass a no-op.
+		const getLeaves = mock(() => [] as Array<{ view: unknown }>);
+		const lv = new CrdtLiveViews({
+			app: { workspace: { getLeavesOfType: getLeaves } } as never,
+			manager: { getText: async () => "", closeDoc: () => {} } as never,
+			enrollment: {} as never,
+			resolveId: (p: string) => `id:${p}`,
+			flushToDisk: async () => {},
+		});
+
+		// One file switch fires active-leaf-change + file-open (+ layout-change):
+		// three synchronous refresh() calls, one real rebind pass.
+		lv.refresh();
+		lv.refresh();
+		lv.refresh();
+		expect(getLeaves.mock.calls.length).toBe(1);
+
+		// The queueMicrotask reset clears the guard, so a genuinely-later refresh
+		// (observing new workspace state) is never dropped.
+		await new Promise((r) => setTimeout(r, 0));
+		lv.refresh();
+		expect(getLeaves.mock.calls.length).toBe(2);
+	});
+});

--- a/tests/crdt/wiring.test.ts
+++ b/tests/crdt/wiring.test.ts
@@ -437,3 +437,53 @@ test("inbound frame for an unknown id strands, then heals on reconcile", async (
 
 	await destroy(a, b);
 });
+
+// A note edited then DELETED while offline must be pruned from the unsent set,
+// so the reconnect re-enroll (reEnrollUnsent) does not fire a spurious STEP1 for
+// a dead doc. forgetUnsent (wired from the plugin's vault delete handler) is the
+// prune. reEnrollUnsent calls enrollment.enroll for each tracked id, so a spy on
+// enroll is the observable "would re-open a room" signal.
+test("forgetUnsent prunes a doc so reEnrollUnsent skips it (offline-delete cleanup)", async () => {
+	const map = new NoteIdMap();
+	const noteId = map.getOrMint("gone.md");
+	const joined = false; // crdt topic not joined → every frame is refused (offline)
+	const wiring = createCrdtWiring({
+		noteIdMap: map,
+		syncEngine: {
+			flushFromCrdt: async () => true,
+			isUnchangedSynced: () => false,
+			materializeEmptyDiscovered: async () => {},
+			reconcileNoteIdMapFromManifest: async () => 0,
+			isSyncBlocked: () => false,
+			ensureNoteIdMapped: () => {},
+			discoverAnnouncedNote: async () => {},
+			commitCrdtConvergence: async () => {},
+		},
+		sendCrdt: () => joined,
+		isBound: () => false,
+		strandHealDebounceMs: 100_000,
+		dbPrefix: "forget-unsent",
+	});
+
+	// Offline edit: the update is produced but sendCrdt refuses it → id is tracked.
+	await wiring.manager.applyLocalEdit(noteId, "edited while offline\n");
+	await sleep(30);
+
+	// Deleted while offline → pruned. reEnrollUnsent must NOT re-enroll it.
+	const enrollAfterForget = spyOn(wiring.enrollment, "enroll");
+	wiring.forgetUnsent(noteId);
+	wiring.reEnrollUnsent();
+	expect(enrollAfterForget).not.toHaveBeenCalled();
+	enrollAfterForget.mockRestore();
+
+	// Control: a still-tracked (not forgotten) id IS re-enrolled on rejoin.
+	await wiring.manager.applyLocalEdit(noteId, "edited offline again\n");
+	await sleep(30);
+	const enrollControl = spyOn(wiring.enrollment, "enroll");
+	wiring.reEnrollUnsent();
+	expect(enrollControl).toHaveBeenCalledWith(noteId);
+	enrollControl.mockRestore();
+
+	wiring.dispose();
+	await wiring.manager.destroy();
+});

--- a/tests/sim/regressions.test.ts
+++ b/tests/sim/regressions.test.ts
@@ -43,6 +43,7 @@ import {
 	equalSeqFence,
 	genesisWipe,
 	offlineBoundEditRecovers,
+	offlineEditSwitchAwayRecovers,
 	test85MissedDeliveryLocalPush,
 } from "./scenarios";
 
@@ -105,6 +106,26 @@ test("#299 live-bound offline edit recovers on reconnect (mutual handshake)", as
 		cleanup(r.topology);
 	}
 	expect(true).toBe(true);
+});
+
+// #299b — offline edit + SWITCH AWAY recovers on reconnect (switch-away class).
+//
+// Prod "moving between files, only some edits make it": an edit typed while the
+// socket is down, to a note then CLOSED before reconnect, is stranded because
+// reEnrollOpenCrdtNotes only re-enrolls still-open notes.
+//
+// Assert on SERVER CONTENT (not assertConverged): if reconnect instead reverted
+// A's edit, all replicas would land on "base" and a convergence check would
+// FALSELY pass. The server-content assertion fails whether the edit is dropped
+// OR reverted. Green ONLY with wiring.reEnrollUnsent() on the rejoin path.
+test("#299b offline edit + switch-away reaches the server on reconnect", async () => {
+	const r = await offlineEditSwitchAwayRecovers();
+	try {
+		const srv = r.topology.server.state().notes.get(r.notePath);
+		expect(srv?.content ?? "").toContain("offline edit by A");
+	} finally {
+		cleanup(r.topology);
+	}
 });
 
 // #288 genesis-wipe — DOCUMENTED-BOUNDARY PIN (P1 Task 7b: exercise the

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -393,7 +393,12 @@ export class Replica {
 				const f = app.vault.getAbstractFileByPath(p);
 				if (f instanceof TFolder)
 					void engine.handleFolderDelete(f); // main.ts:610-611
-				else if (f instanceof TFile) void engine.handleDelete(f); // main.ts:613
+				else if (f instanceof TFile) {
+					// Mirror main.ts: drop the id from the unsent set before delete.
+					const nid = noteIdMap.get(p);
+					if (nid) wiring.forgetUnsent(nid);
+					void engine.handleDelete(f); // main.ts:613
+				}
 			},
 			onRename: (oldP, newP) => {
 				const f = app.vault.getAbstractFileByPath(newP);

--- a/tests/sim/replica.ts
+++ b/tests/sim/replica.ts
@@ -603,6 +603,9 @@ export class Replica {
 			for (const p of boundPaths) {
 				wiring.enrollment.enroll(noteIdMap.getOrMint(p));
 			}
+			// Mirror main.ts: also re-enroll any doc whose live update was refused
+			// while unjoined, so an edit to a since-closed note still converges.
+			wiring.reEnrollUnsent();
 			try {
 				await engine.catchupViaSeqReplay();
 			} catch {

--- a/tests/sim/scenarios.ts
+++ b/tests/sim/scenarios.ts
@@ -230,3 +230,53 @@ export async function offlineBoundEditRecovers(seed = 299): Promise<Test299Resul
 
 	return { topology: t, notePath };
 }
+
+// ---------------------------------------------------------------------------
+// Scenario 5 — offline edit + SWITCH AWAY, recovered on reconnect (the
+// switch-away data-loss class; prod "moving between files, only some make it").
+//
+// Like #299, but A CLOSES the note (switches to another file) before the socket
+// recovers. reEnrollOpenCrdtNotes re-enrolls only notes still open in an editor,
+// so the switched-away note is never re-solicited and its offline edit strands
+// on A's disk — the server row stays "base".
+//
+// DIFFERENTIAL PROOF (source overlay): remove the wiring.reEnrollUnsent() call
+// from the rejoin path (main.ts / replica.ts onCrdtTopicJoined) and the server
+// never receives A's edit — DIVERGES. With it, re-enrolling the refused doc
+// re-opens it from IndexedDB, fires STEP1, and the mutual handshake converges.
+// ---------------------------------------------------------------------------
+
+export interface SwitchAwayResult {
+	topology: Topology;
+	notePath: string;
+	offlineEdit: string;
+}
+
+export async function offlineEditSwitchAwayRecovers(seed = 911): Promise<SwitchAwayResult> {
+	const t = await boot(seed, ["A", "B"], { genesisEmptyDoc: true });
+	const [a] = t.replicas;
+	const notePath = "switch-away.md";
+	await a.createNote(notePath, "base\n");
+	await t.scheduler.drain();
+
+	// A opens the note (live-bound), goes offline, and edits it — the delta is
+	// refused (crdt topic not joined) and held only in A's Y.Doc.
+	await a.openNote(notePath);
+	await t.scheduler.drain();
+	await a.goOffline();
+	await t.scheduler.drain();
+	const offlineEdit = "base\noffline edit by A\n";
+	await a.editNote(notePath, offlineEdit);
+	await t.scheduler.drain();
+
+	// A switches away: the editor closes, the note is no longer live-bound.
+	await a.closeNote(notePath);
+	await t.scheduler.drain();
+
+	// Reconnect: rejoin re-enrolls still-open notes AND (with the fix) any doc
+	// whose update was refused while unjoined — recovering this one.
+	await a.goOnline();
+	await t.scheduler.drain();
+
+	return { topology: t, notePath, offlineEdit };
+}


### PR DESCRIPTION
## Problem

Prod report: *"moving between files and making edits, only some make it to the server."* Confirmed in Loki — `[client:channel] sendCrdt refused (crdt topic not joined): joined=false` on the user's device, across many notes, always preceded by a socket drop (`heartbeat unanswered` / `net::ERR_NETWORK_CHANGED`).

**Root cause:** an edit typed while the CRDT socket is down is refused by `channel.sendCrdt` (topic not joined) and dropped. The rejoin recovery (`reEnrollOpenCrdtNotes`) only re-enrolls notes **still open in an editor**, so an edit made to a note then **switched away from** is never re-solicited by the mutual handshake — stranded on local disk, never reaching the server. #299's recovery covers only still-open notes; this is the switch-away gap.

Reproduced deterministically on current `main` in the sim tier (faithful model server): #299 (note stays open) recovers, but close-before-reconnect strands the edit.

## Changes

**A — the fix.** Track docIds whose `sendCrdt` was refused while unjoined (shared `wiring.ts` send wrapper); on the `crdt:` rejoin, re-enroll them in addition to open leaves. `startSync` reopens the doc from IndexedDB, fires STEP1, and the mutual handshake re-solicits the held struct → converges. Cleared when a later send for the doc succeeds.

**B — lag.** One file switch fires `crdtLiveViews.refresh()` 2–3× (active-leaf-change + file-open + layout-change). Coalesce same-microtask duplicates — the first call runs synchronously as before; duplicates observing identical workspace state skip the O(open-leaves) rebind. Never defers or drops a refresh that sees new state.

**C — log noise.** Throttle the `sendCrdt refused` warn per doc (an offline burst logs once, not per frame) and reword it — with A the frame is recovered on rejoin, so it reads as a transient, not silent loss.

## Test

New differential sim gate **#299b switch-away** (`tests/sim/`): RED without `wiring.reEnrollUnsent()` on the rejoin path, GREEN with it. Asserts the edit reaches the **server** (a plain convergence check would false-green if reconnect *reverted* the edit).

- `bun run build` clean · **2227 pass / 1 skip / 0 fail** (incl. random fuzz sim) · biome + eslint clean · no version bumps.

## Not in this PR

- **Deeper lag** (scope `refresh()` to the focused leaf; reconsider per-open `healNoteOnOpen`) needs real-app profiling before touching this race-sensitive code — deferred.
- **The real Loki bloat** is the mTLS client cert on every shipped client log (`Engram.Logs`, backend repo) — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)