### PR TITLE
feat(logging): remoteLogLevel severity threshold for RemoteLogger

### DIFF
--- a/main.js
+++ b/main.js
@@ -863,7 +863,12 @@ function newTraceContext() {
 }
 
 // src/remote-log.ts
-var RemoteLogger = class {
+var LEVEL_SEVERITY = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3
+}, MAX_BUFFER = 200, FLUSH_INTERVAL_MS = 3e4, FLUSH_THRESHOLD = 20, RemoteLogger = class {
   constructor() {
     this.buffer = [];
     this.flushTimer = null;
@@ -876,6 +881,7 @@ var RemoteLogger = class {
     this.deviceId = null;
     this.vaultId = null;
     this.seq = 0;
+    this.levelThreshold = "info";
   }
   configure(pushFn, pluginVersion, platform) {
     this.pushFn = pushFn, this.pluginVersion = pluginVersion, this.platform = platform;
@@ -895,6 +901,12 @@ var RemoteLogger = class {
   setConnId(id2) {
     this.connId = id2;
   }
+  /** Set the minimum severity that ships. Entries below this level are
+   *  dropped before buffering (they never count toward the ring buffer or
+   *  flush threshold). Default "info" preserves today's behavior. */
+  setLevelThreshold(level) {
+    this.levelThreshold = level;
+  }
   setClientContext(deviceId, vaultId) {
     this.deviceId = deviceId, this.vaultId = vaultId;
   }
@@ -910,7 +922,7 @@ var RemoteLogger = class {
     try {
       await this.pushFn(batch);
     } catch (e) {
-      let space = 200 - this.buffer.length;
+      let space = MAX_BUFFER - this.buffer.length;
       space > 0 && this.buffer.unshift(...batch.slice(0, space));
     } finally {
       this.flushing = !1;
@@ -920,7 +932,7 @@ var RemoteLogger = class {
     this.stopTimer(), await this.flush(), this.buffer = [], this.pushFn = null;
   }
   addEntry(level, category, message, stack, diagnostic) {
-    if (!this.enabled || !this.pushFn) return;
+    if (!this.enabled || !this.pushFn || LEVEL_SEVERITY[level] < LEVEL_SEVERITY[this.levelThreshold]) return;
     let entry = {
       ts: (/* @__PURE__ */ new Date()).toISOString(),
       level,
@@ -930,12 +942,12 @@ var RemoteLogger = class {
       platform: this.platform,
       seq: this.seq++
     };
-    stack && (entry.stack = stack), this.connId && (entry.conn_id = this.connId), this.deviceId && (entry.device_id = this.deviceId), this.vaultId && (entry.vault_id = this.vaultId), diagnostic && (entry.diagnostic = !0), this.buffer.push(entry), this.buffer.length > 200 && this.buffer.splice(0, this.buffer.length - 200), this.buffer.length >= 20 && this.flush();
+    stack && (entry.stack = stack), this.connId && (entry.conn_id = this.connId), this.deviceId && (entry.device_id = this.deviceId), this.vaultId && (entry.vault_id = this.vaultId), diagnostic && (entry.diagnostic = !0), this.buffer.push(entry), this.buffer.length > MAX_BUFFER && this.buffer.splice(0, this.buffer.length - MAX_BUFFER), this.buffer.length >= FLUSH_THRESHOLD && this.flush();
   }
   startTimer() {
     this.stopTimer(), this.flushTimer = window.setInterval(() => {
       this.flush();
-    }, 3e4);
+    }, FLUSH_INTERVAL_MS);
   }
   stopTimer() {
     this.flushTimer && (window.clearInterval(this.flushTimer), this.flushTimer = null);
@@ -952,6 +964,8 @@ var RemoteLogger = class {
   setConnId() {
   },
   setClientContext() {
+  },
+  setLevelThreshold() {
   },
   async flush() {
   },
@@ -3244,6 +3258,7 @@ var DEFAULT_SETTINGS = {
   ignorePatterns: "",
   debounceMs: 2e3,
   diagnosticsEnabled: !1,
+  remoteLogLevel: "info",
   vaultId: null,
   clientId: "",
   planState: null,
@@ -4856,6 +4871,17 @@ secret.md`).setValue(plugin.settings.ignorePatterns).onChange(async (value) => {
   ).addToggle(
     (toggle) => toggle.setValue(plugin.settings.diagnosticsEnabled).onChange(async (value) => {
       plugin.settings.diagnosticsEnabled = value, await plugin.saveSettings();
+    })
+  ), new import_obsidian18.Setting(containerEl).setName("Diagnostics detail").setDesc(
+    "Minimum severity that ships while diagnostics are on. Higher levels send fewer lines. Default: Info."
+  ).addDropdown(
+    (dropdown) => dropdown.addOptions({
+      error: "Errors only",
+      warn: "Warnings and errors",
+      info: "Info (default)",
+      debug: "Debug (verbose)"
+    }).setValue(plugin.settings.remoteLogLevel).onChange(async (value) => {
+      plugin.settings.remoteLogLevel = value, await plugin.saveSettings();
     })
   ), new import_obsidian18.Setting(containerEl).setName("About").setHeading();
   let aboutList = containerEl.createEl("ul", { cls: "engram-about-list" }), versionItem = aboutList.createEl("li");
@@ -22330,7 +22356,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       (entries) => this.api.pushLogs(entries),
       this.manifest.version,
       import_obsidian26.Platform.isMobile ? "mobile" : "desktop"
-    ), remoteLogger.setEnabled(this.settings.diagnosticsEnabled), remoteLogger.setClientContext(this.deviceId, this.settings.vaultId), rlog().info(
+    ), remoteLogger.setLevelThreshold(this.settings.remoteLogLevel), remoteLogger.setEnabled(this.settings.diagnosticsEnabled), remoteLogger.setClientContext(this.deviceId, this.settings.vaultId), rlog().info(
       "lifecycle",
       `Plugin loading | v${this.manifest.version} | ${import_obsidian26.Platform.isMobile ? "mobile" : "desktop"}`
     ), this.syncEngine = new SyncEngine(this.app, this.api, this.settings, async (data) => {
@@ -22679,7 +22705,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     });
   }
   async saveSettings() {
-    this.api.updateConfig(this.settings.apiUrl, this.settings.apiKey), this.api.setVaultId(this.settings.vaultId), this.api.setTracingEnabled(this.settings.diagnosticsEnabled), this.syncEngine.updateSettings(this.settings), rlog().setEnabled(this.settings.diagnosticsEnabled), this.startSyncInterval(), this.setupNoteStream(), await this.savePluginData(this.syncEngine.getLastSync()), this.hasAuthConfigured() ? this.registerVault().then(async (registered) => {
+    this.api.updateConfig(this.settings.apiUrl, this.settings.apiKey), this.api.setVaultId(this.settings.vaultId), this.api.setTracingEnabled(this.settings.diagnosticsEnabled), this.syncEngine.updateSettings(this.settings), rlog().setLevelThreshold(this.settings.remoteLogLevel), rlog().setEnabled(this.settings.diagnosticsEnabled), this.startSyncInterval(), this.setupNoteStream(), await this.savePluginData(this.syncEngine.getLastSync()), this.hasAuthConfigured() ? this.registerVault().then(async (registered) => {
       if (!registered) {
         await this.applySyncGate();
         return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -389,6 +389,7 @@ export default class EngramSyncPlugin extends Plugin {
 			this.manifest.version,
 			Platform.isMobile ? "mobile" : "desktop",
 		);
+		remoteLogger.setLevelThreshold(this.settings.remoteLogLevel);
 		remoteLogger.setEnabled(this.settings.diagnosticsEnabled);
 		remoteLogger.setClientContext(this.deviceId, this.settings.vaultId);
 		rlog().info(
@@ -1151,6 +1152,7 @@ export default class EngramSyncPlugin extends Plugin {
 		this.api.setVaultId(this.settings.vaultId);
 		this.api.setTracingEnabled(this.settings.diagnosticsEnabled);
 		this.syncEngine.updateSettings(this.settings);
+		rlog().setLevelThreshold(this.settings.remoteLogLevel);
 		rlog().setEnabled(this.settings.diagnosticsEnabled);
 		this.startSyncInterval();
 		this.setupNoteStream();

--- a/src/remote-log.ts
+++ b/src/remote-log.ts
@@ -22,6 +22,18 @@ export interface RemoteLogEntry {
 
 type PushFn = (entries: RemoteLogEntry[]) => Promise<void>;
 
+/** Shipping threshold for log entries. A call ships only if its own level's
+ *  severity is at or above the configured threshold. "debug" has no emitting
+ *  call sites yet (reserved for future verbose logging behind the dial). */
+export type RemoteLogLevel = "error" | "warn" | "info" | "debug";
+
+const LEVEL_SEVERITY: Record<RemoteLogLevel, number> = {
+	debug: 0,
+	info: 1,
+	warn: 2,
+	error: 3,
+};
+
 const MAX_BUFFER = 200;
 const FLUSH_INTERVAL_MS = 30_000;
 const FLUSH_THRESHOLD = 20;
@@ -38,6 +50,7 @@ export class RemoteLogger {
 	private deviceId: string | null = null;
 	private vaultId: string | null = null;
 	private seq = 0;
+	private levelThreshold: RemoteLogLevel = "info";
 
 	configure(pushFn: PushFn, pluginVersion: string, platform: string): void {
 		this.pushFn = pushFn;
@@ -69,6 +82,13 @@ export class RemoteLogger {
 
 	setConnId(id: string | null): void {
 		this.connId = id;
+	}
+
+	/** Set the minimum severity that ships. Entries below this level are
+	 *  dropped before buffering (they never count toward the ring buffer or
+	 *  flush threshold). Default "info" preserves today's behavior. */
+	setLevelThreshold(level: RemoteLogLevel): void {
+		this.levelThreshold = level;
 	}
 
 	setClientContext(deviceId: string | null, vaultId: string | null): void {
@@ -116,6 +136,7 @@ export class RemoteLogger {
 		diagnostic?: boolean,
 	): void {
 		if (!this.enabled || !this.pushFn) return;
+		if (LEVEL_SEVERITY[level] < LEVEL_SEVERITY[this.levelThreshold]) return;
 
 		const entry: RemoteLogEntry = {
 			ts: new Date().toISOString(),
@@ -167,6 +188,7 @@ interface NoopLogger {
 	diag(category: string, message: string): void;
 	setConnId(id: string | null): void;
 	setClientContext(deviceId: string | null, vaultId: string | null): void;
+	setLevelThreshold(level: RemoteLogLevel): void;
 	flush(): Promise<void>;
 	destroy(): Promise<void>;
 	setEnabled(enabled: boolean): void;
@@ -180,6 +202,7 @@ const _noop: NoopLogger = {
 	diag() {},
 	setConnId() {},
 	setClientContext() {},
+	setLevelThreshold() {},
 	async flush() {},
 	async destroy() {},
 	setEnabled() {},

--- a/src/tabs/advanced-tab.ts
+++ b/src/tabs/advanced-tab.ts
@@ -1,4 +1,5 @@
 import { Notice, Setting, TFolder } from "obsidian";
+import type { EngramSyncSettings } from "../types";
 import type { TabContext } from "./types";
 
 /** Directories that should never be synced — detect and warn if found in vault. */
@@ -76,6 +77,26 @@ export function renderAdvancedTab(ctx: TabContext): void {
 				plugin.settings.diagnosticsEnabled = value;
 				await plugin.saveSettings();
 			}),
+		);
+
+	new Setting(containerEl)
+		.setName("Diagnostics detail")
+		.setDesc(
+			"Minimum severity that ships while diagnostics are on. Higher levels send fewer lines. Default: Info.",
+		)
+		.addDropdown((dropdown) =>
+			dropdown
+				.addOptions({
+					error: "Errors only",
+					warn: "Warnings and errors",
+					info: "Info (default)",
+					debug: "Debug (verbose)",
+				})
+				.setValue(plugin.settings.remoteLogLevel)
+				.onChange(async (value) => {
+					plugin.settings.remoteLogLevel = value as EngramSyncSettings["remoteLogLevel"];
+					await plugin.saveSettings();
+				}),
 		);
 
 	// ── About ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,13 @@ export interface EngramSyncSettings {
 	 *  Collapses the former remoteLoggingEnabled / diagnosticMode / tracingEnabled
 	 *  trio (migrated in settings-migrate.ts). */
 	diagnosticsEnabled: boolean;
+	/** Minimum severity that ships while `diagnosticsEnabled` is on. Entries
+	 *  below this threshold are dropped before buffering, so they never occupy
+	 *  the ring buffer or count toward the flush threshold. This is a VOLUME
+	 *  dial, orthogonal to the on/off switch above. Default "info" preserves
+	 *  today's behavior — no emitting call site logs below info. "debug" is
+	 *  reserved for future verbose logging behind the dial. */
+	remoteLogLevel: "error" | "warn" | "info" | "debug";
 	/** Server-assigned vault ID. Populated after registration. Null until first sync. */
 	vaultId: string | null;
 	/** Server-side name for the selected vault, mirrored from the registration
@@ -74,6 +81,7 @@ export const DEFAULT_SETTINGS: EngramSyncSettings = {
 	ignorePatterns: "",
 	debounceMs: 2000,
 	diagnosticsEnabled: false,
+	remoteLogLevel: "info",
 	vaultId: null,
 	clientId: "",
 	planState: null,

--- a/tests/remote-log.test.ts
+++ b/tests/remote-log.test.ts
@@ -84,6 +84,79 @@ describe("RemoteLogger basics", () => {
 });
 
 // ---------------------------------------------------------------------------
+// remoteLogLevel severity threshold
+// ---------------------------------------------------------------------------
+
+describe("RemoteLogger level threshold", () => {
+	test("default threshold ships all current levels (info/warn/error)", () => {
+		const logger = new RemoteLogger();
+		const pushFn = mock().mockResolvedValue(undefined);
+		logger.configure(pushFn, "1.0.0", "desktop");
+		logger.setEnabled(true);
+		logger.info("cat", "an info line");
+		logger.warn("cat", "a warn line");
+		logger.error("cat", "an error line");
+		logger.flush();
+		expect(pushFn).toHaveBeenCalledTimes(1);
+		expect(pushFn.mock.calls[0][0]).toHaveLength(3);
+		logger.destroy();
+	});
+
+	test("threshold 'warn' drops an info call", () => {
+		const logger = new RemoteLogger();
+		const pushFn = mock().mockResolvedValue(undefined);
+		logger.configure(pushFn, "1.0.0", "desktop");
+		logger.setEnabled(true);
+		logger.setLevelThreshold("warn");
+		logger.info("cat", "should be dropped");
+		logger.flush();
+		expect(pushFn).not.toHaveBeenCalled();
+		logger.destroy();
+	});
+
+	test("threshold 'warn' ships a warn call", () => {
+		const logger = new RemoteLogger();
+		const pushFn = mock().mockResolvedValue(undefined);
+		logger.configure(pushFn, "1.0.0", "desktop");
+		logger.setEnabled(true);
+		logger.setLevelThreshold("warn");
+		logger.warn("cat", "should ship");
+		logger.flush();
+		expect(pushFn).toHaveBeenCalledTimes(1);
+		expect(pushFn.mock.calls[0][0][0].message).toBe("should ship");
+		logger.destroy();
+	});
+
+	test("threshold 'error' drops warn and info but ships error", () => {
+		const logger = new RemoteLogger();
+		const pushFn = mock().mockResolvedValue(undefined);
+		logger.configure(pushFn, "1.0.0", "desktop");
+		logger.setEnabled(true);
+		logger.setLevelThreshold("error");
+		logger.info("cat", "dropped");
+		logger.warn("cat", "also dropped");
+		logger.error("cat", "shipped");
+		logger.flush();
+		expect(pushFn).toHaveBeenCalledTimes(1);
+		expect(pushFn.mock.calls[0][0]).toHaveLength(1);
+		expect(pushFn.mock.calls[0][0][0].message).toBe("shipped");
+		logger.destroy();
+	});
+
+	test("threshold 'debug' ships everything (no debug-level call sites exist yet)", () => {
+		const logger = new RemoteLogger();
+		const pushFn = mock().mockResolvedValue(undefined);
+		logger.configure(pushFn, "1.0.0", "desktop");
+		logger.setEnabled(true);
+		logger.setLevelThreshold("debug");
+		logger.info("cat", "info");
+		logger.flush();
+		expect(pushFn).toHaveBeenCalledTimes(1);
+		logger.destroy();
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Flush threshold
 // ---------------------------------------------------------------------------
 

--- a/tests/settings-defaults.test.ts
+++ b/tests/settings-defaults.test.ts
@@ -3,3 +3,7 @@ import { DEFAULT_SETTINGS } from "../src/types";
 test("diagnosticsEnabled defaults OFF (Obsidian opt-in rule)", () => {
 	expect(DEFAULT_SETTINGS.diagnosticsEnabled).toBe(false);
 });
+
+test("remoteLogLevel defaults to info (preserves legacy ship-everything behavior)", () => {
+	expect(DEFAULT_SETTINGS.remoteLogLevel).toBe("info");
+});


### PR DESCRIPTION
Adds a **`remoteLogLevel`** severity threshold to `RemoteLogger` — a volume dial for remote logging, orthogonal to the existing `diagnosticsEnabled` on/off switch. That one decides *whether* we ship; this one decides *how much*.

Entries below the configured level are dropped in `addEntry` **before buffering**, so they never occupy the ring buffer or count toward the flush threshold. Surfaced as a "Diagnostics detail" dropdown under the Diagnostics settings section.

Default `info` preserves today's behavior exactly — no emitting call site logs below info. `debug` is reserved for future verbose logging behind the dial.

### Why this is showing up now
This branch was written 2026-07-04 and then forgotten: it existed on the remote with **no PR**, is not an ancestor of `main`, and `remoteLogLevel` is still absent from `main`.

It surfaced because backend CI pairs a plugin branch with the **same name** as the backend branch. Reviving the backend half (engram-app/Engram#1123, `device_id`/`conn_id` on `GET /logs`) auto-paired this stale branch, and since it predated the sim tier it had no `tests/sim/obsidian-shim.ts` — so `headless-protocol` died on a missing module. The two are genuinely halves of the same client-log attribution work, so the fix was to bring this one current rather than break the pairing.

### Rebase notes
`main` collapsed `remoteLoggingEnabled` / `diagnosticMode` / `tracingEnabled` into the single `diagnosticsEnabled` switch (migrated in `settings-migrate.ts`). The original commit gated on `remoteLoggingEnabled`, which no longer exists, so:
- Wiring now gates on `diagnosticsEnabled`; `remoteLogLevel` is added as an independent field rather than resurrecting the removed trio.
- Settings-tab entry adapted to `main`'s single Diagnostics section.
- Dropped the `1.11.8` version bump and the `manifest.json` / `package.json` / `versions.json` churn — release-please owns plugin versions since #273.

### Verification
- `bun test` — **2210 pass, 1 skip, 0 fail** (129 files)
- `bun run build` (tsc + esbuild) clean; `main.js` rebuilt, diff scoped to this feature (33 insertions)
- `biome ci` clean, `lint:css` clean, `lint:obsidian` clean

> Note: `lint:obsidian` initially blew up locally with `Could not find "settings-tab/prefer-setting-definitions"` — stale hardlinked `node_modules` pinning `eslint-plugin-obsidianmd@0.3.0` against a `^0.4.1` requirement. `bun install` fixed it; not a code issue.

**Pairs with engram-app/Engram#1123** — merging them together keeps the CI branch-pairing coherent.
