### PR TITLE
chore: prep tsconfig for TS7 and record deferred dependency bumps

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -7,6 +7,14 @@
 //
 // Our only additions on top of the template: the `obsidianmd/ui/sentence-case`
 // brand allow-list for src files.
+//
+// ponytail: this file is what pins us below TypeScript 7. typescript-eslint
+// hard-throws on TS >= 7 ("does not support TS 7.0") before any config loads —
+// no flag, no env var — because TS 7 is the Go rewrite and the in-process `ts.*`
+// API it reads types from no longer exists. Every version refuses it, canary
+// included. Unblocks when typescript-eslint/typescript-eslint#10940 ships;
+// likely needs `typescript` + `typescript-eslint` bumped in one PR (our ^8
+// caret won't reach a v9). Context and Dependabot history: #353.
 import { globalIgnores } from "eslint/config";
 import obsidianmd from "eslint-plugin-obsidianmd";
 import globals from "globals";

--- a/src/tabs/account-tab.ts
+++ b/src/tabs/account-tab.ts
@@ -25,6 +25,10 @@ export async function renderAccountTab(ctx: TabContext): Promise<void> {
 			.addButton((btn) =>
 				btn
 					.setButtonText("Switch to Engram cloud")
+					// ponytail: stays on setWarning(). The 1.13 typings deprecate
+					// it in favour of setDestructive(), which only exists on
+					// Obsidian >= 1.13.0 — minAppVersion is 1.7.2, so calling it
+					// would throw for most users. Swap when the floor rises (#353).
 					.setWarning()
 					.onClick(async () => {
 						await applyApiUrlChange(

--- a/src/tabs/self-hosted-tab.ts
+++ b/src/tabs/self-hosted-tab.ts
@@ -187,6 +187,8 @@ export function renderAuthSection(ctx: TabContext): void {
 			.addButton((btn) =>
 				btn
 					.setButtonText("Clear key")
+					// ponytail: stays on setWarning() — setDestructive() needs
+					// Obsidian >= 1.13.0 and minAppVersion is 1.7.2. See #353.
 					.setWarning()
 					.onClick(async () => {
 						plugin.settings.apiKey = "";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
+  // `baseUrl` was dropped here: there is no `paths` block and no `@/*` import
+  // anywhere in src/, so it resolved nothing. TypeScript 7 removes the option
+  // outright (TS5102), so keeping a no-op would have been a future blocker.
   "compilerOptions": {
-    "baseUrl": ".",
     "inlineSourceMap": true,
     "inlineSources": true,
     "module": "ESNext",
@@ -10,7 +12,10 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "noImplicitReturns": true,
-    "moduleResolution": "node",
+    // "bundler", not "node"/node10: esbuild does the resolving (see
+    // esbuild.config.mjs), so this matches reality. Don't revert to "node" —
+    // TypeScript 7 removed node10 resolution (TS5108).
+    "moduleResolution": "bundler",
     "importHelpers": true,
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
Fallout from triaging the two stuck Dependabot PRs. Both are being closed —
neither is fixable by upgrading anything today — so this lands the part that
*is* actionable and records the rest next to the code.

Deliberately **no** Dependabot ignore rules: an ignore silences the PR and never
tells you when it's safe again. Full analysis and unblock conditions in #353.

## tsconfig — clears 2 of the 3 TypeScript 7 blockers

- **drop `baseUrl`** — there's no `paths` block and no `@/*` import anywhere in
  `src/`, so it resolved nothing. TS 7 removes it outright (TS5102).
- **`moduleResolution` `node`/node10 → `bundler`** — matches what esbuild
  actually does. TS 7 removes node10 resolution (TS5108).

Pure cleanup, valid on our current TS 5.9. Verified no-op:

```
tsc -p tsconfig.json --noEmit                          → exit 0
tsc -p tsconfig.json --noEmit --moduleResolution bundler → exit 0
```

The third blocker can't be cleaned up ahead of time — see below.

## Deferral notes (`ponytail:` prefixed)

Parked at the point of work so whoever touches these trips over them, rather
than in a config file nobody reads. The `ponytail:` prefix makes them
harvestable as a ledger via `/ponytail-debt`.

| file | records |
|---|---|
| `eslint.config.mts` | typescript-eslint hard-throws on TS >= 7; upstream tracker |
| `src/tabs/account-tab.ts` | `setWarning()` stays — `setDestructive()` needs Obsidian >= 1.13.0 |
| `src/tabs/self-hosted-tab.ts` | same |
| `tsconfig.json` | why `bundler`, and don't revert it |

### Why typescript-eslint is a wall, not a stale pin

`@typescript-eslint/parser` throws before any config loads — no flag, no env var:

```js
if (versionMajor >= 7) { throw new Error('typescript-eslint does not support TS 7.0.') }
```

Every version refuses it. `eslint` itself is already current (10.8.0) and was
never the blocker:

| package | ours | npm `latest` | TS peer range |
|---|---|---|---|
| `eslint` | 10.8.0 | 10.8.0 | already current |
| `typescript-eslint` | 8.65.0 | 8.65.0 | `>=4.8.4 <6.1.0` |
| `typescript-eslint` | — | canary 8.65.1-alpha.19 | `>=4.8.4 <6.1.0` |

TS 7 is the Go rewrite; the in-process `ts.*` API typescript-eslint reads types
from doesn't exist there. Unblocks on typescript-eslint/typescript-eslint#10940.

### Why `setWarning()` stays

`setDestructive()` first appears in Obsidian **1.13.0** (bisected against the
published typings); `minAppVersion` is **1.7.2**. Adopting it would throw
`setDestructive is not a function` in the settings tab for most users.
`setWarning` is deprecated but **not removed**, so there's no deadline.

## Verification

All gates run locally, unpiped:

| gate | result |
|---|---|
| `bun run build` | exit 0 |
| `bun run lint:obsidian` | exit 0 |
| `bun run lint` (biome) | exit 0 |
| `bun run lint:css` | exit 0 |
| `bun run lint:lockfile` | exit 0 |
| `bun test` | **2251 pass, 1 skip, 0 fail** (identical to baseline) |

No version bumps — release-please owns those.

Refs #353
