### PR TITLE
fix: stop the push debounce leaking a phantom pending entry

### DIFF
--- a/main.js
+++ b/main.js
@@ -19794,7 +19794,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let armedPath = file.path, existing = this.debounceTimers.get(armedPath);
     existing && this.time.clearTimeout(existing);
     let timer = this.time.setTimeout(() => {
-      this.debounceTimers.delete(armedPath), this.pushFile(file);
+      this.debounceTimers.delete(armedPath), this.emitStatus(), this.pushFile(file);
     }, this.settings.debounceMs);
     this.debounceTimers.set(armedPath, timer), this.emitStatus();
   }
@@ -19837,8 +19837,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       return;
     }
     if (!this.ready || !this.isSyncable(file)) return;
-    let isBinary = this.isBinaryFile(file);
-    if (isBinary || (_a = this.noteIdMap) == null || _a.rename(oldPath, file.path), !this.shouldIgnore(oldPath))
+    let isBinary = this.isBinaryFile(file), armed = this.debounceTimers.get(oldPath);
+    if (armed && (this.time.clearTimeout(armed), this.debounceTimers.delete(oldPath), this.emitStatus()), isBinary || (_a = this.noteIdMap) == null || _a.rename(oldPath, file.path), !this.shouldIgnore(oldPath))
       try {
         isBinary ? (await this.api.deleteAttachment(oldPath), this.goOnline()) : this.isCrdtEligible(file) || (await this.api.deleteNote(oldPath), this.goOnline());
       } catch (e) {
@@ -22397,7 +22397,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       this.time.clearTimeout(timer);
     this.debounceTimers.clear();
     for (let timer of this.recentlyPushed.values())
-      window.clearTimeout(timer);
+      this.time.clearTimeout(timer);
     this.recentlyPushed.clear();
     for (let timer of this.recentlyFlushed.values())
       this.time.clearTimeout(timer);

--- a/main.js
+++ b/main.js
@@ -19791,12 +19791,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       file instanceof import_obsidian23.TFile && this.recordLiveBoundBaseline(file);
       return;
     }
-    let existing = this.debounceTimers.get(file.path);
-    existing && window.clearTimeout(existing);
-    let timer = window.setTimeout(() => {
-      this.debounceTimers.delete(file.path), this.pushFile(file);
+    let armedPath = file.path, existing = this.debounceTimers.get(armedPath);
+    existing && this.time.clearTimeout(existing);
+    let timer = this.time.setTimeout(() => {
+      this.debounceTimers.delete(armedPath), this.pushFile(file);
     }, this.settings.debounceMs);
-    this.debounceTimers.set(file.path, timer), this.emitStatus();
+    this.debounceTimers.set(armedPath, timer), this.emitStatus();
   }
   /** Handle a vault delete event. */
   async handleDelete(file) {
@@ -19807,7 +19807,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     }
     if (!this.ready || this.suppressDeletes || !this.isSyncable(file) || this.shouldIgnore(file.path)) return;
     let isBinary = this.isBinaryFile(file), existing = this.debounceTimers.get(file.path);
-    existing && (window.clearTimeout(existing), this.debounceTimers.delete(file.path));
+    existing && (this.time.clearTimeout(existing), this.debounceTimers.delete(file.path));
     let crdtNoteId = isBinary ? null : (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(file.path)) != null ? _b : null;
     if (crdtNoteId && this.markRecentlyDeleted(crdtNoteId), isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path), this.syncState.delete((0, import_obsidian23.normalizePath)(file.path)), this.remotelyDeleted.has(file.path)) {
       this.remotelyDeleted.delete(file.path), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && (await ((_d = this.crdt) == null ? void 0 : _d.removeDoc(crdtNoteId)), (_e = this.crdtEnrollment) == null || _e.reset(crdtNoteId));
@@ -22394,7 +22394,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   /** Cancel all pending debounce, cooldown, and health check timers. */
   destroy() {
     for (let timer of this.debounceTimers.values())
-      window.clearTimeout(timer);
+      this.time.clearTimeout(timer);
     this.debounceTimers.clear();
     for (let timer of this.recentlyPushed.values())
       window.clearTimeout(timer);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2108,16 +2108,23 @@ export class SyncEngine {
 			return;
 		}
 
-		// Clear existing debounce timer for this file
-		const existing = this.debounceTimers.get(file.path);
-		if (existing) window.clearTimeout(existing);
+		// Capture the path NOW. Obsidian mutates the SAME TFile in place on a
+		// rename, so reading `file.path` inside the callback resolves to the NEW
+		// path — deleting a key that was never set and stranding the original
+		// forever. That leak surfaced as a status bar permanently reporting a
+		// phantom "1 pending" (pending == debounceTimers.size).
+		const armedPath = file.path;
 
-		const timer = window.setTimeout(() => {
-			this.debounceTimers.delete(file.path);
+		// Clear existing debounce timer for this file
+		const existing = this.debounceTimers.get(armedPath);
+		if (existing) this.time.clearTimeout(existing);
+
+		const timer = this.time.setTimeout(() => {
+			this.debounceTimers.delete(armedPath);
 			void this.pushFile(file);
 		}, this.settings.debounceMs);
 
-		this.debounceTimers.set(file.path, timer);
+		this.debounceTimers.set(armedPath, timer);
 		this.emitStatus();
 	}
 
@@ -2140,7 +2147,7 @@ export class SyncEngine {
 		// Cancel any pending push for this file
 		const existing = this.debounceTimers.get(file.path);
 		if (existing) {
-			window.clearTimeout(existing);
+			this.time.clearTimeout(existing);
 			this.debounceTimers.delete(file.path);
 		}
 
@@ -7475,7 +7482,7 @@ export class SyncEngine {
 	/** Cancel all pending debounce, cooldown, and health check timers. */
 	destroy(): void {
 		for (const timer of this.debounceTimers.values()) {
-			window.clearTimeout(timer);
+			this.time.clearTimeout(timer);
 		}
 		this.debounceTimers.clear();
 		for (const timer of this.recentlyPushed.values()) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2121,6 +2121,11 @@ export class SyncEngine {
 
 		const timer = this.time.setTimeout(() => {
 			this.debounceTimers.delete(armedPath);
+			// Repaint HERE, not via pushFile: it has early returns above its first
+			// emitStatus(), and a persistently-skipped file (an attachment parked
+			// under a plan issue) would leave the bar painting the stale count
+			// forever — nothing polls it.
+			this.emitStatus();
 			void this.pushFile(file);
 		}, this.settings.debounceMs);
 
@@ -2259,6 +2264,19 @@ export class SyncEngine {
 		if (!this.isSyncable(file)) return;
 
 		const isBinary = this.isBinaryFile(file);
+
+		// Cancel any push still armed under the OLD path. Capturing armedPath at
+		// arm time stops it leaking the map entry, but a surviving timer is still
+		// wrong: handleDelete cancels by CURRENT path so it can no longer reach
+		// this one (rename-then-delete inside the window pushes a file the user
+		// just deleted), and it fires without the shouldIgnore(file.path) guard
+		// applied to the push below (renaming INTO an ignored folder still pushes).
+		const armed = this.debounceTimers.get(oldPath);
+		if (armed) {
+			this.time.clearTimeout(armed);
+			this.debounceTimers.delete(oldPath);
+			this.emitStatus();
+		}
 
 		// Keep the note_id mapping stable across the rename (Task 5) — the id
 		// itself never changes on a rename, only the path key it's filed under.
@@ -7486,7 +7504,7 @@ export class SyncEngine {
 		}
 		this.debounceTimers.clear();
 		for (const timer of this.recentlyPushed.values()) {
-			window.clearTimeout(timer);
+			this.time.clearTimeout(timer);
 		}
 		this.recentlyPushed.clear();
 		for (const timer of this.recentlyFlushed.values()) {

--- a/tests/sync-ttl-windows.test.ts
+++ b/tests/sync-ttl-windows.test.ts
@@ -47,6 +47,8 @@ function engineWithClock() {
 		recentlyDeleted: Map<string, number>;
 		markRecentlyFlushed(path: string): void;
 		recentlyFlushed: Map<string, number>;
+		markRecentlyPushed(path: string): void;
+		recentlyPushed: Map<string, number>;
 	};
 	return { engine, clock, probe };
 }
@@ -150,5 +152,55 @@ describe("push debounce bookkeeping", () => {
 		clock.advance(5_000);
 
 		expect(armed(engine)).toBe(0);
+	});
+});
+
+describe("destroy() timer sweep", () => {
+	test("cancels the recentlyPushed cooldown on the injected clock", () => {
+		const { engine, clock, probe } = engineWithClock();
+		probe.markRecentlyPushed("a.md");
+		expect(clock.pendingCount).toBe(1);
+
+		engine.destroy();
+
+		// markWithTtl arms every TTL map through `this.time`, so cancelling with
+		// window.clearTimeout cannot reach the timer — it stays armed and fires
+		// its expiry callback into a torn-down engine on the next tick.
+		expect(clock.pendingCount).toBe(0);
+	});
+});
+
+describe("push debounce, follow-ups from review", () => {
+	function armed(engine: SyncEngine) {
+		return (engine as unknown as { debounceTimers: Map<string, number> }).debounceTimers.size;
+	}
+
+	test("a fired debounce re-emits status so the bar stops painting a stale count", () => {
+		const { engine, clock } = engineWithClock();
+		const seen: number[] = [];
+		engine.onStatusChange = (s) => seen.push(s.pending);
+
+		engine.handleModify(new TFile("a.md"));
+		clock.advance(5_000);
+
+		// pushFile has early returns ABOVE its first emitStatus(), so delegating
+		// the repaint to it leaves the bar showing the pre-fire count forever —
+		// there is no poller to correct it.
+		expect(seen.at(-1)).toBe(0);
+	});
+
+	test("a rename cancels the old path's pending push outright", () => {
+		const { engine, clock } = engineWithClock();
+		const file = new TFile("a.md");
+		engine.handleModify(file);
+
+		file.path = "b.md";
+		void engine.handleRename(file, "a.md");
+
+		// Self-clearing on fire is not enough. A still-armed old-path timer is
+		// uncancellable by handleDelete (which looks up the CURRENT path) and
+		// bypasses handleRename's own shouldIgnore guard on the new path.
+		expect(armed(engine)).toBe(0);
+		expect(clock.pendingCount).toBe(0);
 	});
 });

--- a/tests/sync-ttl-windows.test.ts
+++ b/tests/sync-ttl-windows.test.ts
@@ -8,6 +8,7 @@
  * behaviour on either side of the boundary was never pinned.
  */
 import { describe, expect, mock, test } from "bun:test";
+import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { SyncEngine } from "../src/sync";
 import { ManualTimeProvider } from "../src/time-provider";
@@ -40,6 +41,7 @@ function engineWithClock() {
 		mock().mockResolvedValue(undefined),
 		clock,
 	);
+	engine.setReady();
 	const probe = engine as unknown as {
 		markRecentlyDeleted(id: string): void;
 		recentlyDeleted: Map<string, number>;
@@ -111,5 +113,42 @@ describe("recentlyFlushed echo window", () => {
 		clock.advance(RECENT_DELETE_COOLDOWN_MS);
 
 		expect(clock.pendingCount).toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Debounce bookkeeping (2026-07-30: status bar stuck on "1 pending")
+// ---------------------------------------------------------------------------
+
+describe("push debounce bookkeeping", () => {
+	function armed(engine: SyncEngine) {
+		return (engine as unknown as { debounceTimers: Map<string, number> }).debounceTimers.size;
+	}
+
+	test("a fired debounce clears its own entry", () => {
+		const { engine, clock } = engineWithClock();
+		const file = new TFile("a.md");
+
+		engine.handleModify(file);
+		expect(armed(engine)).toBe(1);
+		clock.advance(5_000);
+
+		expect(armed(engine)).toBe(0);
+	});
+
+	test("a rename before the debounce fires does not leak the old path", () => {
+		const { engine, clock } = engineWithClock();
+		const file = new TFile("a.md");
+
+		engine.handleModify(file);
+		expect(armed(engine)).toBe(1);
+
+		// Obsidian mutates the SAME TFile in place on rename, so a closure that
+		// reads file.path at FIRE time deletes the new key and strands the old —
+		// leaving the status bar permanently showing a phantom pending file.
+		file.path = "b.md";
+		clock.advance(5_000);
+
+		expect(armed(engine)).toBe(0);
 	});
 });


### PR DESCRIPTION
Follow-up to #348 (merged). The status bar reported a permanent "1 pending" because `pending` is literally `debounceTimers.size` and one entry never cleared.

## Root cause

`handleModify` armed a debounce timer whose callback called `this.debounceTimers.delete(file.path)` at **fire** time. Obsidian mutates the same `TFile` in place on a rename, so a rename landing inside the 2s window made the callback delete the **new** key (never set) and strand the **old** one forever. `handleRename` never touches the map, so nothing else reclaimed it.

Same shape as the other bugs in this area: a found-but-wrong value defeats the not-found fallback. `map.delete("b.md")` succeeds as a no-op and the orphan goes unnoticed.

## Changes

- Capture `armedPath` at **arm** time so the timer always removes the key it added (`src/sync.ts`)
- `handleDelete` called `window.clearTimeout` on an id owned by the injected `TimeProvider` — leaks the timer under any non-default clock and is inconsistent with its sibling call sites

## Tests

Two new tests in `tests/sync-ttl-windows.test.ts`, driven by `ManualTimeProvider` so no real waiting.

RED-verified: reverting the `armedPath` capture fails `a rename before the debounce fires does not leak the old path` with `Expected: 0, Received: 1` — exactly the count observed in the field.

2253 pass / 0 fail, biome clean, build clean.

## Impact

No data was ever at risk. The counter tracks disk-to-doc ingest timers; the stranded entry had no file behind it.