### PR TITLE
fix(crdt): never gate the syncStep1 pull on the create-ack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,5 +173,6 @@ Required status checks on `main`: `build-and-test`, `version-check / version-che
 - Editor-binding stale-buffer race (note content copied into a DIFFERENT file on file-switch, PR #194 — bindTo await gap, sync-detach-before-await + bindEpoch + drift view-identity-guard fix) → `docs/context/crdt-editor-bind-race-pollution.md`
 - Missed CRDT delivery healing (catch-up convergence: id adoption parity, base_hash CAS 409, pull backfill, socket vault-catchup via `catchupViaSocket()`) → `docs/context/sync-catchup-convergence.md`
 - Convergence sim tier fidelity gaps (`tests/sim/` — differential gate pays rent; seeded random-op suite does NOT converge, kept as a runnable tool not a test) → `docs/context/crdt-convergence-sim-fidelity-gaps.md`
+- A note that logs `re-handshake fired` and then goes silent forever (the create-ack gate swallowing syncStep1; plus how to read `ci-debug` client logs without misordering them) → `docs/context/crdt-pull-gated-by-create-ack.md`
 
 @/home/open-claw/documents/code-projects/ops-agent/docs/self-updating-docs.md

--- a/docs/context/crdt-pull-gated-by-create-ack.md
+++ b/docs/context/crdt-pull-gated-by-create-ack.md
@@ -1,0 +1,95 @@
+# A note that never heals: the create-ack gate swallowing syncStep1
+
+**Trigger:** a note's disk content is stale, the client logs
+`CRDT catch-up: diverged cold note, socket re-handshake` followed by
+`socket converge: re-handshake fired`, and then **nothing** — no STEP2, no
+flush, no retry. The server log has no inbound frame for that note_id at all.
+
+Found via e2e `test_48_oauth_reconnect_catchup.py::test_oauth_reconnect_receives_update`
+(`engram#1130`), fixed in plugin #335.
+
+## The mechanism
+
+`socketConverge` → `fireCrdtReHandshake` → `ProviderRegistry.reset` + `enroll`
+→ `startSync` → `NoteProvider.sendSyncStep1`. That send goes through the SAME
+transport closure as ops, and that closure is wrapped by the create-before-edit
+gate:
+
+```
+wiring.ts        send: (docId, frame, kind) => { if (kind === "op" && !canSendLive(docId)) hold }
+main.ts          canSendLive: (id) => syncEngine.hasServerNote(id)
+sync.ts          hasServerNote(id) === (getCrdtHead(pathForId(id)) != null)
+```
+
+Before #335 the gate had no `kind`, so it held the pull too. Worse:
+`sendSyncStep1` calls `send` **directly** rather than `broadcast`, so a refused
+pull is not buffered — it is dropped outright, and no later flush replays it.
+
+`crdtHead` is set ONLY by:
+
+- `applyPushedNoteUpdate` / `adoptHistoryLessNote` — a `note_yjs_update`
+  vault-channel fan-out actually landing, or
+- a local create-ack (`CRDT_HEAD_CREATED` sentinel) from `pushFile` / the
+  durable create queue.
+
+**Neither happens for a note created over REST by another writer and discovered
+here via `note_changed`.** `note_changed` materializes the body to disk and sets
+`serverHash`, never a head. If that note's `note_yjs_update` fan-out lands while
+the socket is down, this device holds the note with no head forever, and the one
+recovery path (re-handshake) is gated off. Permanently deaf.
+
+Blast radius is bounded: a later LOCAL edit routes REST (precisely because
+`hasServerNote` is false), which flips the head and unsticks it. So the symptom
+is "this note stopped receiving remote updates until I typed in it", not silent
+loss.
+
+## Reading the evidence (the trap that cost the first two sessions)
+
+`e2e-clerk` uploads `ci-debug-<head-sha>` (e2e-crdt uses `ci-crdt-debug-<sha>`).
+The plugin's own logs ship to the backend, so they live in `docker-compose.log`,
+not `pytest-e2e.log`:
+
+```bash
+export GH_REPO=engram-app/engram
+gh run download <run-id> -n "ci-debug-<head-sha>"
+
+# client trail for one user, in file order
+grep '"category":"client"' docker-compose.log \
+  | grep '<hashed-user-id>' | sed 's/^engram-1 *| *//' \
+  | jq -r '"\(.time) \(.metadata.conn_id // "-" | .[0:8]) \(.message)"'
+
+# server-side truth for the same vault
+grep -v '"category":"client"' docker-compose.log | grep '<vault-id>' \
+  | sed 's/^engram-1 *| *//' | jq -r '"\(.time) \(.severity) \(.message)"'
+```
+
+**Do not order client lines by their `time` field.** It is the timestamp of the
+remote logger's batching POST, so a whole batch shares one millisecond and
+`sort` scrambles causality. Order by file position, and take real timing from
+the SERVER lines (`sync broadcast emit`, `crdt join` / `crdt leave`, `ws connect`).
+Two prior sessions on this bug misattributed cause from batch timestamps — one
+chased an auth flip that was actually teardown 92s later, one attributed a
+diverged-row line to the wrong version of the note.
+
+`conn_id` (in client metadata, and in the socket `Parameters` on the server
+side) is what separates the pre-disconnect connection from the reconnect.
+
+## Ruled out — do not re-walk
+
+- **`crdt_catchup_since` / cursor selection.** The feed served the diverged row
+  correctly; the `diverged cold note` line IS that row.
+- **Unadvertised-resident-doc reconnect.** Headless GREEN 6 covers it, passes.
+- **REST write vs live room split-brain.** `do_rewrite_note` → `maybe_merge_crdt`
+  persists the merged `crdt_state_ciphertext`, so a room hydrated after a REST
+  update projects the new content. Headless repro passes.
+- **`setAdvertised` transition guard.** `reset()` flips it false, `enroll()`
+  true — the edge fires.
+- **OAuth identity drift.** Verified intact at re-handshake time; the api-key
+  flip in the logs is the test's own `finally`.
+
+## Invariant to keep
+
+A **pull** (syncStep1 — a bare state vector, no content) must never be subject
+to a gate that exists to protect **writes**. The server answers an unknown
+`doc_id` with `note_not_found`, so an un-acked pull costs one error reply. A
+held pull costs the note.

--- a/main.js
+++ b/main.js
@@ -21362,7 +21362,7 @@ var NoteProvider = class {
   /** Relay's broadcastMessage: send now if connected, else buffer for the next
    *  onopen flush. A refused send (transport down mid-flight) also buffers. */
   broadcast(frame) {
-    this.connected && this.send(frame) || this.buffer.push(frame);
+    this.connected && this.send(frame, "op") || this.buffer.push(frame);
   }
   /** Relay's onopen: (re)connect the transport. */
   connect() {
@@ -21392,11 +21392,11 @@ var NoteProvider = class {
     this.connected = !0, this.advertised && !wasConnected && this.sendSyncStep1();
     let pending = this.buffer.splice(0);
     for (let frame of pending)
-      this.send(frame) || this.buffer.push(frame);
+      this.send(frame, "op") || this.buffer.push(frame);
   }
   sendSyncStep1() {
     let encoder = createEncoder();
-    writeVarUint(encoder, MESSAGE_SYNC), writeSyncStep1(encoder, this.doc), this.send(toB64(toUint8Array(encoder)));
+    writeVarUint(encoder, MESSAGE_SYNC), writeSyncStep1(encoder, this.doc), this.send(toB64(toUint8Array(encoder)), "pull");
   }
   /** Relay's messageHandlers[messageSync]: apply an inbound frame and, for an
    *  inbound syncStep1, reply with syncStep2. The reply is sent ONLY when it
@@ -21502,8 +21502,11 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
       // syncStep1 on connect advertises the hydrated state instead.
       deferActivation: !0,
       // Create-ack gate: a held note reads as REFUSED so its frames buffer in
-      // the provider and flush once the server row exists.
-      send: (frame) => (this.opts.canSendLive ? !this.opts.canSendLive(noteId) : !1) ? !1 : this.opts.send(noteId, frame),
+      // the provider and flush once the server row exists. OPS only — a
+      // "pull" (syncStep1) carries no content and is the sole way a note whose
+      // fan-out this device missed can converge, so gating it made the
+      // diverged-note heal a permanent no-op (#1130).
+      send: (frame, kind2) => (kind2 === "op" && this.opts.canSendLive ? !this.opts.canSendLive(noteId) : !1) ? !1 : this.opts.send(noteId, frame, kind2),
       onSynced: () => {
         var _a2, _b2, _c2, _d;
         (_b2 = (_a2 = this.opts).onSynced) == null || _b2.call(_a2, noteId), text2.length === 0 && ((_d = (_c2 = this.opts).onEmptyStep2) == null || _d.call(_c2, noteId));
@@ -21812,8 +21815,8 @@ function createCrdtWiring(deps) {
   }
   let unsentDocIds = /* @__PURE__ */ new Set(), registry = new ProviderRegistry({
     dbPrefix: deps.dbPrefix,
-    send: (docId, frame) => {
-      if (deps.canSendLive && !deps.canSendLive(docId))
+    send: (docId, frame, kind) => {
+      if (kind === "op" && deps.canSendLive && !deps.canSendLive(docId))
         return unsentDocIds.add(docId), !1;
       let ok = deps.sendCrdt(docId, frame) !== !1;
       if (ok)

--- a/src/crdt/note-provider.ts
+++ b/src/crdt/note-provider.ts
@@ -20,10 +20,18 @@ import * as syncProtocol from "y-protocols/sync";
 import type * as Y from "yjs";
 import { MESSAGE_SYNC, fromB64, toB64 } from "./wire";
 
+/** What a frame is FOR, so a transport can gate the two classes differently:
+ *  `"pull"` is syncStep1 — a bare state vector requesting the peer's ops, no
+ *  content. `"op"` is everything else (local updates, syncStep2 replies) —
+ *  content leaving this device. The create-before-edit gate holds `"op"` only:
+ *  holding a `"pull"` makes a note that missed its fan-out permanently deaf
+ *  (#1130). */
+export type FrameKind = "pull" | "op";
+
 /** Transport: hand a base64 y-protocols frame to the wire. Returns false when
  *  the frame could NOT be delivered (socket not joined) so the provider holds it
  *  and flushes on reconnect — mirroring Relay's `wsconnected` buffer gate. */
-export type ProviderSend = (frame: string) => boolean;
+export type ProviderSend = (frame: string, kind: FrameKind) => boolean;
 
 export interface NoteProviderOpts {
 	send?: ProviderSend;
@@ -115,7 +123,7 @@ export class NoteProvider {
 	/** Relay's broadcastMessage: send now if connected, else buffer for the next
 	 *  onopen flush. A refused send (transport down mid-flight) also buffers. */
 	private broadcast(frame: string): void {
-		const sent = this.connected && this.send(frame);
+		const sent = this.connected && this.send(frame, "op");
 		if (sent) return;
 		this.buffer.push(frame);
 	}
@@ -159,8 +167,10 @@ export class NoteProvider {
 		if (this.advertised && !wasConnected) this.sendSyncStep1();
 		// Flush anything buffered while offline; re-buffer whatever is still refused.
 		const pending = this.buffer.splice(0);
+		// Only `broadcast` buffers, and it only ever buffers ops — syncStep1 is
+		// re-derived from the live state vector on each connect edge, never replayed.
 		for (const frame of pending) {
-			if (!this.send(frame)) this.buffer.push(frame);
+			if (!this.send(frame, "op")) this.buffer.push(frame);
 		}
 	}
 
@@ -168,7 +178,7 @@ export class NoteProvider {
 		const encoder = encoding.createEncoder();
 		encoding.writeVarUint(encoder, MESSAGE_SYNC);
 		syncProtocol.writeSyncStep1(encoder, this.doc);
-		this.send(toB64(encoding.toUint8Array(encoder)));
+		this.send(toB64(encoding.toUint8Array(encoder)), "pull");
 	}
 
 	/** Relay's messageHandlers[messageSync]: apply an inbound frame and, for an

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -14,7 +14,7 @@ import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 import { projectCanvas, seedCanvasInto } from "./canvas-codec";
 import { CONTENT_KEY, frontmatterOf, projectNote, rawFrontmatterOf } from "./frontmatter-codec";
-import { NoteProvider } from "./note-provider";
+import { type FrameKind, NoteProvider } from "./note-provider";
 import { docHasHistory, seedContentInto } from "./note-seed";
 
 export type DocKind = "note" | "canvas";
@@ -48,8 +48,9 @@ export interface ProviderRegistryOpts {
 	dbPrefix?: string;
 	/** Transport: base64 frame → wire for `noteId`. False when the socket isn't
 	 *  joined (provider buffers + flushes on rejoin). Read the CURRENT socket at
-	 *  call time so a reconnect is transparent. */
-	send: (noteId: string, frame: string) => boolean;
+	 *  call time so a reconnect is transparent. `kind` distinguishes a content-less
+	 *  `"pull"` (syncStep1) from an `"op"` so the create-ack gate holds ops only. */
+	send: (noteId: string, frame: string, kind: FrameKind) => boolean;
 	/** Write a REMOTE-merged doc back to disk (echo-suppressed). Returns false /
 	 *  throws on a real write failure so applyRemoteUpdate can propagate it. */
 	onFlushToDisk: (
@@ -141,10 +142,14 @@ export class ProviderRegistry {
 			// syncStep1 on connect advertises the hydrated state instead.
 			deferActivation: true,
 			// Create-ack gate: a held note reads as REFUSED so its frames buffer in
-			// the provider and flush once the server row exists.
-			send: (frame) => {
-				const gated = this.opts.canSendLive ? !this.opts.canSendLive(noteId) : false;
-				return gated ? false : this.opts.send(noteId, frame);
+			// the provider and flush once the server row exists. OPS only — a
+			// "pull" (syncStep1) carries no content and is the sole way a note whose
+			// fan-out this device missed can converge, so gating it made the
+			// diverged-note heal a permanent no-op (#1130).
+			send: (frame, kind) => {
+				const gated =
+					kind === "op" && this.opts.canSendLive ? !this.opts.canSendLive(noteId) : false;
+				return gated ? false : this.opts.send(noteId, frame, kind);
 			},
 			onSynced: () => {
 				this.opts.onSynced?.(noteId);

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -260,9 +260,16 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 	// provider sends its own local updates through this `send`.
 	const registry = new ProviderRegistry({
 		dbPrefix: deps.dbPrefix,
-		send: (docId, frame) => {
-			// Create-before-edit: hold frames until the note's server row exists.
-			if (deps.canSendLive && !deps.canSendLive(docId)) {
+		send: (docId, frame, kind) => {
+			// Create-before-edit: hold OPS until the note's server row exists. Never
+			// hold a "pull" (syncStep1) — it carries no content, the server answers an
+			// unknown doc_id with note_not_found, and it is the only way a note this
+			// device holds no crdtHead for can converge. Holding it made
+			// socketConverge's diverged-note re-handshake a silent no-op for every
+			// note discovered via note_changed whose Yjs fan-out was missed (#1130,
+			// e2e test_48): hasServerNote stayed false forever, so the heal frame was
+			// dropped and the note never caught up.
+			if (kind === "op" && deps.canSendLive && !deps.canSendLive(docId)) {
 				unsentDocIds.add(docId);
 				return false;
 			}

--- a/tests/crdt-create-ack-gate.test.ts
+++ b/tests/crdt-create-ack-gate.test.ts
@@ -17,7 +17,10 @@
 import { describe, expect, mock, test } from "bun:test";
 import "fake-indexeddb/auto";
 import { TFile } from "obsidian";
+import * as Y from "yjs";
+import { CONTENT_KEY } from "../src/crdt/frontmatter-codec";
 import { NoteIdMap } from "../src/crdt/note-id-map";
+import { NoteProvider } from "../src/crdt/note-provider";
 import { ProviderRegistry } from "../src/crdt/provider-registry";
 import { CRDT_HEAD_CREATED, SyncEngine } from "../src/sync";
 import { DEFAULT_SETTINGS } from "../src/types";
@@ -74,6 +77,89 @@ describe("create-ack gate on live send", () => {
 		mgr.setConnected(true);
 		await mgr.applyLocalEdit("note-1", "hello");
 		expect(send).toHaveBeenCalled();
+		await mgr.destroyAll();
+	});
+
+	// #1130 (e2e test_48): the gate is CREATE-BEFORE-EDIT — it holds outbound
+	// OPS for a note whose server row may not exist yet. syncStep1 is a PULL
+	// (a bare state vector, no content), and it is the ONLY way a diverged
+	// note whose Yjs fan-out this device missed can ever converge. Gating it
+	// made `socketConverge`'s re-handshake a silent no-op for exactly those
+	// notes: a REST-created note discovered via note_changed sets no crdtHead,
+	// so hasServerNote stays false forever and the heal never reaches the wire.
+	// The server answers an unknown doc_id with note_not_found, so an
+	// un-acked pull is harmless.
+	test("enroll's syncStep1 PULL is NOT held by the create-ack gate", async () => {
+		const send = mock(() => true);
+		const mgr = new ProviderRegistry({
+			dbPrefix: "gate-step1-pull",
+			send,
+			onFlushToDisk: async () => {},
+			canSendLive: () => false, // no crdtHead recorded for this note
+		});
+		mgr.setConnected(true);
+		await mgr.startSync("note-1");
+		expect(send).toHaveBeenCalled();
+		await mgr.destroyAll();
+	});
+
+	// The whole #1130 shape end-to-end through the real sync protocol: this
+	// device holds no crdtHead for the note (its Yjs fan-out landed while the
+	// socket was down), the op-log row says the server's copy diverged, and the
+	// only recovery is socketConverge's reset+enroll. With the pull gated the
+	// server never hears the handshake and disk stays stale forever.
+	test("a headless note heals from the server over the enroll handshake", async () => {
+		const server = new Y.Doc();
+		server.getText(CONTENT_KEY).insert(0, "# V2\nUpdated while disconnected");
+		const peer = new NoteProvider(server);
+		const flushed: string[] = [];
+		const mgr = new ProviderRegistry({
+			dbPrefix: "gate-step1-heal",
+			send: (_id, frame) => {
+				queueMicrotask(() => peer.receive(frame));
+				return true;
+			},
+			onFlushToDisk: async (_id, content) => {
+				flushed.push(content);
+			},
+			canSendLive: () => false, // no crdtHead — the note is "unknown" to the gate
+		});
+		peer.setSend((frame) => {
+			void mgr.receive("note-1", frame);
+			return true;
+		});
+		peer.connect(); // the stand-in server's transport is up (it never advertises)
+		mgr.setConnected(true);
+
+		await mgr.startSync("note-1"); // socketConverge's enroll
+		await new Promise<void>((r) => setTimeout(r, 20));
+
+		expect(await mgr.projectedText("note-1")).toContain("Updated while disconnected");
+		expect(flushed.at(-1)).toContain("Updated while disconnected");
+		await mgr.destroyAll();
+		peer.destroy();
+	});
+
+	test("a held note still pulls on reconnect while its ops stay held", async () => {
+		const frames: string[] = [];
+		const send = mock((_id: string, frame: string) => {
+			frames.push(frame);
+			return true;
+		});
+		const mgr = new ProviderRegistry({
+			dbPrefix: "gate-step1-reconnect",
+			send,
+			onFlushToDisk: async () => {},
+			canSendLive: () => false,
+		});
+		mgr.setConnected(true);
+		await mgr.startSync("note-1");
+		const afterEnroll = frames.length;
+		await mgr.applyLocalEdit("note-1", "local edit"); // op — still held
+		expect(frames.length).toBe(afterEnroll);
+		mgr.setConnected(false);
+		mgr.setConnected(true); // reconnect re-advertises
+		expect(frames.length).toBeGreaterThan(afterEnroll);
 		await mgr.destroyAll();
 	});
 });


### PR DESCRIPTION
## Root cause (e2e test_48, `engram-app/engram#1130`)

The create-before-edit gate (`canSendLive` → `SyncEngine.hasServerNote`) exists to hold a note's outbound frames until its server row exists. `NoteProvider.sendSyncStep1` routes through the same transport, so the gate also swallowed the **pull** half of the handshake. Worse, `sendSyncStep1` calls `send` directly rather than `broadcast`, so a refused pull is dropped outright — not even buffered for the next flush.

`hasServerNote` is backed only by `crdtHead`, which is set by a Yjs fan-out apply or a local create-ack. A note created over REST **elsewhere** and discovered here via `note_changed` sets no head. Once that's true, `socketConverge`'s diverged-note re-handshake can never reach the wire — the note is permanently deaf.

## Evidence

`test_48::test_oauth_reconnect_receives_update`, CI run `30217780768`, backend `docker-compose.log` (client remote-log trail, one OAuth user):

```
19:56:42.222  note_changed  upsert V1  (client writes 21 bytes to disk — no head)
19:56:42.235  crdt leave                <- test's disconnect_stream
19:56:42.327  note_yjs_update V1        <- MISSED (would have set crdtHead)
19:56:42.754  note_changed  upsert V2   <- MISSED
19:56:42.756  note_yjs_update V2        <- MISSED
19:56:42.768  crdt join                 <- reconnect
   ...        CRDT catch-up: diverged cold note, socket re-handshake
   ...        socket converge: re-handshake fired
   <silence for the full 120s timeout>
```

The catch-up **did** present the V2 row and **did** detect divergence — so `crdt_catchup_since` and the cursor are not at fault (this supersedes the "next step" in #1130, which pointed at cursor selection). The heal fired into a closed gate. The server log has exactly four lines for that note_id, all fan-out broadcasts; it never received a single frame for it.

That also explains why the sibling create-case passes (no local file → the catch-up writes content directly, no handshake needed) and why the headless REST-update repro passes (B was online for the create, so it holds a head and the gate is open).

## Fix

Frames now carry a kind:

- `"pull"` — syncStep1, a bare state vector, no content. **Never gated.** The server answers an unknown `doc_id` with `note_not_found`, so an un-acked pull is harmless.
- `"op"` — local updates and syncStep2 replies. Held exactly as before.

Three call sites: `NoteProvider` (tags its own frames), `ProviderRegistry` (its `send` wrapper), `wiring.ts` (the production gate).

## Tests

`tests/crdt-create-ack-gate.test.ts` — 3 new, all red before the change:

- enroll's syncStep1 reaches the wire with `canSendLive: () => false`
- a held note re-advertises on reconnect while its ops stay held
- end-to-end through the real sync protocol: a headless registry linked to a peer `NoteProvider` holding V2 heals to V2 on enroll, and `onFlushToDisk` sees it

2197 pass / 0 fail, `tsc` clean, biome + eslint + stylelint clean.

## Verification owed

The e2e `test_48` itself gates this — watch `plugin-e2e-trigger`'s `e2e-clerk` conclusion on this PR.

Closes engram-app/engram#1130
Refs engram-app/engram#1128, engram-app/engram#646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ekpc5LX9FKiBiu6ZiUXsqb