### PR TITLE
fix(auth): never send a request with an empty bearer token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,7 @@ Required status checks on `main`: `build-and-test`, `version-check / version-che
 - V8 OOM prevention on large-vault operations → `docs/context/v8-oom-prevention.md`
 - Editor-binding stale-buffer race (note content copied into a DIFFERENT file on file-switch, PR #194 — bindTo await gap, sync-detach-before-await + bindEpoch + drift view-identity-guard fix) → `docs/context/crdt-editor-bind-race-pollution.md`
 - Missed CRDT delivery healing (catch-up convergence: id adoption parity, base_hash CAS 409, pull backfill, socket vault-catchup via `catchupViaSocket()`) → `docs/context/sync-catchup-convergence.md`
+- Prod `auth-failure-burst` alert traced to our own client (`Bearer ` with an empty token logs `reason=no_auth`, not `signature_error`; unlinked installs loop 401s and the log push re-reports them) → `docs/context/empty-bearer-no-auth-401-loop.md`
 - Convergence sim tier fidelity gaps (`tests/sim/` — differential gate pays rent; seeded random-op suite does NOT converge, kept as a runnable tool not a test) → `docs/context/crdt-convergence-sim-fidelity-gaps.md`
 
 @/home/open-claw/documents/code-projects/ops-agent/docs/self-updating-docs.md

--- a/docs/context/empty-bearer-no-auth-401-loop.md
+++ b/docs/context/empty-bearer-no-auth-401-loop.md
@@ -1,0 +1,77 @@
+# Context Doc: `Bearer ` with no token → `reason=no_auth` 401 loops
+
+_Last verified: 2026-07-26_
+
+## Status
+**Fixed** — plugin PR #336 (`fix/no-empty-bearer-requests`). Alert rule deliberately unchanged.
+
+## Symptom
+`engram-prod-loki-auth-failure-burst` (Grafana uid `cfq15flt31a0wd`, threshold `>20` warn/error `category=auth` lines per 10m) fires several times a day, values clustered just over threshold (21–102). Reads like credential stuffing. Isn't.
+
+## The mechanism (the reusable part)
+An empty bearer token and a garbage bearer token log **different reasons**, and the difference is the whole diagnosis:
+
+| Authorization header | logged `metadata_reason` |
+|---|---|
+| `Bearer ` (empty token) | `no_auth` |
+| `Bearer abc` (garbage) | `signature_error` |
+| absent | `no_auth` |
+
+Why: HTTP strips trailing whitespace from field values (RFC 9110 §5.5), so `Bearer ` arrives as the bare string `Bearer`. That misses the `["Bearer " <> token]` clause in `EngramWeb.Plugs.Auth.authenticate/1` (`engram/lib/engram_web/plugs/auth.ex`) and falls to `{:error, :no_auth}`.
+
+So **`no_auth` from a client that clearly has an Authorization header means an empty credential, not a missing header.** Sentry's `PlugContext` scrubs the `authorization` key out of the logged `__sentry__.request.headers` map, so you cannot tell by looking — absence of the key proves nothing. `X-Vault-ID` / `X-Device-Id` are *not* scrubbed, and their absence is real signal (an unlinked install has no vault).
+
+Confirm it in one shot instead of reasoning about it:
+```bash
+curl -s -o /dev/null -H "Authorization: Bearer " -H "User-Agent: engram-diag-emptytoken-probe" https://api.engram.page/api/me
+```
+then read the reason back out of Loki (see the recipes below).
+
+## Root cause (plugin)
+`src/api.ts` `getAuthToken()` returned `this.apiKey` when `authProvider` was null. For an OAuth install that field is `""`. `authProvider` gets nulled by:
+- `main.ts` `clearAuthAndPromptRelink()` — the server definitively rejected the stored refresh token, or a manual Disconnect
+- `auth-state.ts` `applyApiUrlChange()` — a backend switch
+
+Nothing gated sync, remote logging or the beacon on auth state (`grep isAuthenticated() src/main.ts src/sync.ts` → zero guards), so the install kept firing requests forever, each one an instant 401 plus a warn log line.
+
+**Self-amplifying:** two of the looping endpoints are `/api/logs` and `/api/telemetry/spans` — the client's own error reporting. It reports that it can't authenticate, that report is rejected, and the rejection is itself a `category=auth` warn line. In the 24h sampled, 200 of 890 lines were the observability channel complaining about itself.
+
+**Fix:** `getAuthToken()` throws on an empty credential (one guard on the shared request path, covers every caller), and the beacon transport thunk drops its batch while `lastToken` is empty — the beacon posts with `window.fetch`, so it bypasses that path.
+
+## Triage recipes
+
+Break the burst down by reason + file first — `no_auth` vs `signature_error` splits "empty credential" from "wrong key":
+```logql
+sum by (reason, file) (count_over_time(
+  {service="engram", env="prod"} | json
+  | metadata_category="auth" | severity=~"warning|error"
+  | label_format reason=`{{.metadata_reason}}`, file=`{{.metadata_file}}` [24h]))
+```
+
+Attribute to a client. Bracket syntax is required for hyphenated JSON keys, and the `__sentry__` blob is only reachable with a second `json` stage:
+```logql
+sum by (ip, country) (count_over_time(
+  {service="engram", env="prod"} | json
+  | metadata_category="auth" | metadata_reason="no_auth"
+  | json ip="metadata.__sentry__.request.headers[\"cf-connecting-ip\"]",
+         country="metadata.__sentry__.request.headers[\"cf-ipcountry\"]" [24h]))
+```
+
+`metadata_request_path` is `[REDACTED]` (RedactFilter), so get routes from Tempo instead:
+```traceql
+{resource.deployment.environment="prod" && span.http.response.status_code=401}
+  | count_over_time() by (span.http.route, span.client.address)
+```
+
+Firing history for any rule, with the evaluated value:
+```logql
+{from="state-history"} | json | ruleUID="cfq15flt31a0wd" | current=~"Alerting.*"
+```
+(datasource `grafanacloud-alert-state-history`; note `ruleUID` is a parsed field, not a stream label, so it cannot go in the selector.)
+
+## Don't misattribute to the dev machine
+`category=client` remote-log lines and `category=auth` rejections are different populations and can point at different people. In this incident the `client` lines were ~96% from the maintainer's home NAT (their own Obsidian instances), while every `no_auth` rejection came from three foreign installs. Same alert dashboard, unrelated causes. Check `cf-connecting-ip` before concluding "it's us" — and remember a household NAT cannot distinguish the dev box from a laptop or phone on the same wifi.
+
+## Related
+- [[auth-failure-burst-stale-token-on-backend-switch]] in the workspace repo — the socket `signature_error` class, and the earlier retune that excluded `user_socket.ex`. That exclusion is why this HTTP-side class was left fully exposed.
+- `spa-stale-socket-token-loop.md` — the backend mislabels expired Clerk tokens as `signature_error`, which muddies that reason but not `no_auth`.

--- a/main.js
+++ b/main.js
@@ -1014,12 +1014,12 @@ var EngramApi = class _EngramApi {
     this.lastToken = "";
     this.baseUrl = _EngramApi.normalizeBaseUrl(baseUrl), this.beacon = new BeaconBuffer(() => {
       var _a, _b;
-      return this.tracingEnabled ? {
+      return !this.tracingEnabled || !this.lastToken ? null : {
         baseUrl: this.baseUrl,
         token: this.lastToken,
         vaultId: (_a = this.getActiveVaultId()) != null ? _a : "",
         deviceId: (_b = this.deviceId) != null ? _b : ""
-      } : null;
+      };
     });
   }
   /** Enable/disable trace header injection + the obsidian.push beacon. When
@@ -1041,8 +1041,22 @@ var EngramApi = class _EngramApi {
   getActiveVaultId() {
     return this.authProvider ? this.authProvider.getVaultId() : this.vaultId;
   }
+  /** The credential for the next request, or a throw when there isn't one.
+   *
+   *  An empty token would go out as `Authorization: Bearer ` — the HTTP layer
+   *  strips trailing whitespace from field values, so the server receives a
+   *  bare `Bearer`, fails the `"Bearer " <> token` match in the Auth plug and
+   *  logs `reason=no_auth`. An unlinked install (authProvider nulled by
+   *  clearAuthAndPromptRelink / a backend switch, empty apiKey) otherwise
+   *  loops those 401s forever across folder pushes, log pushes and beacons —
+   *  including the log push carrying the complaint about the 401s. Failing
+   *  here instead keeps every one of those off the wire; a single guard in the
+   *  shared path covers all callers. */
   async getAuthToken() {
-    return this.authProvider ? this.authProvider.getToken() : this.apiKey;
+    let token = this.authProvider ? await this.authProvider.getToken() : this.apiKey;
+    if (!token)
+      throw new Error("Not authenticated: no API key or access token");
+    return token;
   }
   /** Strip trailing slashes and append /api if not already present. */
   static normalizeBaseUrl(url) {

--- a/src/api.ts
+++ b/src/api.ts
@@ -93,7 +93,9 @@ export class EngramApi {
 	) {
 		this.baseUrl = EngramApi.normalizeBaseUrl(baseUrl);
 		this.beacon = new BeaconBuffer(() => {
-			if (!this.tracingEnabled) return null;
+			// No credential = drop the batch. The beacon posts with window.fetch,
+			// so it bypasses the getAuthToken guard and would 401 on its own.
+			if (!this.tracingEnabled || !this.lastToken) return null;
 			return {
 				baseUrl: this.baseUrl,
 				token: this.lastToken,
@@ -130,11 +132,23 @@ export class EngramApi {
 		return this.vaultId;
 	}
 
+	/** The credential for the next request, or a throw when there isn't one.
+	 *
+	 *  An empty token would go out as `Authorization: Bearer ` — the HTTP layer
+	 *  strips trailing whitespace from field values, so the server receives a
+	 *  bare `Bearer`, fails the `"Bearer " <> token` match in the Auth plug and
+	 *  logs `reason=no_auth`. An unlinked install (authProvider nulled by
+	 *  clearAuthAndPromptRelink / a backend switch, empty apiKey) otherwise
+	 *  loops those 401s forever across folder pushes, log pushes and beacons —
+	 *  including the log push carrying the complaint about the 401s. Failing
+	 *  here instead keeps every one of those off the wire; a single guard in the
+	 *  shared path covers all callers. */
 	private async getAuthToken(): Promise<string> {
-		if (this.authProvider) {
-			return this.authProvider.getToken();
+		const token = this.authProvider ? await this.authProvider.getToken() : this.apiKey;
+		if (!token) {
+			throw new Error("Not authenticated: no API key or access token");
 		}
-		return this.apiKey;
+		return token;
 	}
 
 	/** Strip trailing slashes and append /api if not already present. */

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -841,6 +841,49 @@ describe("EngramApi", () => {
 			expect(opts.headers.Authorization).toBe(`Bearer ${TEST_KEY}`);
 		});
 
+		// An empty credential produces `Authorization: Bearer ` — the HTTP layer
+		// strips the trailing space, so the server sees a bare `Bearer` and logs
+		// reason=no_auth. An unlinked install used to loop those forever (prod
+		// 2026-07-26: 890 no_auth 401s/24h from 3 installs, tripping the
+		// auth-failure-burst alert). Never spend a request we know is a 401.
+		test("request refuses to send when the api key is empty", async () => {
+			const unauthed = new EngramApi(TEST_SERVER, "");
+			await expect(unauthed.getMe()).rejects.toThrow(/not authenticated/i);
+			expect(mockRequestUrl).not.toHaveBeenCalled();
+		});
+
+		test("request refuses to send when the provider yields an empty token", async () => {
+			const provider: AuthProvider = {
+				getToken: mock(() => Promise.resolve("")),
+				getVaultId: mock(() => null),
+				isAuthenticated: mock(() => false),
+				signOut: mock(() => {}),
+			};
+			api.setAuthProvider(provider);
+			await expect(api.getMe()).rejects.toThrow(/not authenticated/i);
+			expect(mockRequestUrl).not.toHaveBeenCalled();
+		});
+
+		test("beacon drops spans instead of posting them unauthenticated", () => {
+			const calls: any[] = [];
+			(global as any).fetch = (url: string, opts: unknown) => {
+				calls.push({ url, opts });
+				return Promise.resolve();
+			};
+			const unauthed = new EngramApi(TEST_SERVER, "");
+			unauthed.setTracingEnabled(true);
+			unauthed.beacon.enqueue({
+				trace_id: "1".repeat(32),
+				parent_span_id: "2".repeat(16),
+				name: "obsidian.push",
+				start_us: 1,
+				end_us: 2,
+				attributes: {},
+			});
+			unauthed.beacon.flush();
+			expect(calls).toHaveLength(0);
+		});
+
 		test("on 401, invalidates access token and retries once with refreshed token", async () => {
 			let callCount = 0;
 			const invalidate = mock(() => {});


### PR DESCRIPTION
## Why

`engram-prod-loki-auth-failure-burst` has fired 14 times in the last 7 days. It is not credential stuffing and not the socket-signature class the existing runbook covers — it is our own plugin, unlinked, looping 401s.

**Chain:** an install with no auth provider (nulled by `clearAuthAndPromptRelink`, or by a backend switch) and an empty `apiKey` fell through to `getAuthToken() → this.apiKey === ""`, so `sendRequest` built `Authorization: Bearer ` with nothing after it. HTTP strips trailing whitespace from field values, so the backend sees a bare `Bearer`, misses the `["Bearer " <> token]` match in `EngramWeb.Plugs.Auth.authenticate/1` and logs `reason=no_auth` — one warn line in `category=auth` per request.

Verified against prod:

| probe | logged reason |
|---|---|
| `Authorization: Bearer ` (empty) | `no_auth` |
| `Authorization: Bearer abc` | `signature_error` |

Nothing gated sync, remote logging or the trace beacon on auth state (`grep isAuthenticated() src/main.ts src/sync.ts` → no guards), so such an install never stops. Prod, 24h to 2026-07-26: **890 `no_auth` 401s** from three installs — `POST /api/folders` ×648, `/api/logs` ×102, `/api/telemetry/spans` ×98, `/api/attachments` ×14. Note the middle two: the client's log push and beacon carry its own complaints about the 401s, so the noise feeds itself.

## What changed

- `getAuthToken()` throws instead of returning an empty credential. One guard on the shared request path covers every caller — folders, notes, attachments, logs, search — rather than gating each one.
- The beacon transport thunk drops its batch while `lastToken` is empty. It posts with `window.fetch`, so it bypasses the guard above and would 401 on its own.

No version bump — release-please owns that.

## Tests

3 new cases in `tests/api.test.ts`: empty apiKey and empty provider token both reject **without touching `requestUrl`**, and an unauthenticated beacon flush issues no `fetch`.

Full suite 2197 pass / 1 skip / 0 fail, `bun run build`, `biome ci`, `lint:obsidian`, `lint:css` all clean.

> One caveat, stated plainly: the very first (cold) run of the suite in this worktree reported 1 failure whose identity I did not capture, and 8 consecutive runs since have been green — including replays of both `sim/random` seeds from that run, which pass. Unresolved rather than dismissed; CI is the next look.

## Follow-ups not in scope

The alert rule is deliberately untouched — volume should fall to ~0 once this ships, and retuning now would mask the client bug. Separately, the `[client:auth] OAuth refresh failed` timeouts / `ERR_NAME_NOT_RESOLVED` / `ERR_QUIC_PROTOCOL_ERROR` lines in prod are a different (network-side) story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fXPYtAKeUBLKjW9QmVRpZ