### PR TITLE
ci: ignore all tags, not just v-prefixed ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,15 @@ name: CI
 on:
   push:
     branches: ["**"]
-    tags-ignore: ["v*"]
+    # No tag should start CI — every tag we push points at a commit this
+    # workflow already gated on its branch. This was ["v*"], which missed
+    # release-please's own tag: release-please-config.json sets
+    # include-v-in-tag=false, so it publishes BARE semver (1.18.1, no v) and
+    # every release quietly ran a second full CI on head_branch=<version>.
+    # "**" is exhaustive and needs no upkeep when a new tag shape appears.
+    # (pr-build.yml's <version>-pr.<n>.<sha> preview tags are created through
+    # the releases API with GITHUB_TOKEN, so they never triggered this anyway.)
+    tags-ignore: ["**"]
 
 permissions:
   contents: read


### PR DESCRIPTION
`ci.yml` had `tags-ignore: ["v*"]`, but `release-please-config.json` sets `include-v-in-tag: false`, so release-please publishes **bare** semver tags (`1.18.1`, no `v`). That pattern never matched, so every release quietly ran a second full CI on the tag.

Observed on tonight's 1.18.1 release:

```
CI | event=push | branch=1.18.1 | success   <- duplicate, this PR removes it
CI | event=push | branch=main   | success   <- the real one
```

No tag should start CI: every tag we push points at a commit this workflow already gated on its branch. `**` is exhaustive and needs no upkeep when a new tag shape appears.

## Scope check

Audited every workflow in the repo for tag dependencies before widening the pattern:

- `pr-build.yml` creates `<version>-pr.<n>.<sha>` preview tags, but through the releases API with `GITHUB_TOKEN` — GitHub's anti-recursion rule means those never triggered CI. Confirmed empirically: filtering the last 60 CI runs for tag-shaped `headBranch` values returns only `1.18.1`, no preview tags.
- `pr-cleanup.yml` only *deletes* tags.
- `release-please.yml` and `release-audit.yml` reference tags but are not tag-triggered.
- There is no tag-triggered release workflow here; release-please builds and uploads the BRAT assets itself.

So nothing depends on a tag-triggered run.

## Why now

Same bug as engram#1133, found while fixing it in the backend — that repo hit it through its own release-please tags. Fixing only the repo where it was noticed would have left the sibling broken.

No version bump: release-please owns those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013fXPYtAKeUBLKjW9QmVRpZ