### PR TITLE
docs(context): land the bun-audit brace-expansion false-positive doc

### DIFF
--- a/docs/context/bun-audit-brace-expansion-false-positive.md
+++ b/docs/context/bun-audit-brace-expansion-false-positive.md
@@ -1,0 +1,79 @@
+# `bun audit` brace-expansion false-positive
+
+_Last verified: 2026-07-30_
+
+## The Problem
+
+`bun audit` (run in the "Security audit" step of `.github/workflows/ci.yml`, part
+of the required `build-and-test` check) started failing on `main` for advisory
+**GHSA-mh99-v99m-4gvg** (brace-expansion ReDoS), flagging our already-patched
+`brace-expansion@1.1.16`.
+
+Root cause: bun collapses that advisory into a single vulnerable range `<=5.0.7`
+and only considers `>=5.0.8` safe. The 1.x line was actually fixed in 1.1.12
+(and `1.1.16` ships on the npm `maintenance-v1` tag with that fix), but bun's
+over-broad merged range false-flags every 1.x version regardless. Our existing
+`"brace-expansion": "^1.1.16"` override was correct for the real advisory but
+does not satisfy bun's range check.
+
+## The Fix (plugin PR #324)
+
+Add **both** overrides in `package.json`:
+
+```jsonc
+"overrides": {
+  "brace-expansion": "^5.0.8",
+  "minimatch": "^10.0.1"
+}
+```
+
+Why both:
+
+- Bumping `brace-expansion` to `^5.0.8` alone breaks eslint. Its transitive
+  `minimatch@3` does `require('brace-expansion')` expecting the **bare function**,
+  but brace-expansion 5.x's CJS build exports `{ expand }` → `TypeError: expand
+  is not a function` in `Minimatch.braceExpand`.
+- `minimatch@10` consumes the **named** `{ expand }` export, so bumping it too
+  restores compatibility.
+- `minimatch` is eslint-toolchain-only (not imported in `src/`), so there is no
+  runtime or bundle impact.
+
+Verified: `bun audit` clean, eslint pass, `bun run build` pass, 2224 tests pass.
+
+## Reusable Lesson
+
+When `bun audit` flags a transitive dep that looks already-patched, check whether
+bun merged the advisory ranges too broadly (only accepting the latest major as
+safe). The fix may require jumping the dep to the newest major **and** bumping
+the intermediate consumer (here `minimatch`) to a version compatible with the
+new module shape (bare-function export → named `{ expand }` export).
+
+## It recurred in engram-marketing (2026-07-30)
+
+The identical advisory took `engram-marketing`'s nightly `Audit` red for three
+nights, reaching it through the same shape of dev-only lint tooling:
+
+```
+linkinator  > glob > minimatch > brace-expansion
+remark-cli  > unified-args > unified-engine > glob > minimatch > brace-expansion
+```
+
+Fixed there with the **same paired override** (`brace-expansion ^5.0.8` +
+`minimatch ^10.0.1`) in marketing PR #156. If a third repo trips this, apply the
+pair — not `brace-expansion` alone.
+
+That same audit run also flagged **`sharp <0.35.0`**
+([GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj),
+inherited libvips CVE-2026-33327/33328/35590/35591). Unlike brace-expansion that
+one is a **real** vulnerability, not a merged-range artifact — do not assume every
+`bun audit` high is a false positive. Check each advisory individually.
+
+Still valid on this repo as of 2026-07-30: after the biome 1→2 / eslint 9→10 bump
+(#350) the overrides are unchanged and `bun audit` is clean.
+
+## References
+
+- `package.json` `overrides`
+- `.github/workflows/ci.yml` "Security audit" step
+- GHSA-mh99-v99m-4gvg (brace-expansion ReDoS)
+- plugin PR #324 (`fix/brace-expansion-audit`), rebased dependabot PR #319


### PR DESCRIPTION
This doc was written during #324 (2026-07-24) but **never committed** — it sat untracked in the working copy, one `git clean` away from being lost. It's the reason I could diagnose engram-marketing's audit failure in minutes today, so it's worth having in the repo.

## What it explains

Why `bun audit` flags an already-patched `brace-expansion@1.x`: bun collapses GHSA-mh99-v99m-4gvg into a single `<=5.0.7` range and only accepts `>=5.0.8`, but the 1.x line was actually fixed in 1.1.12. And why the fix needs a **paired** `minimatch ^10` override — `brace-expansion@5`'s CJS build exports `{ expand }` while `minimatch@3` calls it as a bare function.

## Refreshed while landing it

- **It recurred in engram-marketing**, red for three nights, via the same lint-tooling path (`linkinator` / `remark-cli` → `glob` → `minimatch` → `brace-expansion`), fixed with the same paired override in marketing #156. Now recorded so a third repo doesn't rediscover it.
- **Corrected a dangerous implication.** The same marketing audit run also flagged `sharp <0.35.0` ([GHSA-f88m-g3jw-g9cj](https://github.com/advisories/GHSA-f88m-g3jw-g9cj), inherited libvips CVE-2026-33327/33328/35590/35591) — a **real** vulnerability, not a merged-range artifact. As written, the doc risked teaching "bun audit highs are false positives." It now says to check each advisory individually.
- **Re-verified today:** after the biome 1→2 / eslint 9→10 bump (#350), the `overrides` block is unchanged and `bun audit` is clean.

Docs only — no code, no dependency change.