### PR TITLE
fix(crdt): persistent per-note Y.Doc lifetime (bounded LRU) to stop switch-away edit loss

### DIFF
--- a/main.js
+++ b/main.js
@@ -16768,6 +16768,20 @@ var _CrdtManager = class _CrdtManager {
      *  it to callbacks. */
     this.docs = /* @__PURE__ */ new Map();
     /**
+     * LRU recency of resident doc IDs — least-recently-used first, most-recent
+     * last. Touched on every `entry()` access (mint or cache hit). Drives
+     * cap-pressure eviction so the resident set stays bounded WITHOUT tearing a
+     * doc down the moment its editor view closes (which caused the switch-away
+     * churn/data-loss). Same key space as `docs`.
+     */
+    this.lru = [];
+    /**
+     * Doc IDs that must never be evicted regardless of LRU position — a live
+     * editor is bound to them. `CrdtLiveViews` calls `protect`/`unprotect` on
+     * bind/release. Same key space as `docs`.
+     */
+    this.protectedIds = /* @__PURE__ */ new Set();
+    /**
      * Per-session set of doc IDs for which at least one inbound server sync
      * frame has been applied (i.e. the STEP2 handshake has completed for the
      * path). Keyed by docId — same key space as `docs`.
@@ -16884,6 +16898,43 @@ var _CrdtManager = class _CrdtManager {
    *  orphaned mint doc was torn down (removeDoc) after a genesis adopt. */
   hasDoc(noteId) {
     return this.docs.has(this.docId(noteId));
+  }
+  /** Pin `noteId`'s doc in the resident set: it must not be LRU-evicted while
+   *  a live editor is bound to it. `CrdtLiveViews` calls this on bind. */
+  protect(noteId) {
+    this.protectedIds.add(this.docId(noteId));
+  }
+  /** Release the pin from `protect`. The doc stays resident (recently used) and
+   *  is only freed later under cap pressure. Called on editor unbind/release. */
+  unprotect(noteId) {
+    this.protectedIds.delete(this.docId(noteId));
+  }
+  /** Mark `id` most-recently-used, then evict the least-recently-used resident
+   *  docs until the set fits `residentCap`. Never evicts a protected
+   *  (live-bound) or in-flight doc, nor `id` itself. Eviction reuses closeDoc's
+   *  persist-safe teardown (IndexedDB store kept — the note re-hydrates on next
+   *  open), so nothing is lost. */
+  touchLru(id2) {
+    var _a, _b;
+    let at = this.lru.indexOf(id2);
+    at !== -1 && this.lru.splice(at, 1), this.lru.push(id2);
+    let cap = (_a = this.opts.residentCap) != null ? _a : 64;
+    if (!(this.docs.size <= cap))
+      for (let i = 0; i < this.lru.length && this.docs.size > cap; ) {
+        let cand = this.lru[i];
+        if (cand === void 0 || cand === id2 || this.protectedIds.has(cand) || ((_b = this.inFlightOps.get(cand)) != null ? _b : 0) > 0 || !this.docs.has(cand)) {
+          i++;
+          continue;
+        }
+        this.closeDoc(cand);
+      }
+  }
+  /** Remove `id` from the LRU + protected bookkeeping. Called from the single
+   *  teardown choke point so every destroyer (closeDoc / removeDoc / destroy /
+   *  flatten / eviction) keeps the resident-set metadata consistent. */
+  forgetResident(id2) {
+    let at = this.lru.indexOf(id2);
+    at !== -1 && this.lru.splice(at, 1), this.protectedIds.delete(id2);
   }
   /**
    * Apply a disk-read content string into the doc's Y.Text and frontmatter
@@ -17089,7 +17140,7 @@ var _CrdtManager = class _CrdtManager {
    *  differ there (closeDoc/removeDoc clear both, flattenIfBloated keeps
    *  them for the re-opened entry, destroy() clears in bulk). */
   async teardownEntry(id2, e, opts) {
-    this.docs.delete(id2), e.doc.destroy(), opts.clearData && await e.persistence.clearData(), await e.persistence.destroy();
+    this.docs.delete(id2), this.forgetResident(id2), e.doc.destroy(), opts.clearData && await e.persistence.clearData(), await e.persistence.destroy();
   }
   closeDoc(noteId) {
     var _a;
@@ -17205,7 +17256,7 @@ var _CrdtManager = class _CrdtManager {
     var _a, _b, _c;
     let id2 = this.docId(noteId), cached = this.docs.get(id2);
     if (cached)
-      return await cached.ready, cached;
+      return this.touchLru(id2), await cached.ready, cached;
     let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), kind = (_c = (_b = (_a = this.opts).docKind) == null ? void 0 : _b.call(_a, noteId)) != null ? _c : "note", text2 = doc2.getText(CONTENT_KEY), ready = persistence.whenSynced.then(() => {
     }), hasContent2 = () => kind === "canvas" ? !canvasIsEmpty(doc2) : text2.length > 0, entry = {
       doc: doc2,
@@ -17240,7 +17291,7 @@ var _CrdtManager = class _CrdtManager {
       }).finally(() => {
         this.pendingFlush.get(id2) === flush && this.pendingFlush.delete(id2);
       });
-    }), this.docs.set(id2, entry), await ready, hasContent2() && (entry.hadContent = !0), entry;
+    }), this.docs.set(id2, entry), this.touchLru(id2), await ready, hasContent2() && (entry.hadContent = !0), entry;
   }
   /**
    * Returns true when the Y.Text already carries CRDT history (content
@@ -19386,13 +19437,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  have opened the note in the editor while the apply was in flight, in
    *  which case that room now owns the doc's lifecycle and it must stay
    *  resident. */
-  hibernateIfIdle(path, noteId) {
-    if (this.crdt && !this.isLiveBound((0, import_obsidian20.normalizePath)(path)))
-      try {
-        this.crdt.closeDoc(noteId);
-      } catch (e) {
-        devLog().log("crdt", `hibernateIfIdle: closeDoc ${noteId} failed \u2014 ${errMsg(e)}`);
-      }
+  hibernateIfIdle(_path, _noteId) {
   }
   setCrdtCatchupSince(fn) {
     this.crdtCatchupSince = fn;
@@ -22482,16 +22527,19 @@ var SAVE_NUDGE_DEBOUNCE_MS = 300, ViewerRefcount = class {
       devLog().log("crdt", `requestSaveForBoundPath failed for ${path}: ${errMsg(e)}`);
     }
   }
-  /** The last viewer of `path` left: persist the current Y.Text to disk, then
-   *  free the doc so the resident set stays bounded by open notes (closeDoc was
-   *  dead code before this — a Y.Doc leaked for every note ever visited in a
-   *  session). The IndexedDB store is preserved, so the note re-hydrates on next
-   *  open or remote update; no data loss. Skips the free if a new viewer bound
-   *  during the async flush (re-open race) — destroying a doc the editor just
-   *  re-bound to would break live sync. Returns the promise for tests. */
+  /** The last viewer of `path` left: persist the current Y.Text to disk and
+   *  UNPROTECT the doc so it becomes eligible for later cap-pressure eviction —
+   *  but do NOT tear it down now. Closing the doc on view-release caused the
+   *  switch-away churn: getDoc() (startSync/handleFrame) immediately re-minted
+   *  it, and rapid file switching produced a close<->re-mint storm that bound
+   *  the editor to the wrong/empty doc and stranded edits. The doc now stays
+   *  resident (Relay-style) until the LRU working set overflows, so switching
+   *  back to a recent note reuses the SAME stable doc. Skips the unprotect if a
+   *  new viewer bound during the async flush (re-open race). Returns the
+   *  promise for tests. */
   async onLastViewerRelease(path) {
     let noteId = this.deps.resolveId(path), text2 = await this.deps.manager.getText(noteId);
-    await this.deps.flushToDisk(path, text2), this.refcount.isBound(path) || this.deps.manager.closeDoc(noteId);
+    await this.deps.flushToDisk(path, text2), this.refcount.isBound(path) || this.deps.manager.unprotect(noteId);
   }
   /** Open (or get cached) the path's Y.Text from the CRDT manager, resolving
    *  (minting if needed) the note_id that actually keys the doc (Task 6). */
@@ -22521,7 +22569,9 @@ var SAVE_NUDGE_DEBOUNCE_MS = 300, ViewerRefcount = class {
       ctrl || (ctrl = new EditorController({
         getYText: (p) => this.getYText(p),
         awareness: () => this.localAwareness,
-        onBind: (p, id2) => this.refcount.bind(p, id2),
+        onBind: (p, id2) => {
+          this.refcount.bind(p, id2), this.deps.manager.protect(this.deps.resolveId(p));
+        },
         onRelease: (p, id2) => this.refcount.release(p, id2),
         // The MdView owning this cm is stable for the cm's lifetime, but the
         // FILE it displays is not (Obsidian reuses views across note

--- a/src/crdt/live/live-views.ts
+++ b/src/crdt/live/live-views.ts
@@ -173,18 +173,21 @@ export class CrdtLiveViews {
 		}
 	}
 
-	/** The last viewer of `path` left: persist the current Y.Text to disk, then
-	 *  free the doc so the resident set stays bounded by open notes (closeDoc was
-	 *  dead code before this — a Y.Doc leaked for every note ever visited in a
-	 *  session). The IndexedDB store is preserved, so the note re-hydrates on next
-	 *  open or remote update; no data loss. Skips the free if a new viewer bound
-	 *  during the async flush (re-open race) — destroying a doc the editor just
-	 *  re-bound to would break live sync. Returns the promise for tests. */
+	/** The last viewer of `path` left: persist the current Y.Text to disk and
+	 *  UNPROTECT the doc so it becomes eligible for later cap-pressure eviction —
+	 *  but do NOT tear it down now. Closing the doc on view-release caused the
+	 *  switch-away churn: getDoc() (startSync/handleFrame) immediately re-minted
+	 *  it, and rapid file switching produced a close<->re-mint storm that bound
+	 *  the editor to the wrong/empty doc and stranded edits. The doc now stays
+	 *  resident (Relay-style) until the LRU working set overflows, so switching
+	 *  back to a recent note reuses the SAME stable doc. Skips the unprotect if a
+	 *  new viewer bound during the async flush (re-open race). Returns the
+	 *  promise for tests. */
 	private async onLastViewerRelease(path: string): Promise<void> {
 		const noteId = this.deps.resolveId(path);
 		const text = await this.deps.manager.getText(noteId);
 		await this.deps.flushToDisk(path, text);
-		if (!this.refcount.isBound(path)) this.deps.manager.closeDoc(noteId);
+		if (!this.refcount.isBound(path)) this.deps.manager.unprotect(noteId);
 	}
 
 	/** Open (or get cached) the path's Y.Text from the CRDT manager, resolving
@@ -223,7 +226,12 @@ export class CrdtLiveViews {
 				ctrl = new EditorController({
 					getYText: (p) => this.getYText(p),
 					awareness: () => this.localAwareness,
-					onBind: (p, id) => this.refcount.bind(p, id),
+					onBind: (p, id) => {
+						this.refcount.bind(p, id);
+						// Pin the doc while a live editor is bound so cap-pressure
+						// eviction can never yank it out from under the binding.
+						this.deps.manager.protect(this.deps.resolveId(p));
+					},
 					onRelease: (p, id) => this.refcount.release(p, id),
 					// The MdView owning this cm is stable for the cm's lifetime, but the
 					// FILE it displays is not (Obsidian reuses views across note

--- a/src/crdt/manager.ts
+++ b/src/crdt/manager.ts
@@ -138,6 +138,18 @@ export interface CrdtManagerOptions {
 	 * test unchanged.
 	 */
 	docKind?: (noteId: string) => DocKind;
+	/**
+	 * Max number of Y.Docs kept resident in memory (the LRU working set).
+	 * A note's doc lives for as long as it fits here — it is NEVER torn down
+	 * merely because its editor view closed. This is the Relay-style persistent
+	 * doc lifetime: rapid file switching among a handful of notes keeps every
+	 * one of them resident, so the editor stays bound to ONE stable doc instead
+	 * of racing a close<->re-mint storm. Eviction only happens under cap
+	 * pressure, and never for a protected (live-bound) or in-flight doc.
+	 * Default 64 — comfortably above any realistic set of simultaneously-open
+	 * tabs, bounded enough to cap memory on a long browsing session.
+	 */
+	residentCap?: number;
 }
 
 interface Entry {
@@ -169,6 +181,20 @@ export class CrdtManager {
 	 *  here. The manager itself never interprets the string, it only forwards
 	 *  it to callbacks. */
 	private readonly docs = new Map<string, Entry>();
+	/**
+	 * LRU recency of resident doc IDs — least-recently-used first, most-recent
+	 * last. Touched on every `entry()` access (mint or cache hit). Drives
+	 * cap-pressure eviction so the resident set stays bounded WITHOUT tearing a
+	 * doc down the moment its editor view closes (which caused the switch-away
+	 * churn/data-loss). Same key space as `docs`.
+	 */
+	private readonly lru: string[] = [];
+	/**
+	 * Doc IDs that must never be evicted regardless of LRU position — a live
+	 * editor is bound to them. `CrdtLiveViews` calls `protect`/`unprotect` on
+	 * bind/release. Same key space as `docs`.
+	 */
+	private readonly protectedIds = new Set<string>();
 	/**
 	 * Per-session set of doc IDs for which at least one inbound server sync
 	 * frame has been applied (i.e. the STEP2 handshake has completed for the
@@ -300,6 +326,55 @@ export class CrdtManager {
 	 *  orphaned mint doc was torn down (removeDoc) after a genesis adopt. */
 	hasDoc(noteId: string): boolean {
 		return this.docs.has(this.docId(noteId));
+	}
+
+	/** Pin `noteId`'s doc in the resident set: it must not be LRU-evicted while
+	 *  a live editor is bound to it. `CrdtLiveViews` calls this on bind. */
+	protect(noteId: string): void {
+		this.protectedIds.add(this.docId(noteId));
+	}
+
+	/** Release the pin from `protect`. The doc stays resident (recently used) and
+	 *  is only freed later under cap pressure. Called on editor unbind/release. */
+	unprotect(noteId: string): void {
+		this.protectedIds.delete(this.docId(noteId));
+	}
+
+	/** Mark `id` most-recently-used, then evict the least-recently-used resident
+	 *  docs until the set fits `residentCap`. Never evicts a protected
+	 *  (live-bound) or in-flight doc, nor `id` itself. Eviction reuses closeDoc's
+	 *  persist-safe teardown (IndexedDB store kept — the note re-hydrates on next
+	 *  open), so nothing is lost. */
+	private touchLru(id: string): void {
+		const at = this.lru.indexOf(id);
+		if (at !== -1) this.lru.splice(at, 1);
+		this.lru.push(id);
+		const cap = this.opts.residentCap ?? 64;
+		if (this.docs.size <= cap) return;
+		// Walk LRU-first, evicting eligible docs until we're back under the cap.
+		for (let i = 0; i < this.lru.length && this.docs.size > cap; ) {
+			const cand = this.lru[i];
+			if (
+				cand === undefined ||
+				cand === id ||
+				this.protectedIds.has(cand) ||
+				(this.inFlightOps.get(cand) ?? 0) > 0 ||
+				!this.docs.has(cand)
+			) {
+				i++;
+				continue;
+			}
+			this.closeDoc(cand); // persist-safe; teardownEntry drops it from this.lru
+		}
+	}
+
+	/** Remove `id` from the LRU + protected bookkeeping. Called from the single
+	 *  teardown choke point so every destroyer (closeDoc / removeDoc / destroy /
+	 *  flatten / eviction) keeps the resident-set metadata consistent. */
+	private forgetResident(id: string): void {
+		const at = this.lru.indexOf(id);
+		if (at !== -1) this.lru.splice(at, 1);
+		this.protectedIds.delete(id);
 	}
 
 	/**
@@ -620,6 +695,7 @@ export class CrdtManager {
 		// that fires this un-awaited (closeDoc) may be followed immediately by
 		// an apply whose entry() must mint a FRESH doc, never see the dying one.
 		this.docs.delete(id);
+		this.forgetResident(id); // keep the LRU + protected set consistent
 		e.doc.destroy();
 		if (opts.clearData) await e.persistence.clearData();
 		await e.persistence.destroy();
@@ -833,6 +909,7 @@ export class CrdtManager {
 		const id = this.docId(noteId);
 		const cached = this.docs.get(id);
 		if (cached) {
+			this.touchLru(id); // mark most-recently-used so it survives eviction
 			await cached.ready;
 			return cached;
 		}
@@ -929,6 +1006,7 @@ export class CrdtManager {
 		});
 
 		this.docs.set(id, entry);
+		this.touchLru(id); // record recency + evict LRU overflow (never this id)
 		await ready;
 		// IDB hydration replayed stored updates above; rehydrated non-empty content
 		// counts as "has held content" (#288) even if no listener observed it.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3194,17 +3194,18 @@ export class SyncEngine {
 	 *  have opened the note in the editor while the apply was in flight, in
 	 *  which case that room now owns the doc's lifecycle and it must stay
 	 *  resident. */
-	private hibernateIfIdle(path: string, noteId: string): void {
-		if (!this.crdt) return;
-		if (this.isLiveBound(normalizePath(path))) return;
-		// Best-effort memory reclamation: a failure to free the doc must not throw
-		// into the never-throw convergence loop nor downgrade an already-recorded
-		// head. The doc simply stays resident (bounded; retried next hibernate).
-		try {
-			this.crdt.closeDoc(noteId);
-		} catch (e) {
-			devLog().log("crdt", `hibernateIfIdle: closeDoc ${noteId} failed — ${errMsg(e)}`);
-		}
+	private hibernateIfIdle(_path: string, _noteId: string): void {
+		// No-op since the persistent-doc rework: doc lifetime is now the
+		// CrdtManager's bounded LRU working set (`residentCap`), not per-apply
+		// hibernation. Eagerly closing an idle doc here was a churn source — a
+		// background apply's own getDoc() and any concurrent startSync/handleFrame
+		// re-minted the doc microseconds later, and during rapid file switching
+		// that close<->re-mint storm bound the editor to the wrong/empty doc and
+		// stranded edits. Idle docs now stay resident (their IndexedDB store
+		// intact) until the working set overflows, at which point the manager
+		// evicts the least-recently-used unprotected, non-in-flight doc. Kept as a
+		// no-op (rather than deleting both call sites) so the apply flow reads
+		// unchanged; safe to inline away later.
 	}
 
 	private crdtCatchupSince:

--- a/tests/crdt-live-views.test.ts
+++ b/tests/crdt-live-views.test.ts
@@ -66,12 +66,17 @@ describe("CrdtLiveViews doc lifecycle (onLastViewerRelease)", () => {
 		getText?: (id: string) => Promise<string>;
 	}) {
 		const closed: string[] = [];
+		const unprotected: string[] = [];
 		const flushed: Array<{ path: string; content: string }> = [];
 		const releaseErrors: Array<{ path: string; err: unknown }> = [];
 		const manager = {
 			getText: opts?.getText ?? (async (id: string) => `text-of-${id}`),
 			closeDoc: (id: string) => {
 				closed.push(id);
+			},
+			protect: () => {},
+			unprotect: (id: string) => {
+				unprotected.push(id);
 			},
 		};
 		const lv = new CrdtLiveViews({
@@ -88,21 +93,25 @@ describe("CrdtLiveViews doc lifecycle (onLastViewerRelease)", () => {
 				releaseErrors.push({ path, err });
 			},
 		});
-		return { lv, closed, flushed, releaseErrors };
+		return { lv, closed, unprotected, flushed, releaseErrors };
 	}
 
-	it("flushes then frees the doc when the last viewer releases", async () => {
-		const { lv, closed, flushed } = makeLiveViews();
+	it("flushes then UNPROTECTS (keeps resident) when the last viewer releases", async () => {
+		const { lv, closed, unprotected, flushed } = makeLiveViews();
 		await (
 			lv as unknown as { onLastViewerRelease(p: string): Promise<void> }
 		).onLastViewerRelease("a.md");
 		expect(flushed).toEqual([{ path: "a.md", content: "text-of-id:a.md" }]);
-		expect(closed).toEqual(["id:a.md"]); // doc freed after the final flush
+		// Persistent-doc rework: the doc is NOT torn down on view-release (that
+		// caused switch-away churn). It stays resident and merely loses its
+		// eviction pin, so it survives in the LRU working set until cap pressure.
+		expect(closed).toEqual([]);
+		expect(unprotected).toEqual(["id:a.md"]);
 	});
 
-	it("does NOT free the doc if a viewer re-binds during the flush (re-open race)", async () => {
+	it("does NOT unprotect if a viewer re-binds during the flush (re-open race)", async () => {
 		let onFlush: () => void = () => {};
-		const { lv, closed } = makeLiveViews({
+		const { lv, closed, unprotected } = makeLiveViews({
 			flushToDisk: async () => {
 				onFlush();
 			},
@@ -114,11 +123,12 @@ describe("CrdtLiveViews doc lifecycle (onLastViewerRelease)", () => {
 		await (
 			lv as unknown as { onLastViewerRelease(p: string): Promise<void> }
 		).onLastViewerRelease("a.md");
-		expect(closed).toEqual([]); // re-bound during flush → left resident
+		expect(closed).toEqual([]);
+		expect(unprotected).toEqual([]); // re-bound during flush → stays pinned
 	});
 
-	it("a flush failure retains the doc (no free without a successful persist)", async () => {
-		const { lv, closed } = makeLiveViews({
+	it("a flush failure keeps the doc pinned (no unprotect without a successful persist)", async () => {
+		const { lv, closed, unprotected } = makeLiveViews({
 			flushToDisk: async () => {
 				throw new Error("disk full");
 			},
@@ -128,11 +138,12 @@ describe("CrdtLiveViews doc lifecycle (onLastViewerRelease)", () => {
 				lv as unknown as { onLastViewerRelease(p: string): Promise<void> }
 			).onLastViewerRelease("a.md"),
 		).rejects.toThrow("disk full");
-		expect(closed).toEqual([]); // never freed — we could not persist
+		expect(closed).toEqual([]);
+		expect(unprotected).toEqual([]); // never unpinned — we could not persist
 	});
 
-	it("a getText failure neither flushes nor frees", async () => {
-		const { lv, closed, flushed } = makeLiveViews({
+	it("a getText failure neither flushes nor unprotects", async () => {
+		const { lv, closed, unprotected, flushed } = makeLiveViews({
 			getText: async () => {
 				throw new Error("no text");
 			},
@@ -144,6 +155,7 @@ describe("CrdtLiveViews doc lifecycle (onLastViewerRelease)", () => {
 		).rejects.toThrow("no text");
 		expect(flushed).toEqual([]);
 		expect(closed).toEqual([]);
+		expect(unprotected).toEqual([]);
 	});
 
 	it("surfaces a last-release failure via onReleaseError instead of swallowing it", async () => {
@@ -184,7 +196,12 @@ describe("CrdtLiveViews.requestSaveForBoundPath (fix wave 6)", () => {
 
 	function makeLiveViewsWithViews(views: Array<InstanceType<typeof MdView>>) {
 		const app = { workspace: { getLeavesOfType: mock(() => views.map((view) => ({ view }))) } };
-		const manager = { getText: async (id: string) => `text-of-${id}`, closeDoc: () => {} };
+		const manager = {
+			getText: async (id: string) => `text-of-${id}`,
+			closeDoc: () => {},
+			protect: () => {},
+			unprotect: () => {},
+		};
 		const lv = new CrdtLiveViews({
 			app: app as never,
 			manager: manager as never,
@@ -238,7 +255,12 @@ describe("CrdtLiveViews.refresh() coalescing", () => {
 		const getLeaves = mock(() => [] as Array<{ view: unknown }>);
 		const lv = new CrdtLiveViews({
 			app: { workspace: { getLeavesOfType: getLeaves } } as never,
-			manager: { getText: async () => "", closeDoc: () => {} } as never,
+			manager: {
+				getText: async () => "",
+				closeDoc: () => {},
+				protect: () => {},
+				unprotect: () => {},
+			} as never,
 			enrollment: {} as never,
 			resolveId: (p: string) => `id:${p}`,
 			flushToDisk: async () => {},

--- a/tests/crdt/manager.test.ts
+++ b/tests/crdt/manager.test.ts
@@ -7,6 +7,68 @@ import { rlog } from "../../src/remote-log";
 import { reconcileColdStart } from "../../src/sync";
 
 // ---------------------------------------------------------------------------
+// Persistent-doc LRU working set (Relay-style doc lifetime).
+//
+// Root cause of the switch-away edit loss: getDoc() re-mints a doc whenever one
+// isn't resident, while onLastViewerRelease/hibernateIfIdle closeDoc() the doc
+// the instant its editor view closes. Rapid file switching produces a
+// close<->re-mint storm that binds the editor to the wrong/empty doc and strands
+// edits. Fix: a note's Y.Doc is resident for as long as it fits in a bounded LRU
+// working set — never torn down on view-release — so the editor stays bound to
+// one stable doc. Eviction happens only under cap pressure, and never for a
+// live-bound (protected) or in-flight doc.
+// ---------------------------------------------------------------------------
+
+test("getDoc keeps a note resident across re-access (no re-mint) within the cap", async () => {
+	const mgr = new CrdtManager({
+		dbPrefix: "vault-lru-resident",
+		residentCap: 8,
+		onUpdate: () => {},
+		onFlushToDisk: async () => {},
+	});
+	const first = await mgr.getDoc("a.md");
+	const firstGuid = first.guid;
+	// Touch several other notes (well within the cap), then come back to a.md.
+	for (const p of ["b.md", "c.md", "d.md"]) await mgr.getDoc(p);
+	const again = await mgr.getDoc("a.md");
+	expect(again.guid).toBe(firstGuid); // SAME Y.Doc — not re-minted (no churn)
+	expect(mgr.hasDoc("a.md")).toBe(true);
+	await mgr.destroy();
+});
+
+test("resident set evicts the least-recently-used unprotected doc past the cap", async () => {
+	const mgr = new CrdtManager({
+		dbPrefix: "vault-lru-evict",
+		residentCap: 2,
+		onUpdate: () => {},
+		onFlushToDisk: async () => {},
+	});
+	await mgr.getDoc("old.md"); // LRU
+	await mgr.getDoc("mid.md");
+	await mgr.getDoc("new.md"); // opening the 3rd evicts the LRU (old.md)
+	expect(mgr.hasDoc("old.md")).toBe(false); // evicted
+	expect(mgr.hasDoc("mid.md")).toBe(true);
+	expect(mgr.hasDoc("new.md")).toBe(true);
+	await mgr.destroy();
+});
+
+test("a protected (live-bound) doc is never evicted, even as the LRU", async () => {
+	const mgr = new CrdtManager({
+		dbPrefix: "vault-lru-protect",
+		residentCap: 1,
+		onUpdate: () => {},
+		onFlushToDisk: async () => {},
+	});
+	await mgr.getDoc("bound.md");
+	mgr.protect("bound.md"); // editor bound to it — must survive cap pressure
+	await mgr.getDoc("other1.md");
+	await mgr.getDoc("other2.md");
+	expect(mgr.hasDoc("bound.md")).toBe(true); // protected: still resident
+	mgr.unprotect("bound.md");
+	await mgr.destroy();
+});
+
+// ---------------------------------------------------------------------------
 // Task 6: doc-shape constants + frontmatterOf accessor
 // ---------------------------------------------------------------------------
 

--- a/tests/crdt/note-yjs-update.test.ts
+++ b/tests/crdt/note-yjs-update.test.ts
@@ -75,7 +75,7 @@ function noteEngine(opts: {
 }
 
 describe("applyPushedNoteUpdate (note_yjs_update)", () => {
-	test("a confirmed, not-live-bound note applies the update, persists the head, and hibernates the doc (P3)", async () => {
+	test("a confirmed, not-live-bound note applies the update, persists the head, and keeps the doc resident (persistent-doc rework)", async () => {
 		const { e, applied, closed } = noteEngine({});
 		markConfirmed(e, "id-a");
 		const update = new Uint8Array([1, 2, 3]);
@@ -84,7 +84,11 @@ describe("applyPushedNoteUpdate (note_yjs_update)", () => {
 
 		expect(applied).toEqual([{ id: "id-a", update }]);
 		expect((e as any).getCrdtHead("a.md")).toBe("SRV");
-		expect(closed).toEqual(["id-a"]); // idle doc freed after the head is durably set
+		// hibernateIfIdle is now a no-op: doc lifetime is the CrdtManager's bounded
+		// LRU working set, not per-apply hibernation (eager close raced startSync/
+		// handleFrame re-mints and stranded switch-away edits). The idle doc stays
+		// resident until the working set overflows.
+		expect(closed).toEqual([]);
 	});
 
 	test("a live-bound note APPLIES the fan-out update (the room is not a guaranteed delivery path)", async () => {
@@ -277,9 +281,11 @@ describe("applyPushedNoteUpdate — gap heal (missed-open reconnect)", () => {
 });
 
 describe("applyPushedNoteUpdate ordering (b#3)", () => {
-	test("the idle doc is freed only AFTER setCrdtHead durably records the head", async () => {
-		// Mirrors the coldReceive ordering test: hibernateIfIdle -> closeDoc must
-		// run AFTER the head is persisted, so a half-recorded note is never freed.
+	test("an idle apply records the head and never closes the doc (persistent-doc rework)", async () => {
+		// hibernateIfIdle no longer closes the doc — lifetime is the CrdtManager's
+		// bounded LRU. The apply must still durably record the head; it just must
+		// not free the doc (eager close raced startSync/handleFrame re-mints and
+		// stranded switch-away edits).
 		const order: string[] = [];
 		const crdt = {
 			applyRemoteUpdate: async () => {},
@@ -299,6 +305,6 @@ describe("applyPushedNoteUpdate ordering (b#3)", () => {
 
 		await (e as any).applyPushedNoteUpdate("id-a", new Uint8Array([1]), "SRV");
 
-		expect(order).toEqual(["head:a.md", "close:id-a"]);
+		expect(order).toEqual(["head:a.md"]); // head recorded; no close
 	});
 });

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -554,13 +554,16 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	// Heal-room release (fan-out idle invariant): the diverged-cold-note heal
 	// and the queued-delivery nudge open a TRANSIENT room via reset+enroll.
 	// Once the convergence commits (or the delivery settles), the room must be
-	// RELEASED — enrollment un-marked (so a future heal can re-handshake) and
-	// the doc hibernated. Without the release every healed idle note holds a
-	// room for the rest of the session (the e2e fan-out precondition flake,
-	// test_cold_send_over_fanout_opens_no_room).
+	// RELEASED — enrollment un-marked (so a future heal can re-handshake).
+	// Without the release every healed idle note holds a room for the rest of
+	// the session (the e2e fan-out precondition flake,
+	// test_cold_send_over_fanout_opens_no_room). Since the persistent-doc rework
+	// the room release no longer *closes* the doc (hibernateIfIdle is a no-op —
+	// eager close raced startSync/handleFrame re-mints and stranded switch-away
+	// edits); the doc stays resident under the manager's bounded LRU.
 	// -----------------------------------------------------------------------
 
-	test("heal-room release: verified commit for an IDLE note resets enrollment and hibernates the doc", async () => {
+	test("heal-room release: verified commit for an IDLE note resets enrollment (doc stays resident)", async () => {
 		const { engine, enroll, reset, closeDoc, projectedText } = crdtEngine();
 		const localFile = new TFile("owned.md");
 		mockApp.vault.getFileByPath.mockReturnValue(localFile);
@@ -586,11 +589,12 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		projectedText.mockResolvedValue("new server body");
 		await engine.commitCrdtConvergence("note-id-1");
 
-		// Release: a SECOND reset (un-mark, so a future heal re-handshakes) and
-		// the doc hibernated — the idle note holds no room after convergence.
+		// Release: a SECOND reset (un-mark, so a future heal re-handshakes). The
+		// idle note holds no room after convergence. The doc is NOT closed now —
+		// it stays resident under the LRU (hibernateIfIdle is a no-op).
 		expect(reset).toHaveBeenCalledTimes(2);
 		expect(reset.mock.calls[1]?.[0]).toBe("note-id-1");
-		expect(closeDoc).toHaveBeenCalledWith("note-id-1");
+		expect(closeDoc).not.toHaveBeenCalled();
 		// No re-enroll — released, not re-opened.
 		expect(enroll).toHaveBeenCalledTimes(1);
 	});
@@ -638,7 +642,7 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		await engine.commitCrdtConvergence("note-id-1");
 
 		expect(reset).toHaveBeenCalledWith("note-id-1");
-		expect(closeDoc).toHaveBeenCalledWith("note-id-1");
+		expect(closeDoc).not.toHaveBeenCalled(); // doc stays resident (LRU-managed)
 		expect((engine as any).queue.size).toBe(0); // the settle still dequeues
 	});
 


### PR DESCRIPTION
## The bug (Todd's repro: switch files, some edits never reach the server)

Rapid file switching in Obsidian silently drops edits. Root cause, caught in prod Loki (device \`a75644e9\`, build \`g894db69\` diagnostics):

\`getDoc()\` re-mints a Y.Doc whenever one isn't resident, while \`onLastViewerRelease\` and \`hibernateIfIdle\` \`closeDoc()\` the doc the instant its editor view closes / a background apply finishes. The channel stays subscribed after you navigate away, so incoming frames (\`startSync\`/\`handleFrame\`/\`hasHistory\`) keep resurrecting docs that hibernation just closed — a **close↔re-mint storm**. The capture showed one open note cycling through 3+ distinct Y.Docs in seconds, ending with the editor bound to the **wrong doc**:

\`\`\`
BIND ok path="New Document Intake.md" docGuid=030ac835 ytLen=8618 edLen=34007
\`\`\`

edLen=34007 = the *previous* note's buffer. After this, sends stop entirely.

## The fix (Relay-style persistent doc)

A note's Y.Doc lives for as long as it fits a bounded LRU working set (\`CrdtManager.residentCap\`, default 64) — **never torn down merely because its editor view closed**. Switching among a handful of files keeps each doc resident, so the editor stays bound to one stable doc.

- **CrdtManager**: LRU recency + protected-set. \`touchLru()\` on every \`entry()\` access evicts the least-recently-used **unprotected, non-in-flight** doc past the cap (persist-safe \`closeDoc\` — IndexedDB store kept). \`protect()\`/\`unprotect()\` pin a live-bound doc.
- **CrdtLiveViews**: \`onBind\` protects; \`onLastViewerRelease\` unprotects instead of \`closeDoc\`.
- **SyncEngine.hibernateIfIdle**: now a no-op (lifetime is the manager's LRU). Heal-room release still resets enrollment; it just no longer eager-closes.

## Tests

TDD: manager LRU tests (resident-within-cap / evict-LRU / never-evict-protected), updated live-views + note-yjs-update + sync-catchup behavior. Full suite green (2232).

Complements #325 (send-layer re-enroll) — that fixed the *send* path; this fixes the *doc-lifetime* layer that was still churning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KtkcQifSgcYC9GHEAfrpvj