### PR TITLE
fix(logging): remoteLogLevel=debug actually reaches Loki

### DIFF
--- a/main.js
+++ b/main.js
@@ -942,7 +942,7 @@ var LEVEL_SEVERITY = {
       platform: this.platform,
       seq: this.seq++
     };
-    stack && (entry.stack = stack), this.connId && (entry.conn_id = this.connId), this.deviceId && (entry.device_id = this.deviceId), this.vaultId && (entry.vault_id = this.vaultId), diagnostic && (entry.diagnostic = !0), this.buffer.push(entry), this.buffer.length > MAX_BUFFER && this.buffer.splice(0, this.buffer.length - MAX_BUFFER), this.buffer.length >= FLUSH_THRESHOLD && this.flush();
+    this.levelThreshold === "debug" && LEVEL_SEVERITY[level] < LEVEL_SEVERITY.warn && (entry.diagnostic = !0), stack && (entry.stack = stack), this.connId && (entry.conn_id = this.connId), this.deviceId && (entry.device_id = this.deviceId), this.vaultId && (entry.vault_id = this.vaultId), diagnostic && (entry.diagnostic = !0), this.buffer.push(entry), this.buffer.length > MAX_BUFFER && this.buffer.splice(0, this.buffer.length - MAX_BUFFER), this.buffer.length >= FLUSH_THRESHOLD && this.flush();
   }
   startTimer() {
     this.stopTimer(), this.flushTimer = window.setInterval(() => {

--- a/src/remote-log.ts
+++ b/src/remote-log.ts
@@ -147,6 +147,18 @@ export class RemoteLogger {
 			platform: this.platform,
 			seq: this.seq++,
 		};
+		// Verbose mode opts sub-warn entries into Loki. The backend keeps client
+		// logs out of Loki below warn (Category: :client is absent from
+		// @info_to_loki, so a whole plugin fleet can't flood it) and offers
+		// exactly one escape hatch: `diagnostic: true`. Without this, setting
+		// remoteLogLevel to "debug" made the plugin SEND info lines that the
+		// backend then dropped — verbose logging that produced nothing to read.
+		// Gated on "debug", never the "info" default, so the flood guard still
+		// holds for everyone who hasn't explicitly asked for the firehose.
+		// warn/error already ship, so flagging them would just pad the payload.
+		if (this.levelThreshold === "debug" && LEVEL_SEVERITY[level] < LEVEL_SEVERITY.warn) {
+			entry.diagnostic = true;
+		}
 		if (stack) entry.stack = stack;
 		if (this.connId) entry.conn_id = this.connId;
 		if (this.deviceId) entry.device_id = this.deviceId;

--- a/tests/remote-log.test.ts
+++ b/tests/remote-log.test.ts
@@ -349,3 +349,59 @@ describe("RemoteLogger client context + seq + diag", () => {
 		expect(sent[0].level).toBe("info");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Loki reachability (2026-07-28)
+// ---------------------------------------------------------------------------
+
+// The backend drops re-emitted client logs below warn UNLESS the entry carries
+// `diagnostic: true` (Engram.Logger.Category: :client is deliberately absent
+// from @info_to_loki so a plugin fleet can't flood Loki). So setting
+// remoteLogLevel to "debug" made the plugin SEND info lines that then died at
+// the backend filter — the setting silently did nothing for the one thing you
+// want it for. Two investigations were lost to exactly this.
+describe("verbose remote logging reaches Loki", () => {
+	function loggerAt(level: "info" | "debug") {
+		const sent: RemoteLogEntry[][] = [];
+		const logger = new RemoteLogger();
+		logger.configure(
+			async (batch: RemoteLogEntry[]) => {
+				sent.push(batch);
+			},
+			"1.0.0",
+			"desktop",
+		);
+		logger.setEnabled(true);
+		logger.setLevelThreshold(level);
+		return { logger, sent };
+	}
+
+	test("at debug, info entries opt into Loki", async () => {
+		const { logger, sent } = loggerAt("debug");
+
+		logger.info("crdt", "something worth seeing");
+		await logger.flush();
+
+		expect(sent[0]?.[0]?.diagnostic).toBe(true);
+	});
+
+	test("at the default level, info entries do NOT opt in (no fleet-wide flood)", async () => {
+		const { logger, sent } = loggerAt("info");
+
+		logger.info("crdt", "routine chatter");
+		await logger.flush();
+
+		expect(sent[0]?.[0]?.diagnostic).toBeUndefined();
+	});
+
+	test("warn already reaches Loki, so it stays unflagged even at debug", async () => {
+		const { logger, sent } = loggerAt("debug");
+
+		logger.warn("crdt", "a real problem");
+		await logger.flush();
+
+		// warn/error ship regardless (Category.loki_ship? passes them); flagging
+		// them would only add noise to the payload.
+		expect(sent[0]?.[0]?.diagnostic).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Setting `remoteLogLevel` to `debug` made the plugin **send** info-level entries that the backend then silently dropped. Verbose logging produced nothing to read.

## Why

The backend deliberately keeps client logs out of Loki below `warn` — `Engram.Logger.Category` omits `:client` from `@info_to_loki` so a whole plugin fleet can't flood it:

```elixir
# :client is NOT here: re-emitted plugin info would flood Loki; verbose client
# entries opt in per-entry via a loki_ship override (see Logs.insert_logs).
@info_to_loki [:billing, :crypto, :lifecycle, :oban, :boot, :websocket]
```

It offers exactly one escape hatch, in `Logs.reemit_to_logger`:

```elixir
if entry["diagnostic"] == true do
  Keyword.put(meta, :loki_ship, true)
```

`RemoteLogger` only ever set `diagnostic` from `diag()`, never from `info()`. So the setting and the escape hatch never met.

## Cost

Two investigations this session. The code path that recreated a deleted note (`onLastViewerRelease` → `flushToDisk` → `flushFromCrdt`) logs at info and left **no trace at all** — we had to ship a temporary warn-level tracer to find it, then strip it again.

## Fix

Sub-`warn` entries carry `diagnostic: true` when the threshold is `debug`.

- Gated on `debug` specifically, **never** the `info` default — the flood guard still holds for anyone who hasn't asked for the firehose.
- `warn`/`error` already ship via `loki_ship?`, so they stay unflagged rather than padding the payload.

No backend change: this uses machinery that already existed.

## Tests

RED-verified. `debug` flags info; the default does not; `warn` stays unflagged even at `debug`.

Suite **2213 pass / 0 fail**; build + biome + eslint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N62e5eq31DoffeCH2LJDFM