### PR TITLE
feat(settings): collapse 3 diagnostics toggles into one

### DIFF
--- a/main.js
+++ b/main.js
@@ -1410,6 +1410,11 @@ var ApiKeyAuth = class {
 _OAuthAuth.EXPIRY_BUFFER_MS = 6e4;
 var OAuthAuth = _OAuthAuth;
 
+// src/settings-migrate.ts
+function migrateDiagnosticsEnabled(raw) {
+  return raw ? typeof raw.diagnosticsEnabled == "boolean" ? raw.diagnosticsEnabled : !!(raw.remoteLoggingEnabled || raw.diagnosticMode || raw.tracingEnabled) : !1;
+}
+
 // src/error-util.ts
 function errMsg(e) {
   var _a;
@@ -3062,16 +3067,14 @@ var DEFAULT_SETTINGS = {
   ignorePatterns: "",
   debounceMs: 2e3,
   conflictViewMode: "unified",
-  remoteLoggingEnabled: !1,
-  diagnosticMode: !1,
+  diagnosticsEnabled: !1,
   conflictResolution: "auto",
   enableCrdt: !0,
   vaultId: null,
   clientId: "",
   planState: null,
   searchDefaultMode: "hybrid",
-  waitlistPromptSeen: !1,
-  tracingEnabled: !1
+  waitlistPromptSeen: !1
 }, DESTRUCTIVE_CHOICES = /* @__PURE__ */ new Set([
   "pull-all-delete-local",
   "push-all-delete-remote"
@@ -4624,21 +4627,11 @@ function renderAdvancedTab(ctx) {
 secret.md`).setValue(plugin.settings.ignorePatterns).onChange(async (value) => {
       plugin.settings.ignorePatterns = value, await plugin.saveSettings();
     }), text2.inputEl.rows = 6, text2.inputEl.addClass("engram-ignore-textarea");
-  }).settingEl.addClass("engram-ignore-setting"), new import_obsidian19.Setting(containerEl).setName("Diagnostics").setHeading(), new import_obsidian19.Setting(containerEl).setName("Remote logging").setDesc("Send sync events to the server for remote debugging.").addToggle(
-    (toggle) => toggle.setValue(plugin.settings.remoteLoggingEnabled).onChange(async (value) => {
-      plugin.settings.remoteLoggingEnabled = value, await plugin.saveSettings();
-    })
-  ), new import_obsidian19.Setting(containerEl).setName("Diagnostic mode (verbose)").setDesc(
-    "Log detailed vault and connection activity for troubleshooting. Metadata only, never note content. Requires remote logging. Leave off for normal use."
+  }).settingEl.addClass("engram-ignore-setting"), new import_obsidian19.Setting(containerEl).setName("Diagnostics").setHeading(), new import_obsidian19.Setting(containerEl).setName("Diagnostics").setDesc(
+    "Send detailed sync, vault, and connection activity to the server for troubleshooting, with distributed tracing on requests. Metadata only, never note content. Leave off for normal use."
   ).addToggle(
-    (toggle) => toggle.setValue(plugin.settings.diagnosticMode).onChange(async (value) => {
-      plugin.settings.diagnosticMode = value, await plugin.saveSettings();
-    })
-  ), new import_obsidian19.Setting(containerEl).setName("Distributed tracing").setDesc(
-    "Attach a trace ID to sync requests and report timing to the server for cross-system debugging. No note content is sent."
-  ).addToggle(
-    (toggle) => toggle.setValue(plugin.settings.tracingEnabled).onChange(async (value) => {
-      plugin.settings.tracingEnabled = value, await plugin.saveSettings();
+    (toggle) => toggle.setValue(plugin.settings.diagnosticsEnabled).onChange(async (value) => {
+      plugin.settings.diagnosticsEnabled = value, await plugin.saveSettings();
     })
   ), new import_obsidian19.Setting(containerEl).setName("About").setHeading();
   let aboutList = containerEl.createEl("ul", { cls: "engram-about-list" }), versionItem = aboutList.createEl("li");
@@ -20533,7 +20526,7 @@ function formatVaultEvent(kind, path, extra) {
   return parts.join(" ");
 }
 function registerDiagnostics(plugin) {
-  let on = () => plugin.settings.diagnosticMode, emit = (kind, path, extra) => {
+  let on = () => plugin.settings.diagnosticsEnabled, emit = (kind, path, extra) => {
     on() && rlog().diag("vault", formatVaultEvent(kind, path, extra));
   };
   plugin.registerEvent(
@@ -20833,13 +20826,13 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian25.Plugin
       new EmailCaptureModal(this.app, () => {
         this.settings.waitlistPromptSeen = !0, this.saveSettings();
       }).open();
-    }), this.api = new EngramApi(this.settings.apiUrl, this.settings.apiKey), this.settings.vaultId && this.api.setVaultId(this.settings.vaultId), this.api.setDeviceId(this.deviceId), this.api.setTracingEnabled(this.settings.tracingEnabled), this.authProvider = this.createAuthProvider(), this.authProvider && this.api.setAuthProvider(this.authProvider);
+    }), this.api = new EngramApi(this.settings.apiUrl, this.settings.apiKey), this.settings.vaultId && this.api.setVaultId(this.settings.vaultId), this.api.setDeviceId(this.deviceId), this.api.setTracingEnabled(this.settings.diagnosticsEnabled), this.authProvider = this.createAuthProvider(), this.authProvider && this.api.setAuthProvider(this.authProvider);
     let remoteLogger = initRemoteLog();
     remoteLogger.configure(
       (entries) => this.api.pushLogs(entries),
       this.manifest.version,
       import_obsidian25.Platform.isMobile ? "mobile" : "desktop"
-    ), remoteLogger.setEnabled(this.settings.remoteLoggingEnabled), remoteLogger.setClientContext(this.deviceId, this.settings.vaultId), rlog().info(
+    ), remoteLogger.setEnabled(this.settings.diagnosticsEnabled), remoteLogger.setClientContext(this.deviceId, this.settings.vaultId), rlog().info(
       "lifecycle",
       `Plugin loading | v${this.manifest.version} | ${import_obsidian25.Platform.isMobile ? "mobile" : "desktop"}`
     ), this.syncEngine = new SyncEngine(this.app, this.api, this.settings, async (data) => {
@@ -21098,7 +21091,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian25.Plugin
   async loadSettings() {
     var _a, _b;
     let data = await this.loadPluginData();
-    this.settings = Object.assign({}, DEFAULT_SETTINGS, data == null ? void 0 : data.settings), this.syncGateAcceptedFor = (_a = data == null ? void 0 : data.syncGateAcceptedFor) != null ? _a : null, this.noteIdMap = NoteIdMap.fromJSON(data == null ? void 0 : data.noteIds);
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, data == null ? void 0 : data.settings);
+    let rawSettings = data == null ? void 0 : data.settings;
+    this.settings.diagnosticsEnabled = migrateDiagnosticsEnabled(rawSettings);
+    for (let legacy of ["remoteLoggingEnabled", "diagnosticMode", "tracingEnabled"])
+      delete this.settings[legacy];
+    this.syncGateAcceptedFor = (_a = data == null ? void 0 : data.syncGateAcceptedFor) != null ? _a : null, this.noteIdMap = NoteIdMap.fromJSON(data == null ? void 0 : data.noteIds);
     let dirty = !1, migratedUrl = migrateCloudApiUrl(this.settings.apiUrl, ENGRAM_CLOUD_URL);
     migratedUrl && migratedUrl !== this.settings.apiUrl && (this.settings.apiUrl = migratedUrl, dirty = !0), this.settings.clientId || (this.settings.clientId = await generateClientId(this.app), dirty = !0), this.deviceId = (_b = data == null ? void 0 : data.deviceId) != null ? _b : null, this.deviceId || (this.deviceId = crypto.randomUUID(), dirty = !0), dirty && await this.writePluginData({
       ...data,
@@ -21107,7 +21105,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian25.Plugin
     });
   }
   async saveSettings() {
-    this.api.updateConfig(this.settings.apiUrl, this.settings.apiKey), this.api.setVaultId(this.settings.vaultId), this.api.setTracingEnabled(this.settings.tracingEnabled), this.syncEngine.updateSettings(this.settings), rlog().setEnabled(this.settings.remoteLoggingEnabled), this.startSyncInterval(), this.setupNoteStream(), await this.savePluginData(this.syncEngine.getLastSync()), this.hasAuthConfigured() && this.registerVault().then(async (registered) => {
+    this.api.updateConfig(this.settings.apiUrl, this.settings.apiKey), this.api.setVaultId(this.settings.vaultId), this.api.setTracingEnabled(this.settings.diagnosticsEnabled), this.syncEngine.updateSettings(this.settings), rlog().setEnabled(this.settings.diagnosticsEnabled), this.startSyncInterval(), this.setupNoteStream(), await this.savePluginData(this.syncEngine.getLastSync()), this.hasAuthConfigured() && this.registerVault().then(async (registered) => {
       if (!registered) return;
       if (!await this.applySyncGate())
         return this.doSyncWithFirstSyncCheck();

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -2,7 +2,7 @@
  * Verbose diagnostic firehose. Emits metadata-only log lines for vault and
  * workspace activity so a WS "blip" can be reconstructed from the client side.
  * NEVER logs note content: only path, event kind, byte counts, and timing.
- * Gated by the diagnosticMode setting (which itself requires remoteLoggingEnabled).
+ * Gated by the single diagnosticsEnabled setting.
  */
 import { type App, TFile, TFolder } from "obsidian";
 import { rlog } from "./remote-log";
@@ -24,11 +24,11 @@ export function formatVaultEvent(
 interface DiagnosticsHost {
 	app: App;
 	registerEvent(ref: unknown): void;
-	settings: { diagnosticMode: boolean };
+	settings: { diagnosticsEnabled: boolean };
 }
 
 export function registerDiagnostics(plugin: DiagnosticsHost): void {
-	const on = () => plugin.settings.diagnosticMode;
+	const on = () => plugin.settings.diagnosticsEnabled;
 	const emit = (kind: EventKind, path: string, extra?: Record<string, string | number>) => {
 		if (!on()) return;
 		rlog().diag("vault", formatVaultEvent(kind, path, extra));

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
 	seededAccessToken,
 } from "./auth";
 import { migrateCloudApiUrl, withClearedAuth } from "./auth-state";
+import { migrateDiagnosticsEnabled } from "./settings-migrate";
 import { NoteChannel } from "./channel";
 import { ConflictModal } from "./conflict-modal";
 import { errMsg } from "./error-util";
@@ -222,7 +223,7 @@ export default class EngramSyncPlugin extends Plugin {
 		// Wire the per-install device id (minted in loadSettings) onto the real
 		// api instance before any sync runs, so cursor pulls carry X-Device-Id.
 		this.api.setDeviceId(this.deviceId);
-		this.api.setTracingEnabled(this.settings.tracingEnabled);
+		this.api.setTracingEnabled(this.settings.diagnosticsEnabled);
 
 		this.authProvider = this.createAuthProvider();
 		if (this.authProvider) {
@@ -236,7 +237,7 @@ export default class EngramSyncPlugin extends Plugin {
 			this.manifest.version,
 			Platform.isMobile ? "mobile" : "desktop",
 		);
-		remoteLogger.setEnabled(this.settings.remoteLoggingEnabled);
+		remoteLogger.setEnabled(this.settings.diagnosticsEnabled);
 		remoteLogger.setClientContext(this.deviceId, this.settings.vaultId);
 		rlog().info(
 			"lifecycle",
@@ -780,6 +781,14 @@ export default class EngramSyncPlugin extends Plugin {
 	async loadSettings(): Promise<void> {
 		const data = await this.loadPluginData();
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, data?.settings);
+		// Collapse the legacy remoteLoggingEnabled / diagnosticMode / tracingEnabled
+		// toggles into the single diagnosticsEnabled (on if any legacy one was on),
+		// then drop the stale keys so the next save persists only the new shape.
+		const rawSettings = data?.settings as Record<string, unknown> | undefined;
+		this.settings.diagnosticsEnabled = migrateDiagnosticsEnabled(rawSettings);
+		for (const legacy of ["remoteLoggingEnabled", "diagnosticMode", "tracingEnabled"]) {
+			delete (this.settings as unknown as Record<string, unknown>)[legacy];
+		}
 		this.syncGateAcceptedFor = data?.syncGateAcceptedFor ?? null;
 		this.noteIdMap = NoteIdMap.fromJSON(data?.noteIds);
 		// Migrate a stored Cloud apiUrl off the legacy SPA host (app.engram.page,
@@ -821,9 +830,9 @@ export default class EngramSyncPlugin extends Plugin {
 	async saveSettings(): Promise<void> {
 		this.api.updateConfig(this.settings.apiUrl, this.settings.apiKey);
 		this.api.setVaultId(this.settings.vaultId);
-		this.api.setTracingEnabled(this.settings.tracingEnabled);
+		this.api.setTracingEnabled(this.settings.diagnosticsEnabled);
 		this.syncEngine.updateSettings(this.settings);
-		rlog().setEnabled(this.settings.remoteLoggingEnabled);
+		rlog().setEnabled(this.settings.diagnosticsEnabled);
 		this.startSyncInterval();
 		this.setupNoteStream();
 		await this.savePluginData(this.syncEngine.getLastSync());

--- a/src/settings-migrate.ts
+++ b/src/settings-migrate.ts
@@ -1,0 +1,16 @@
+/**
+ * Settings migrations for persisted plugin data (data.json `settings`).
+ */
+
+/** Collapse the three legacy diagnostics toggles — `remoteLoggingEnabled`,
+ *  `diagnosticMode`, `tracingEnabled` — into the single `diagnosticsEnabled`.
+ *
+ *  An already-migrated blob (has a boolean `diagnosticsEnabled`) is returned
+ *  verbatim so re-running is idempotent. Otherwise diagnostics turns ON if ANY
+ *  legacy toggle was on, so a user who had remote logging or tracing enabled
+ *  keeps it after the upgrade. */
+export function migrateDiagnosticsEnabled(raw: Record<string, unknown> | undefined): boolean {
+	if (!raw) return false;
+	if (typeof raw.diagnosticsEnabled === "boolean") return raw.diagnosticsEnabled;
+	return Boolean(raw.remoteLoggingEnabled || raw.diagnosticMode || raw.tracingEnabled);
+}

--- a/src/tabs/advanced-tab.ts
+++ b/src/tabs/advanced-tab.ts
@@ -83,35 +83,13 @@ export function renderAdvancedTab(ctx: TabContext): void {
 	new Setting(containerEl).setName("Diagnostics").setHeading();
 
 	new Setting(containerEl)
-		.setName("Remote logging")
-		.setDesc("Send sync events to the server for remote debugging.")
-		.addToggle((toggle) =>
-			toggle.setValue(plugin.settings.remoteLoggingEnabled).onChange(async (value) => {
-				plugin.settings.remoteLoggingEnabled = value;
-				await plugin.saveSettings();
-			}),
-		);
-
-	new Setting(containerEl)
-		.setName("Diagnostic mode (verbose)")
+		.setName("Diagnostics")
 		.setDesc(
-			"Log detailed vault and connection activity for troubleshooting. Metadata only, never note content. Requires remote logging. Leave off for normal use.",
+			"Send detailed sync, vault, and connection activity to the server for troubleshooting, with distributed tracing on requests. Metadata only, never note content. Leave off for normal use.",
 		)
 		.addToggle((toggle) =>
-			toggle.setValue(plugin.settings.diagnosticMode).onChange(async (value) => {
-				plugin.settings.diagnosticMode = value;
-				await plugin.saveSettings();
-			}),
-		);
-
-	new Setting(containerEl)
-		.setName("Distributed tracing")
-		.setDesc(
-			"Attach a trace ID to sync requests and report timing to the server for cross-system debugging. No note content is sent.",
-		)
-		.addToggle((toggle) =>
-			toggle.setValue(plugin.settings.tracingEnabled).onChange(async (value) => {
-				plugin.settings.tracingEnabled = value;
+			toggle.setValue(plugin.settings.diagnosticsEnabled).onChange(async (value) => {
+				plugin.settings.diagnosticsEnabled = value;
 				await plugin.saveSettings();
 			}),
 		);

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,12 @@ export interface EngramSyncSettings {
 	debounceMs: number;
 	/** Preferred conflict diff view: unified or side-by-side */
 	conflictViewMode: "unified" | "side-by-side";
-	/** Send errors and sync lifecycle events to the server for remote debugging */
-	remoteLoggingEnabled: boolean;
-	/** Verbose diagnostic firehose: log vault/editor + WS/sync events (metadata
-	 *  only, never content). Requires remoteLoggingEnabled. Default OFF. */
-	diagnosticMode: boolean;
+	/** Single diagnostics switch. When on: ship sync/error events AND verbose
+	 *  vault/editor/WS activity to the server, AND attach distributed-tracing
+	 *  headers to requests. Metadata only, never note content. Default OFF.
+	 *  Collapses the former remoteLoggingEnabled / diagnosticMode / tracingEnabled
+	 *  trio (migrated in settings-migrate.ts). */
+	diagnosticsEnabled: boolean;
 	/** How to handle conflicts that can't be auto-merged.
 	 *  "auto" creates a conflict copy file (non-blocking).
 	 *  "modal" shows the interactive diff modal. */
@@ -61,11 +62,6 @@ export interface EngramSyncSettings {
 	/** True once the first-run waitlist popup has been shown (submitted OR
 	 *  dismissed). Set once, never re-shown. */
 	waitlistPromptSeen?: boolean;
-	/** Dark-launch gate for distributed tracing: inject a `traceparent` header
-	 *  on backend requests and emit a coalesced `obsidian.push` beacon. Default
-	 *  OFF: when false, sendRequest does no id generation, no timing capture,
-	 *  no header, and enqueues nothing (single boolean check). */
-	tracingEnabled: boolean;
 }
 
 /** Which search backend the panel uses. */
@@ -98,8 +94,7 @@ export const DEFAULT_SETTINGS: EngramSyncSettings = {
 	ignorePatterns: "",
 	debounceMs: 2000,
 	conflictViewMode: "unified",
-	remoteLoggingEnabled: false,
-	diagnosticMode: false,
+	diagnosticsEnabled: false,
 	conflictResolution: "auto",
 	enableCrdt: true,
 	vaultId: null,
@@ -107,7 +102,6 @@ export const DEFAULT_SETTINGS: EngramSyncSettings = {
 	planState: null,
 	searchDefaultMode: "hybrid",
 	waitlistPromptSeen: false,
-	tracingEnabled: false,
 };
 
 /** A note as returned by POST /notes */

--- a/tests/auth-state.test.ts
+++ b/tests/auth-state.test.ts
@@ -23,7 +23,7 @@ const fullSettings = (override: Partial<EngramSyncSettings> = {}): EngramSyncSet
 	ignorePatterns: "node_modules",
 	debounceMs: 2000,
 	conflictViewMode: "unified",
-	remoteLoggingEnabled: false,
+	diagnosticsEnabled: false,
 	conflictResolution: "auto",
 	...override,
 });
@@ -176,14 +176,14 @@ describe("withClearedAuth", () => {
 			clientId: "stable-client-id",
 			ignorePatterns: "tmp/**",
 			debounceMs: 1500,
-			remoteLoggingEnabled: true,
+			diagnosticsEnabled: true,
 		});
 		const cleared = withClearedAuth(before);
 		expect(cleared.apiUrl).toBe("http://engram.ax");
 		expect(cleared.clientId).toBe("stable-client-id");
 		expect(cleared.ignorePatterns).toBe("tmp/**");
 		expect(cleared.debounceMs).toBe(1500);
-		expect(cleared.remoteLoggingEnabled).toBe(true);
+		expect(cleared.diagnosticsEnabled).toBe(true);
 	});
 
 	test("does not mutate input settings object", () => {

--- a/tests/settings-defaults.test.ts
+++ b/tests/settings-defaults.test.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_SETTINGS } from "../src/types";
 
-test("diagnosticMode defaults OFF (Obsidian opt-in rule)", () => {
-	expect(DEFAULT_SETTINGS.diagnosticMode).toBe(false);
+test("diagnosticsEnabled defaults OFF (Obsidian opt-in rule)", () => {
+	expect(DEFAULT_SETTINGS.diagnosticsEnabled).toBe(false);
 });

--- a/tests/settings-migrate.test.ts
+++ b/tests/settings-migrate.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Migration: the three legacy diagnostics toggles (remoteLoggingEnabled,
+ * diagnosticMode, tracingEnabled) collapse into one `diagnosticsEnabled`.
+ * On upgrade, diagnostics is ON if ANY of the legacy toggles was on, so a user
+ * who had remote logging or tracing enabled keeps it. An explicit new value
+ * always wins (re-migration must be idempotent).
+ */
+import { describe, expect, test } from "bun:test";
+import { migrateDiagnosticsEnabled } from "../src/settings-migrate";
+
+describe("migrateDiagnosticsEnabled", () => {
+	test("undefined / empty persisted settings -> off", () => {
+		expect(migrateDiagnosticsEnabled(undefined)).toBe(false);
+		expect(migrateDiagnosticsEnabled({})).toBe(false);
+	});
+
+	test("any legacy toggle on -> on", () => {
+		expect(migrateDiagnosticsEnabled({ remoteLoggingEnabled: true })).toBe(true);
+		expect(migrateDiagnosticsEnabled({ diagnosticMode: true })).toBe(true);
+		expect(migrateDiagnosticsEnabled({ tracingEnabled: true })).toBe(true);
+	});
+
+	test("all legacy toggles off -> off", () => {
+		expect(
+			migrateDiagnosticsEnabled({
+				remoteLoggingEnabled: false,
+				diagnosticMode: false,
+				tracingEnabled: false,
+			}),
+		).toBe(false);
+	});
+
+	test("explicit new value wins over legacy (idempotent re-migration)", () => {
+		// Already migrated: diagnosticsEnabled present -> use it verbatim.
+		expect(migrateDiagnosticsEnabled({ diagnosticsEnabled: true })).toBe(true);
+		expect(
+			migrateDiagnosticsEnabled({ diagnosticsEnabled: false, remoteLoggingEnabled: true }),
+		).toBe(false);
+	});
+});


### PR DESCRIPTION
**Parked, not proposed.** Surfaced by a worktree audit — this branch was local-only (never pushed, no PR) and would have been permanently lost on cleanup. Opening as a draft so it's recoverable and discoverable; no claim that it should merge as-is.

## What it does

Collapses three separate diagnostics toggles in plugin settings into a single control. 1 commit, 9 files, +109/-74 — a net simplification of the settings surface, with `tests/settings-migrate.test.ts` (+40) covering migration of existing users off the three old keys.

## Audit notes

- Last touched **2026-07-07** — roughly 66 commits of `main` ago. Expect conflicts and red CI against current `main`.
- The migration test is the load-bearing part: users on the old three-key shape need their settings carried over, so this is not a pure UI change.
- Settings have moved since (CRDT relay rework, enrollment removal), so the three keys this collapses may no longer all exist. **Verify the old keys are still present before rebasing** — if they're gone, the migration path is the only salvageable piece.

## Decision needed

Rebase and verify the three source toggles still exist — or close this and delete the branch, keeping the settings-migration pattern in mind for whenever the diagnostics surface next gets touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fXPYtAKeUBLKjW9QmVRpZ