### PR TITLE
fix(crdt): push held state up on WS-reconnect rejoin (reEnrollUnsent)

### DIFF
--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -462,7 +462,17 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		reEnrollUnsent: () => {
 			// Snapshot: enroll() → startSync succeeds → clears the id from the set;
 			// iterate a copy so that mutation can't skip entries mid-loop.
-			for (const id of [...unsentDocIds]) enrollment.enroll(id);
+			for (const id of [...unsentDocIds]) {
+				// enroll re-fires STEP1 — a PULL. The real backend never STEP1s back
+				// (sync.ts:785-789), so the pull alone can't re-solicit an edit refused
+				// during the joined=false gap: the client Y.Doc stays AHEAD of the
+				// server and commitCrdtConvergence defers forever (prod: "only some
+				// edits make it"). Also PUSH the held state up — mirrors the create-ack
+				// rejoin (sync.ts:800 flushHeldEditsOnCreateAck). Idempotent Yjs merge
+				// on the existing lineage, so no doubling (manager.ts:553-561).
+				enrollment.enroll(id);
+				void manager.flushHeldState(id);
+			}
 		},
 		forgetUnsent: (docId) => {
 			unsentDocIds.delete(docId);

--- a/tests/crdt/wiring.test.ts
+++ b/tests/crdt/wiring.test.ts
@@ -487,3 +487,52 @@ test("forgetUnsent prunes a doc so reEnrollUnsent skips it (offline-delete clean
 	wiring.dispose();
 	await wiring.manager.destroy();
 });
+
+// An edit refused while the crdt topic was unjoined (offline / a reconnect or
+// plugin-reload gap) lands in the Y.Doc but never on the wire. On rejoin,
+// reEnrollUnsent must not only re-enroll (STEP1, a PULL) but also PUSH the held
+// state up via manager.flushHeldState — mirroring the create-ack path
+// (sync.ts:800 flushHeldEditsOnCreateAck). Without the push, a real PULL-ONLY
+// backend (sync.ts:785-789 "the backend never STEP1s back") never receives the
+// held edit: the client Y.Doc stays ahead of the server and commitCrdtConvergence
+// defers forever (prod: "only some edits make it to the server", projLen>stagedLen).
+// The sim tier can't gate this (its ModelServer sends a mutual STEP1 AND its async
+// y-indexeddb replay re-emits the held update on reconnect — two fidelity artifacts
+// that mask it), so this seam-level spy is the discriminating gate. Spy pattern
+// mirrors the enroll spy above.
+test("reEnrollUnsent pushes held state up (flushHeldState) for a doc refused while offline", async () => {
+	const map = new NoteIdMap();
+	const noteId = map.getOrMint("held.md");
+	const joined = false; // crdt topic not joined → the edit is refused and held
+	const wiring = createCrdtWiring({
+		noteIdMap: map,
+		syncEngine: {
+			flushFromCrdt: async () => true,
+			isUnchangedSynced: () => false,
+			materializeEmptyDiscovered: async () => {},
+			reconcileNoteIdMapFromManifest: async () => 0,
+			isSyncBlocked: () => false,
+			ensureNoteIdMapped: () => {},
+			discoverAnnouncedNote: async () => {},
+			commitCrdtConvergence: async () => {},
+		},
+		sendCrdt: () => joined,
+		isBound: () => false,
+		strandHealDebounceMs: 100_000,
+		dbPrefix: "reenroll-flush",
+	});
+
+	// Offline edit: the update is produced but sendCrdt refuses it → id is tracked
+	// in the unsent set (the prod "refused while joined=false" population).
+	await wiring.manager.applyLocalEdit(noteId, "held edit reaches the server\n");
+	await sleep(30);
+
+	// Rejoin: reEnrollUnsent must PUSH the held state (not just STEP1-pull).
+	const flushSpy = spyOn(wiring.manager, "flushHeldState");
+	wiring.reEnrollUnsent();
+	expect(flushSpy).toHaveBeenCalledWith(noteId);
+	flushSpy.mockRestore();
+
+	wiring.dispose();
+	await wiring.manager.destroy();
+});


### PR DESCRIPTION
## The bug (root-caused from prod diagnostics)

An edit made while the crdt topic is unjoined — offline, or the brief `joined=false` gap after a reconnect / plugin reload — lands in the Y.Doc but its `sendCrdt` frame is **refused and dropped**. On rejoin, `reEnrollUnsent` only re-enrolled (`enroll` → STEP1, a **PULL**). The real backend never STEP1s back (`sync.ts:785-789`), so the pull can't re-solicit the held edit: the client Y.Doc stays **ahead** of the server and `commitCrdtConvergence` **defers forever**.

Prod evidence (Loki): `converge: commit DEFERRED _AI Instructions.md projLen=10261 … stagedLen=10257 …` — the client is 4 chars ahead, the note never converges, and it re-handshakes "attempt 1" every visit. User symptom: *"moving between files, only some edits make it to the server"* (the stuck notes are the open working files).

## The fix

`reEnrollUnsent` now also **pushes** the held state up via `manager.flushHeldState(id)` — mirroring the create-ack rejoin path (`sync.ts:800` `flushHeldEditsOnCreateAck`). Same primitive that path already trusts: `Y.encodeStateAsUpdate` on the **existing lineage** through the same `onUpdate` transport = an idempotent Yjs merge delivering only the missing ops.

**No doubling.** Certified by design + docstring (`manager.ts:553-561`, `sync.ts:793-796`): it reuses the existing doc lineage, never seeds a fresh one. This is the automated form of the proven "type a space + delete" workaround.

## Testing (TDD)

`tests/crdt/wiring.test.ts` spies `flushHeldState` on the **real** manager after an offline-refused edit + `reEnrollUnsent`. **RED** pre-fix (never called) → **GREEN** post-fix. Mirrors the existing `enroll`-spy test alongside it.

The sim tier **cannot** gate this class — its ModelServer answers a client STEP1 with a mutual STEP1, *and* its async y-indexeddb replay re-emits the held update on reconnect; both are fidelity artifacts that mask the prod stall (documented in the test). The full CRDT + sim suites (191 tests, incl. the random differential/doubling guard) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)