### PR TITLE
feat: Relay-pattern migration — six patterns adopted from the Relay audit

### DIFF
--- a/src/content-hash.ts
+++ b/src/content-hash.ts
@@ -1,0 +1,15 @@
+/** Fast string hash (FNV-1a 32-bit). Not cryptographic — just for content
+ *  change detection.
+ *
+ *  Lives in its own module rather than in sync.ts so a consumer that needs only
+ *  a content hash (the debug snapshot, and shortly the LCA record) does not pull
+ *  the entire sync engine into its import graph. `sync.ts` re-exports it, so
+ *  existing importers are unaffected. */
+export function fnv1a(s: string): number {
+	let h = 0x811c9dc5;
+	for (let i = 0; i < s.length; i++) {
+		h ^= s.charCodeAt(i);
+		h = Math.imul(h, 0x01000193);
+	}
+	return h >>> 0;
+}

--- a/src/crdt/lca-merge.ts
+++ b/src/crdt/lca-merge.ts
@@ -1,0 +1,55 @@
+/**
+ * Apply a disk edit to a Y.Doc's text WITHOUT reverting remote work.
+ *
+ * The problem this replaces (#357). `seedContentInto` ends in
+ * `diffIntoYText(text, diskBody)` — a TWO-way diff that forces the Y.Text to
+ * equal the disk snapshot. Any remote op that landed between reading the file
+ * and running the diff is absent from that snapshot, so the diff deletes it.
+ * That is the stale-snapshot revert class (e2e test_83), and it is why
+ * `applyLocalEdit` carries a 3-attempt retry loop that ticks `remoteSeq` and
+ * awaits `pendingFlush` just to detect the race — a workaround for a missing
+ * merge base.
+ *
+ * With a base (the last-synced content, which `BaseStore` already persists —
+ * its own docstring calls it "the common ancestor for 3-way merge") the right
+ * operation is not "make the doc equal disk" but "apply the disk's delta
+ * RELATIVE TO THE BASE onto the doc". Remote ops survive because they exist in
+ * the doc and are untouched by that delta.
+ *
+ * ponytail: `diff-match-patch` is already a dependency and `patch_make` /
+ * `patch_apply` is precisely this operation. No node-diff3 (what Relay uses), no
+ * hand-rolled merge.
+ */
+
+import { diff_match_patch } from "diff-match-patch";
+
+export interface LcaMergeResult {
+	/** Merged text. Usable even when `clean` is false. */
+	text: string;
+	/** False when at least one hunk could not be applied — overlapping edits to
+	 *  the same region. The caller must not treat a dirty merge as authoritative;
+	 *  it should fall back to its conflict path rather than silently shipping
+	 *  mangled content. */
+	clean: boolean;
+}
+
+/**
+ * Merge the disk-side delta onto the document's current text.
+ *
+ * @param base    last-synced content (the common ancestor)
+ * @param disk    what the file says now
+ * @param current what the Y.Doc says now (may already contain remote work)
+ */
+export function mergeDiskOntoDoc(base: string, disk: string, current: string): LcaMergeResult {
+	// Nothing changed on disk relative to the base: there is no delta to apply,
+	// and forcing the doc back toward a stale snapshot is exactly the bug.
+	if (base === disk) return { text: current, clean: true };
+	// The doc has not moved since the base, so the disk content IS the answer.
+	// Short-circuited rather than routed through patching, which can fuzz.
+	if (base === current) return { text: disk, clean: true };
+
+	const dmp = new diff_match_patch();
+	const patches = dmp.patch_make(base, disk);
+	const [merged, applied] = dmp.patch_apply(patches, current);
+	return { text: merged, clean: applied.every(Boolean) };
+}

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -12,7 +12,9 @@
 // re-handshake) become no-ops the persistent doc doesn't need.
 import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
+import { fnv1a } from "../content-hash";
 import { Lifetime } from "../lifetime";
+import type { SyncRecorder } from "../sync-recorder";
 import { projectCanvas, seedCanvasInto } from "./canvas-codec";
 import { isDestroyedError, NoteDestroyedError } from "./destroyed-error";
 import { CONTENT_KEY, frontmatterOf, projectNote, rawFrontmatterOf } from "./frontmatter-codec";
@@ -73,6 +75,12 @@ export interface ProviderRegistryOpts {
 	onEmptyStep2?: (noteId: string) => void;
 	docKind?: (noteId: string) => DocKind;
 	onPersistError?: (noteId: string, err: unknown) => void;
+	/** Optional timeline capture (#356). Injected HERE rather than at each call
+	 *  site because every seam worth recording — receive, send, local edit, raw
+	 *  remote update, enroll, reset, connection, flush — already passes through
+	 *  this class. One hook, eight seams, no instrumentation scattered across
+	 *  sync.ts and the live views. No-op when absent or when its flag is off. */
+	recorder?: SyncRecorder;
 }
 
 export class ProviderRegistry {
@@ -169,7 +177,14 @@ export class ProviderRegistry {
 			// production runs and what tests/crdt/wiring.test.ts pins. A duplicate
 			// here could silently drift from the shipped one (it did: the suite
 			// exercised only the duplicate, so #1130 could regress green).
-			send: (frame, kind) => this.opts.send(noteId, frame, kind),
+			send: (frame, kind) => {
+				const accepted = this.opts.send(noteId, frame, kind);
+				// Record the ACCEPTED result, not merely the attempt: a refused frame
+				// (socket unjoined, create-gate holding) is buffered for later, and
+				// that distinction is exactly what a delivery investigation needs.
+				this.opts.recorder?.record("send", noteId, { kind, accepted });
+				return accepted;
+			},
 			onSynced: () => {
 				this.opts.onSynced?.(noteId);
 				// A first syncStep2 that left the doc empty = the server's "genuinely
@@ -196,9 +211,16 @@ export class ProviderRegistry {
 			if (!entry.lifetime.active) return; // deleted mid-flight — never flush a dead doc
 			if (origin !== provider && origin !== REMOTE) return;
 			entry.remoteSeq += 1;
-			const flush = Promise.resolve(
-				this.opts.onFlushToDisk(noteId, this.project(entry)),
-			).then((ok) => {
+			const projected = this.project(entry);
+			// Hash, never content: a timeline is exportable and note bodies are
+			// private. Two hashes are enough to tell "did this write change
+			// anything" and to line a flush up against a later disk read.
+			this.opts.recorder?.record("flush", noteId, {
+				hash: fnv1a(projected).toString(16),
+				length: projected.length,
+				remoteSeq: entry.remoteSeq,
+			});
+			const flush = Promise.resolve(this.opts.onFlushToDisk(noteId, projected)).then((ok) => {
 				if (ok === false) throw new Error(`flushFromCrdt write failure for ${noteId}`);
 			});
 			entry.pendingFlush = flush;
@@ -315,6 +337,17 @@ export class ProviderRegistry {
 		// server's lineage (avoids the #846 doubling). "Consumed, nothing to push".
 		if (!lca && this.opts.isUnchangedSynced?.(noteId, content)) return content;
 
+		// Recorded AFTER the guards, so a timeline shows what the doc actually
+		// consumed rather than what the caller offered. `lca` is here because
+		// history-vs-no-history picks the seed strategy, and getting that wrong is
+		// the #846 lineage-doubling class.
+		this.opts.recorder?.record("localEdit", noteId, {
+			hash: fnv1a(content).toString(16),
+			length: content.length,
+			lca,
+			kind: e.kind,
+		});
+
 		if (e.kind === "canvas") {
 			return seedCanvasInto(e.doc, content) ? content : null;
 		}
@@ -335,6 +368,7 @@ export class ProviderRegistry {
 		// fanned it back -> an infinite echo storm. The disk-flush listener fires for
 		// the provider origin too, so the merge still writes to disk. (Relay parity:
 		// everything the sync machinery applies uses the provider as origin.)
+		this.opts.recorder?.record("remoteUpdate", noteId, { bytes: update.byteLength });
 		Y.applyUpdate(e.doc, update, e.provider);
 		const flush = e.pendingFlush;
 		if (flush) {
@@ -382,6 +416,7 @@ export class ProviderRegistry {
 	/** Route an inbound wire frame to its provider (creating it if a fan-out
 	 *  announced a note this device hasn't opened). */
 	async receive(noteId: string, frameB64: string): Promise<void> {
+		this.opts.recorder?.record("receive", noteId, { frame: frameB64 });
 		(await this.entry(noteId)).provider.receive(frameB64);
 	}
 
@@ -395,6 +430,7 @@ export class ProviderRegistry {
 		// below is the fire-and-forget wrapper that absorbs it.
 		this.assertAlive(noteId);
 		this.enrolledIds.add(noteId);
+		this.opts.recorder?.record("enroll", noteId, {});
 		const e = await this.entry(noteId);
 		e.provider.setAdvertised(true);
 		if (this.connected) e.provider.setConnected(true);
@@ -415,6 +451,7 @@ export class ProviderRegistry {
 	 *  out. reset+enroll = a fresh re-handshake. */
 	reset(noteId: string): void {
 		this.enrolledIds.delete(noteId);
+		this.opts.recorder?.record("reset", noteId, {});
 		const e = this.entries.get(noteId);
 		if (!e) return;
 		e.provider.setAdvertised(false);
@@ -441,6 +478,12 @@ export class ProviderRegistry {
 	 *  outlives the socket. */
 	setConnected(connected: boolean): void {
 		this.connected = connected;
+		// Vault-wide, so noteId is null. Reconnect boundaries are the single most
+		// useful landmark when reading a timeline back.
+		this.opts.recorder?.record("connection", null, {
+			connected,
+			resident: this.entries.size,
+		});
 		for (const e of this.entries.values()) e.provider.setConnected(connected);
 	}
 

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -18,6 +18,7 @@ import type { SyncRecorder } from "../sync-recorder";
 import { projectCanvas, seedCanvasInto } from "./canvas-codec";
 import { isDestroyedError, NoteDestroyedError } from "./destroyed-error";
 import { CONTENT_KEY, frontmatterOf, projectNote, rawFrontmatterOf } from "./frontmatter-codec";
+import { mergeDiskOntoDoc } from "./lca-merge";
 import { type FrameKind, NoteProvider } from "./note-provider";
 import { docHasHistory, seedContentInto } from "./note-seed";
 
@@ -75,6 +76,18 @@ export interface ProviderRegistryOpts {
 	onEmptyStep2?: (noteId: string) => void;
 	docKind?: (noteId: string) => DocKind;
 	onPersistError?: (noteId: string, err: unknown) => void;
+	/** Last-synced content for this note — the merge base (#357). Backed by
+	 *  `BaseStore`, which already persists exactly this and calls it "the common
+	 *  ancestor for 3-way merge". Null when none is recorded (a note that has
+	 *  never completed a sync), which falls back to the pre-LCA path. */
+	lcaFor?: (noteId: string) => string | null;
+	/** `crdtLcaMerge` flag. Read per call so a toggle takes effect without a
+	 *  stack rebuild. */
+	lcaMergeEnabled?: () => boolean;
+	/** Called when a merge could not apply every hunk. The content is still
+	 *  written, but the caller may want to record an issue — a dirty merge is the
+	 *  honest conflict signal that the two-way diff never produced. */
+	onDirtyMerge?: (noteId: string) => void;
 	/** Optional timeline capture (#356). Injected HERE rather than at each call
 	 *  site because every seam worth recording — receive, send, local edit, raw
 	 *  remote update, enroll, reset, connection, flush — already passes through
@@ -299,9 +312,36 @@ export class ProviderRegistry {
 		if (!e.lifetime.active) return null; // destroyed while we awaited hydration
 		let content = diskContent;
 
+		// LCA path (#357). With a merge base we apply the disk's delta RELATIVE TO
+		// THE BASE, so a remote op that landed after the disk read survives by
+		// construction. That removes the reason for the retry loop below: there is
+		// no stale-snapshot race left to detect, because we are no longer forcing
+		// the doc to equal the snapshot.
+		const base = this.opts.lcaMergeEnabled?.() ? this.opts.lcaFor?.(noteId) : null;
+		if (base !== null && base !== undefined && e.kind === "note") {
+			const merged = mergeDiskOntoDoc(base, diskContent, this.project(e));
+			if (merged.clean) {
+				this.opts.recorder?.record("localEdit", noteId, {
+					hash: fnv1a(merged.text).toString(16),
+					length: merged.text.length,
+					lca: true,
+					merged: true,
+					kind: e.kind,
+				});
+				seedContentInto(e.doc, e.text, merged.text, docHasHistory(e.doc, e.kind));
+				return merged.text;
+			}
+			// Dirty merge: overlapping edits to the same region. Fall through to the
+			// pre-LCA path rather than writing content we know is mangled — the
+			// existing guards are conservative and will decline rather than revert.
+			this.opts.onDirtyMerge?.(noteId);
+		}
+
 		// Stale-snapshot revert guard (e2e test_83): diskContent was read before
 		// this resolved; a remote merge in that window is absent from it, and
 		// diffing would DELETE the remote ops. Re-read across a doc-stable window.
+		// Still the path when the LCA flag is off, no base is recorded yet, the doc
+		// is a canvas, or the merge came back dirty.
 		if (reread) {
 			let stable = false;
 			for (let attempt = 0; attempt < 3 && !stable; attempt++) {

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -317,7 +317,17 @@ export class ProviderRegistry {
 		// construction. That removes the reason for the retry loop below: there is
 		// no stale-snapshot race left to detect, because we are no longer forcing
 		// the doc to equal the snapshot.
-		const base = this.opts.lcaMergeEnabled?.() ? this.opts.lcaFor?.(noteId) : null;
+		//
+		// Gated on the doc HAVING history. A history-less doc holds no remote work
+		// for the merge to protect, and routing it here would bypass the adopt-first
+		// gate below: `mergeDiskOntoDoc` short-circuits base===disk to the doc's own
+		// projection, which for a fresh doc is empty — and the caller records
+		// fnv1a(returned) as the last-synced baseline, so an empty return poisons
+		// isUnchangedSynced for a note that actually has content (#846 doubling).
+		const base =
+			this.opts.lcaMergeEnabled?.() && (hasLca ?? docHasHistory(e.doc, e.kind))
+				? this.opts.lcaFor?.(noteId)
+				: null;
 		if (base !== null && base !== undefined && e.kind === "note") {
 			const merged = mergeDiskOntoDoc(base, diskContent, this.project(e));
 			if (merged.clean) {

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -1,6 +1,7 @@
 import { errMsg } from "../error-util";
 import { rlog } from "../remote-log";
 import type { SyncEngine } from "../sync";
+import type { SyncRecorder } from "../sync-recorder";
 import { isDestroyedError } from "./destroyed-error";
 import { InvariantChecker, type InvariantViolation } from "./invariants";
 import type { NoteIdMap } from "./note-id-map";
@@ -68,6 +69,9 @@ export interface CrdtWiringDeps {
 	 *  it — each real device has its own browser origin. Set only by tests that
 	 *  run two "devices" against one shared fake-indexeddb process. */
 	dbPrefix?: string;
+	/** Timeline capture (#356). Handed straight to the registry, which is where
+	 *  every recordable seam already passes through. Omitted = no recording. */
+	recorder?: SyncRecorder;
 }
 
 export interface CrdtWiring {
@@ -275,6 +279,7 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 	// provider sends its own local updates through this `send`.
 	const registry = new ProviderRegistry({
 		dbPrefix: deps.dbPrefix,
+		recorder: deps.recorder,
 		send: (docId, frame, kind) => {
 			// Create-before-edit: hold OPS until the note's server row exists. Never
 			// hold a "handshake" frame (syncStep1, or the syncStep2 written in reply

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -72,6 +72,13 @@ export interface CrdtWiringDeps {
 	/** Timeline capture (#356). Handed straight to the registry, which is where
 	 *  every recordable seam already passes through. Omitted = no recording. */
 	recorder?: SyncRecorder;
+	/** Merge base for a note_id (#357), resolved through the id map to the path
+	 *  BaseStore is keyed by. Omitted = the pre-LCA path. */
+	lcaFor?: (noteId: string) => string | null;
+	/** `crdtLcaMerge` flag, read per call. */
+	lcaMergeEnabled?: () => boolean;
+	/** A merge that could not apply every hunk. */
+	onDirtyMerge?: (noteId: string) => void;
 }
 
 export interface CrdtWiring {
@@ -280,6 +287,9 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 	const registry = new ProviderRegistry({
 		dbPrefix: deps.dbPrefix,
 		recorder: deps.recorder,
+		lcaFor: deps.lcaFor,
+		lcaMergeEnabled: deps.lcaMergeEnabled,
+		onDirtyMerge: deps.onDirtyMerge,
 		send: (docId, frame, kind) => {
 			// Create-before-edit: hold OPS until the note's server row exists. Never
 			// hold a "handshake" frame (syncStep1, or the syncStep2 written in reply

--- a/src/debug-api.ts
+++ b/src/debug-api.ts
@@ -13,12 +13,18 @@
 
 import type { SnapshotDeps, SnapshotRegistry } from "./debug-snapshot";
 import { buildNoteSnapshot, buildVaultSnapshot } from "./debug-snapshot";
+import { type SyncEvent, serializeTimeline } from "./sync-recorder";
 
 const GLOBAL_KEY = "__engramDebug";
 
 export interface DebugApi {
 	note(key: string, includeContent?: boolean): Promise<unknown>;
 	vault(): unknown;
+	/** Recorded sync timeline (#356), optionally narrowed to one note. Returns
+	 *  the JSON a replay fixture is made of — copy it out of the console, or
+	 *  attach it to a bug report. */
+	timeline(noteId?: string): string;
+	clearTimeline(): void;
 }
 
 export interface DebugApiHost {
@@ -29,6 +35,7 @@ export interface DebugApiHost {
 	syncStateFor: SnapshotDeps["syncStateFor"];
 	isLiveBound(path: string): boolean;
 	pendingPromises(): { label: string; ageMs: number }[];
+	recorder: { timeline(noteId?: string): SyncEvent[]; clear(): void };
 }
 
 export function createDebugApi(host: DebugApiHost): DebugApi {
@@ -36,7 +43,16 @@ export function createDebugApi(host: DebugApiHost): DebugApi {
 	return {
 		note: (key, includeContent = false) => buildNoteSnapshot(key, deps, { includeContent }),
 		vault: () => buildVaultSnapshot(deps),
+		// Accepts a path as well as an id, matching `note()` — an investigation
+		// starts from whichever the evidence contained.
+		timeline: (noteId) =>
+			serializeTimeline(host.recorder.timeline(noteId ? resolveId(host, noteId) : undefined)),
+		clearTimeline: () => host.recorder.clear(),
 	};
+}
+
+function resolveId(host: DebugApiHost, key: string): string {
+	return host.idForPath(key) ?? key;
 }
 
 export function installDebugApi(api: DebugApi): void {

--- a/src/debug-api.ts
+++ b/src/debug-api.ts
@@ -1,0 +1,49 @@
+/**
+ * Installs the debug snapshot on `window.__engramDebug`.
+ *
+ * Gated on `diagnosticsEnabled`, NOT on `DEV_MODE`: the whole point is to
+ * inspect a real user's install while they are looking at the broken note. A
+ * dev-only handle would be absent in exactly the situation it exists for.
+ *
+ * Usage from the developer console:
+ *   await __engramDebug.note("notes/a.md")          // redacted
+ *   await __engramDebug.note("notes/a.md", true)    // with content
+ *   __engramDebug.vault()
+ */
+
+import type { SnapshotDeps, SnapshotRegistry } from "./debug-snapshot";
+import { buildNoteSnapshot, buildVaultSnapshot } from "./debug-snapshot";
+
+const GLOBAL_KEY = "__engramDebug";
+
+export interface DebugApi {
+	note(key: string, includeContent?: boolean): Promise<unknown>;
+	vault(): unknown;
+}
+
+export interface DebugApiHost {
+	registry: SnapshotRegistry;
+	idForPath(path: string): string | null;
+	pathForId(noteId: string): string | null;
+	readDisk: SnapshotDeps["readDisk"];
+	syncStateFor: SnapshotDeps["syncStateFor"];
+	isLiveBound(path: string): boolean;
+	pendingPromises(): { label: string; ageMs: number }[];
+}
+
+export function createDebugApi(host: DebugApiHost): DebugApi {
+	const deps: SnapshotDeps = host;
+	return {
+		note: (key, includeContent = false) => buildNoteSnapshot(key, deps, { includeContent }),
+		vault: () => buildVaultSnapshot(deps),
+	};
+}
+
+export function installDebugApi(api: DebugApi): void {
+	(window as unknown as Record<string, unknown>)[GLOBAL_KEY] = api;
+}
+
+export function uninstallDebugApi(): void {
+	// Intentional cleanup of a debug global; biome 2 dropped lint/performance/noDelete.
+	delete (window as unknown as Record<string, unknown>)[GLOBAL_KEY];
+}

--- a/src/debug-snapshot.ts
+++ b/src/debug-snapshot.ts
@@ -1,0 +1,267 @@
+/**
+ * One struct holding every copy of a note, side by side.
+ *
+ * Ported from Relay (`src/RelayDebugAPI.ts` `DocumentSnapshot`). Today, working
+ * out why a note diverged means reading `remote-log` output in Loki backwards
+ * and inferring state that was never recorded directly. Every CRDT incident in
+ * our history opened with the same half hour of "which copy is wrong". This
+ * answers that in one call.
+ *
+ * Two deliberate design choices:
+ *
+ * 1. **Content is withheld by default.** Note bodies are private, and a
+ *    snapshot is exactly the kind of thing that gets pasted into a support
+ *    ticket. Lengths and hashes are always present so the two sides stay
+ *    comparable; the text itself needs `{ includeContent: true }`.
+ *
+ * 2. **Every section degrades independently.** A snapshot that throws on the
+ *    broken state it exists to describe is useless precisely when it is needed,
+ *    so a failing section becomes `null` plus an entry in `errors`.
+ *
+ * ponytail: no separate IndexedDB replay. The resident doc is hydrated FROM
+ * IndexedDB, so a doc/idb split is only visible in the narrow window before
+ * `entry.ready` resolves. Upgrade path if that window ever matters: open the
+ * store, replay into a throwaway Y.Doc, and add an `idb` section beside `doc`.
+ */
+
+import { fnv1a } from "./content-hash";
+import type { FileSyncState } from "./types";
+
+export interface SnapshotContentView {
+	length: number;
+	/** FNV-1a of the content. Present even when the content itself is withheld,
+	 *  so doc and disk remain comparable in a redacted snapshot. */
+	hash: string;
+	/** Only when `includeContent` was requested. */
+	content?: string;
+}
+
+export interface DocView extends SnapshotContentView {
+	/** Whether the Y.Doc carries prior history (an LCA exists in CRDT terms). */
+	hasHistory: boolean;
+	/** Byte length of the doc's state vector. A cheap proxy for lineage size. */
+	stateVectorBytes: number;
+}
+
+export interface DiskView extends SnapshotContentView {
+	mtime: number;
+}
+
+export interface RoomView {
+	resident: boolean;
+	enrolled: boolean;
+	synced: boolean;
+	pendingGap: boolean;
+	undelivered: boolean;
+	removed: boolean;
+	liveBound: boolean;
+}
+
+export interface ServerView {
+	crdtHead?: string;
+	serverHash?: string;
+	version?: number;
+	seq?: number;
+	/** Last-synced content hash this device recorded. */
+	syncedHash?: number;
+}
+
+export interface NoteSnapshot {
+	path: string | null;
+	noteId: string | null;
+	idmap: {
+		idForPath: string | null;
+		pathForId: string | null;
+		/** False when the two directions disagree — the drift that strands flushes. */
+		bijective: boolean;
+	};
+	doc: DocView | null;
+	disk: DiskView | null;
+	server: ServerView | null;
+	room: RoomView;
+	/** True/false when both sides were readable, null when either failed. */
+	docMatchesDisk: boolean | null;
+	/** The server is known to hold a row for this note (a crdtHead was recorded). */
+	hasServerNote: boolean;
+	/** Sections that could not be read, as `"<section>: <reason>"`. */
+	errors: string[];
+}
+
+export interface VaultSnapshot {
+	rooms: { resident: number; enrolled: number; removed: number };
+	/** Outstanding async work, oldest first. */
+	pending: { label: string; ageMs: number }[];
+}
+
+/** Narrow structural view of ProviderRegistry — keeps this module testable
+ *  without standing up IndexedDB or a socket. */
+export interface SnapshotRegistry {
+	hasDoc(noteId: string): boolean;
+	projectedText(noteId: string): Promise<string>;
+	hasHistory(noteId: string): Promise<boolean>;
+	encodeStateVector(noteId: string): Promise<Uint8Array>;
+	isSynced(noteId: string): boolean;
+	hasPendingGap(noteId: string): Promise<boolean>;
+	hasUndeliveredOps(noteId: string): boolean;
+	enrolled: ReadonlySet<string>;
+	removedIds: ReadonlySet<string>;
+	residentIds(): string[];
+}
+
+export interface SnapshotDeps {
+	idForPath(path: string): string | null;
+	pathForId(noteId: string): string | null;
+	registry: SnapshotRegistry;
+	readDisk(path: string): Promise<{ length: number; mtime: number; content: string } | null>;
+	syncStateFor(path: string): FileSyncState | undefined;
+	isLiveBound(path: string): boolean;
+	pendingPromises(): { label: string; ageMs: number }[];
+}
+
+export interface SnapshotOpts {
+	/** Include raw note content. Off by default: see the module comment. */
+	includeContent?: boolean;
+}
+
+const hashOf = (content: string): string => fnv1a(content).toString(16);
+
+function describe(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Resolve a user-supplied key, which may be either a vault path or a note_id.
+ *
+ * Accepting both matters in practice: the wire and the logs are id-keyed while
+ * the user thinks in paths, so an investigation starts from whichever one the
+ * evidence happened to contain.
+ */
+function resolveKey(
+	key: string,
+	deps: SnapshotDeps,
+): { path: string | null; noteId: string | null } {
+	const idFromPath = deps.idForPath(key);
+	if (idFromPath) return { path: key, noteId: idFromPath };
+
+	const pathFromId = deps.pathForId(key);
+	if (pathFromId) return { path: pathFromId, noteId: key };
+
+	// Unmapped. Treat it as a path so the disk section can still be read — a
+	// file that exists on disk with no id is itself a finding.
+	return { path: key, noteId: null };
+}
+
+export async function buildNoteSnapshot(
+	key: string,
+	deps: SnapshotDeps,
+	opts: SnapshotOpts = {},
+): Promise<NoteSnapshot> {
+	const errors: string[] = [];
+	const { path, noteId } = resolveKey(key, deps);
+
+	const idForPath = path ? deps.idForPath(path) : null;
+	const pathForId = noteId ? deps.pathForId(noteId) : null;
+
+	const removed = noteId ? deps.registry.removedIds.has(noteId) : false;
+	const resident = noteId ? deps.registry.hasDoc(noteId) : false;
+
+	let doc: DocView | null = null;
+	let docContent: string | null = null;
+	if (noteId && resident) {
+		try {
+			const content = await deps.registry.projectedText(noteId);
+			docContent = content;
+			doc = {
+				length: content.length,
+				hash: hashOf(content),
+				hasHistory: await deps.registry.hasHistory(noteId),
+				stateVectorBytes: (await deps.registry.encodeStateVector(noteId)).byteLength,
+				...(opts.includeContent ? { content } : {}),
+			};
+		} catch (e) {
+			errors.push(`doc: ${describe(e)}`);
+		}
+	}
+
+	let disk: DiskView | null = null;
+	let diskContent: string | null = null;
+	if (path) {
+		try {
+			const read = await deps.readDisk(path);
+			if (read) {
+				diskContent = read.content;
+				disk = {
+					length: read.length,
+					hash: hashOf(read.content),
+					mtime: read.mtime,
+					...(opts.includeContent ? { content: read.content } : {}),
+				};
+			}
+		} catch (e) {
+			errors.push(`disk: ${describe(e)}`);
+		}
+	}
+
+	let pendingGap = false;
+	if (noteId && resident) {
+		try {
+			pendingGap = await deps.registry.hasPendingGap(noteId);
+		} catch (e) {
+			errors.push(`room: ${describe(e)}`);
+		}
+	}
+
+	const state = path ? deps.syncStateFor(path) : undefined;
+
+	return {
+		path,
+		noteId,
+		idmap: {
+			idForPath,
+			pathForId,
+			// Both directions present and agreeing = healthy. Neither present =
+			// nothing to disagree about (an unmapped path is reported elsewhere).
+			// Exactly ONE present = the two directions have drifted apart, which is
+			// the half-mapped state that strands flushes — it must not read as
+			// healthy just because nothing contradicts it.
+			bijective: idForPath && pathForId ? pathForId === path : !idForPath && !pathForId,
+		},
+		doc,
+		disk,
+		server: state
+			? {
+					crdtHead: state.crdtHead,
+					serverHash: state.serverHash,
+					version: state.version,
+					seq: state.seq,
+					syncedHash: state.hash,
+				}
+			: null,
+		room: {
+			resident,
+			enrolled: noteId ? deps.registry.enrolled.has(noteId) : false,
+			synced: noteId ? deps.registry.isSynced(noteId) : false,
+			pendingGap,
+			undelivered: noteId ? deps.registry.hasUndeliveredOps(noteId) : false,
+			removed,
+			liveBound: path ? deps.isLiveBound(path) : false,
+		},
+		docMatchesDisk:
+			docContent !== null && diskContent !== null ? docContent === diskContent : null,
+		hasServerNote: state?.crdtHead != null,
+		errors,
+	};
+}
+
+export function buildVaultSnapshot(deps: SnapshotDeps): VaultSnapshot {
+	return {
+		rooms: {
+			resident: deps.registry.residentIds().length,
+			enrolled: deps.registry.enrolled.size,
+			removed: deps.registry.removedIds.size,
+		},
+		// Oldest first: a wedged operation is the one worth seeing, and it is the
+		// one that has been outstanding longest.
+		pending: [...deps.pendingPromises()].sort((a, b) => b.ageMs - a.ageMs),
+	};
+}

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -1,0 +1,95 @@
+/**
+ * Typed feature flags with a schema.
+ *
+ * Ported from Relay (`src/flags.ts` + `src/flagManager.ts`). The valuable part
+ * is not the booleans — we already have those in settings — it is that the
+ * schema is a mapped type over `FeatureFlags`, so **adding a flag without
+ * declaring its category, title and description is a type error**. That is what
+ * stops a flag from shipping as an undocumented boolean nobody can find.
+ *
+ * Categories decide visibility, which is the second half of the idea:
+ *   - `labs`      — opt-in user-facing behavior. Always shown.
+ *   - `debugging` — diagnostic instrumentation. Shown only with diagnostics on.
+ *   - `danger`    — changes persistence or sync semantics. Diagnostics-only, and
+ *                   rendered in a marked zone. Must default OFF (asserted in
+ *                   tests) — a danger flag that ships on is an un-reviewed
+ *                   migration wearing a flag's clothes.
+ *
+ * ponytail: no singleton manager, no server-pushed overrides. Relay has both;
+ * we have no backend flag endpoint to push from, and every consumer already
+ * receives its options explicitly. Add a manager when a second reader needs the
+ * flags without a path to thread them through.
+ */
+
+export type FlagCategory = "labs" | "debugging" | "danger";
+
+export interface FlagSchemaEntry {
+	default: boolean;
+	category: FlagCategory;
+	/** Row heading in settings. */
+	title: string;
+	/** One-line summary beside the toggle. */
+	description: string;
+}
+
+/** Every supported flag. Adding a key here forces a `FLAG_SCHEMA` entry. */
+export interface FeatureFlags {
+	/** Capture an ordered timeline of CRDT sync events for replay (#356). */
+	crdtRecording: boolean;
+	/** Merge disk changes against the persisted LCA instead of diffing against
+	 *  current doc state (#357). */
+	crdtLcaMerge: boolean;
+}
+
+export const FLAG_SCHEMA: { [K in keyof FeatureFlags]: FlagSchemaEntry } = {
+	crdtRecording: {
+		default: false,
+		category: "debugging",
+		title: "Record CRDT sync timeline",
+		description:
+			"Capture an ordered event timeline for each synced note so a sync failure can be replayed offline. Metadata and note content stay local.",
+	},
+	crdtLcaMerge: {
+		default: false,
+		category: "danger",
+		title: "Three-way merge against the last common ancestor",
+		description:
+			"Merge disk edits against the last synced content instead of the current document state. Changes how concurrent edits are resolved.",
+	},
+};
+
+const FLAG_KEYS = Object.keys(FLAG_SCHEMA) as (keyof FeatureFlags)[];
+
+/**
+ * Resolve stored overrides against the schema defaults.
+ *
+ * Deliberately strict about what it accepts: `data.json` is a user-editable
+ * file, so a hand-edited `"true"` must not enable a danger flag by truthiness,
+ * and a key left behind by a retired flag must not survive into the result.
+ */
+export function resolveFlags(stored: Partial<FeatureFlags> | undefined): FeatureFlags {
+	const out = {} as FeatureFlags;
+	for (const key of FLAG_KEYS) {
+		const value = stored?.[key];
+		out[key] = typeof value === "boolean" ? value : FLAG_SCHEMA[key].default;
+	}
+	return out;
+}
+
+export type FlagEntry = [keyof FeatureFlags, FlagSchemaEntry];
+
+/** Schema entries in declaration order, filtered to one category. */
+export function flagsForCategory(category: FlagCategory): FlagEntry[] {
+	return FLAG_KEYS.filter((key) => FLAG_SCHEMA[key].category === category).map((key) => [
+		key,
+		FLAG_SCHEMA[key],
+	]);
+}
+
+/** Which flags the settings UI should draw. `labs` always; the rest only once
+ *  the user has opted into diagnostics. */
+export function visibleFlags(diagnosticsEnabled: boolean): FlagEntry[] {
+	return FLAG_KEYS.filter(
+		(key) => diagnosticsEnabled || FLAG_SCHEMA[key].category === "labs",
+	).map((key) => [key, FLAG_SCHEMA[key]]);
+}

--- a/src/has-logging.ts
+++ b/src/has-logging.ts
@@ -1,0 +1,85 @@
+/**
+ * A base class that gives every subclass pre-tagged loggers.
+ *
+ * Ported from Relay (`src/debug.ts` `HasLogging`). The problem it solves in our
+ * codebase is tag drift: today a log site is `rlog().info("channel", ...)`, so
+ * the category is a string literal repeated at every call site. Rename the
+ * concept and the tags rot silently — greps stop finding things, and Loki
+ * queries keep matching a name that no longer exists.
+ *
+ * Here the tag is bound once (defaulting to the class name) and `setLoggers`
+ * retags every subsequent line, so a per-note object can relabel itself on
+ * rename and its logs follow.
+ *
+ * ponytail: a sink indirection instead of importing `rlog`/`devLog` directly.
+ * Two reasons — this module stays dependency-free and therefore trivially
+ * testable, and the plugin decides once (in main.ts) where lines go. Upgrade
+ * path if a second destination is ever needed: make the sink a list.
+ */
+
+export type LogLevel = "debug" | "info" | "warn" | "error";
+
+export type LogSink = (level: LogLevel, category: string, message: string) => void;
+
+let sink: LogSink | null = null;
+
+/** Install the process-wide destination for `HasLogging` output. Pass `null` to
+ *  detach (tests, and plugin unload). */
+export function setLogSink(next: LogSink | null): void {
+	sink = next;
+}
+
+/** Render one argument for the flat string a log line carries. Objects are
+ *  JSON so a structured value survives. An unserializable one (cyclic, a BigInt,
+ *  a live Y.Doc) degrades to a NAMED marker rather than throwing at the log site
+ *  — a logging call must never be the thing that breaks a sync path. The marker
+ *  carries the constructor name because `[object Object]`, the default
+ *  stringification, tells the reader nothing about what was dropped. */
+function render(arg: unknown): string {
+	if (typeof arg === "string") return arg;
+	if (arg instanceof Error) return arg.message;
+	if (arg === null || typeof arg !== "object") return String(arg);
+	try {
+		// JSON.stringify returns undefined for values with no JSON form; treat that
+		// the same as a throw so the marker path is the single fallback.
+		return JSON.stringify(arg) ?? `[unserializable ${arg.constructor?.name ?? "object"}]`;
+	} catch {
+		return `[unserializable ${arg.constructor?.name ?? "object"}]`;
+	}
+}
+
+function emit(level: LogLevel, category: string, args: unknown[]): void {
+	if (!sink) return;
+	sink(level, category, args.map(render).join(" "));
+}
+
+export class HasLogging {
+	private logContext: string;
+
+	constructor(context?: string) {
+		this.logContext = context ?? new.target.name;
+	}
+
+	/** Retag every subsequent line from this object. Call when the thing being
+	 *  logged about changes identity — a note that was renamed, a folder that
+	 *  moved. */
+	protected setLoggers(context: string): void {
+		this.logContext = context;
+	}
+
+	protected debug(...args: unknown[]): void {
+		emit("debug", this.logContext, args);
+	}
+
+	protected log(...args: unknown[]): void {
+		emit("info", this.logContext, args);
+	}
+
+	protected warn(...args: unknown[]): void {
+		emit("warn", this.logContext, args);
+	}
+
+	protected error(...args: unknown[]): void {
+		emit("error", this.logContext, args);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2072,6 +2072,20 @@ export default class EngramSyncPlugin extends Plugin {
 							noteIdMap: this.noteIdMap,
 							syncEngine: this.syncEngine,
 							recorder: this.syncRecorder,
+							// BaseStore is keyed by vault path and already holds exactly the
+							// last-synced content its own docstring calls "the common
+							// ancestor for 3-way merge"; the registry is keyed by note_id,
+							// so resolve through the id map.
+							lcaFor: (noteId) => {
+								const path = this.noteIdMap.pathForId(noteId);
+								return path ? (this.baseStore?.get(path)?.content ?? null) : null;
+							},
+							lcaMergeEnabled: () => this.flags.crdtLcaMerge,
+							onDirtyMerge: (noteId) =>
+								rlog().warn(
+									"crdt",
+									`LCA merge left unapplied hunks for ${noteId} — fell back to the two-way path`,
+								),
 							// `?? false`: a null socket (mid-reconnect) must read as REFUSED so
 							// the frame is held in unsentDocIds and flushed on rejoin — never
 							// silently dropped as if sent.

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,13 @@ import { type CrdtWiring, createCrdtWiring } from "./crdt/wiring";
 import { makeCrdtOpSend } from "./crdt-op-dispatch";
 import { type CrdtOp, CrdtOpQueue } from "./crdt-op-queue";
 import { destroyDevLog, devLog, initDevLog } from "./dev-log";
+import { type FeatureFlags, resolveFlags } from "./feature-flags";
+import { setLogSink } from "./has-logging";
+import { PromiseTracker, setActiveTracker } from "./track-promise";
+
+/** Replaced by esbuild at build time (see esbuild.config.mjs `define`). */
+declare const DEV_MODE: boolean;
+
 import { registerDiagnostics } from "./diagnostics";
 import { EmailCaptureModal } from "./email-capture-modal";
 import { errMsg } from "./error-util";
@@ -181,6 +188,18 @@ export function channelIdentityMatches(
 export default class EngramSyncPlugin extends Plugin {
 	settings: EngramSyncSettings = DEFAULT_SETTINGS;
 	api: EngramApi = new EngramApi("", "");
+	/** Dev-build only: registry of outstanding async work, exposed through the
+	 *  debug snapshot so a wedged sync shows up as a long-lived pending entry
+	 *  instead of having to be inferred from logs. Null in production. */
+	promiseTracker: PromiseTracker | null = null;
+
+	/** Resolved feature flags (stored overrides applied over schema defaults).
+	 *  Recomputed on every read so a settings toggle takes effect without a
+	 *  reload — these are cheap (a fixed-size object literal), and caching one
+	 *  would just add an invalidation bug. */
+	get flags(): FeatureFlags {
+		return resolveFlags(this.settings.featureFlags);
+	}
 	/** Persist the user's chosen search mode as the new default. Passed to the
 	 *  search view + modal so a mode switch in either surface sticks. */
 	private persistSearchMode = (mode: SearchMode): void => {
@@ -343,6 +362,22 @@ export default class EngramSyncPlugin extends Plugin {
 
 	async onload(): Promise<void> {
 		initDevLog();
+		// Route HasLogging output to both existing destinations, so a class that
+		// extends it needs no logger wiring of its own. devLog is tree-shaken in
+		// production; rlog respects the diagnostics switch and level threshold.
+		setLogSink((level, category, message) => {
+			devLog().log(category, message);
+			// "debug" stops at the local ring buffer on purpose. rlog has no debug
+			// method, and shipping debug volume to Loki is exactly the cardinality
+			// problem the remoteLogLevel dial exists to avoid.
+			if (level === "error") rlog().error(category, message);
+			else if (level === "warn") rlog().warn(category, message);
+			else if (level === "info") rlog().info(category, message);
+		});
+		if (DEV_MODE) {
+			this.promiseTracker = new PromiseTracker();
+			setActiveTracker(this.promiseTracker);
+		}
 		devLog().log("lifecycle", "plugin loading");
 		rlog().info("lifecycle", `onload start — v${this.manifest.version}`);
 		activeDocument.body.classList.add("engram-vault-sync-active");
@@ -1079,6 +1114,12 @@ export default class EngramSyncPlugin extends Plugin {
 			this.syncInterval = null;
 		}
 		void destroyRemoteLog();
+		// Detach the sink BEFORE the loggers go away: a HasLogging subclass torn
+		// down after this point would otherwise write into a destroyed devLog.
+		setLogSink(null);
+		setActiveTracker(null);
+		this.promiseTracker?.destroy();
+		this.promiseTracker = null;
 		destroyDevLog();
 		// Yjs stamps globalThis['__ $YJS$ __'] = true on import to guard against
 		// duplicate copies (yjs#438). Obsidian reloads the plugin module graph on

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import { createDebugApi, installDebugApi, uninstallDebugApi } from "./debug-api"
 import { destroyDevLog, devLog, initDevLog } from "./dev-log";
 import { type FeatureFlags, resolveFlags } from "./feature-flags";
 import { setLogSink } from "./has-logging";
+import { SyncRecorder } from "./sync-recorder";
 import { PromiseTracker, setActiveTracker } from "./track-promise";
 
 /** Replaced by esbuild at build time (see esbuild.config.mjs `define`). */
@@ -193,6 +194,14 @@ export default class EngramSyncPlugin extends Plugin {
 	 *  debug snapshot so a wedged sync shows up as a long-lived pending entry
 	 *  instead of having to be inferred from logs. Null in production. */
 	promiseTracker: PromiseTracker | null = null;
+
+	/** Timeline capture for the CRDT seams (#356). Constructed once and kept for
+	 *  the plugin's lifetime — it reads the flag on every record call, so
+	 *  toggling recording never needs the CRDT stack rebuilt. Its buffer is
+	 *  bounded, and it costs one predicate call per seam while off. */
+	readonly syncRecorder: SyncRecorder = new SyncRecorder({
+		enabled: () => this.flags.crdtRecording,
+	});
 
 	/** Resolved feature flags (stored overrides applied over schema defaults).
 	 *  Recomputed on every read so a settings toggle takes effect without a
@@ -1231,6 +1240,7 @@ export default class EngramSyncPlugin extends Plugin {
 				syncStateFor: (path) => this.syncEngine.exportSyncState()[normalizePath(path)],
 				isLiveBound: (path) => this.crdtLiveViews?.isBound(path) ?? false,
 				pendingPromises: () => this.promiseTracker?.pending() ?? [],
+				recorder: this.syncRecorder,
 			}),
 		);
 	}
@@ -2061,6 +2071,7 @@ export default class EngramSyncPlugin extends Plugin {
 						const wiring = createCrdtWiring({
 							noteIdMap: this.noteIdMap,
 							syncEngine: this.syncEngine,
+							recorder: this.syncRecorder,
 							// `?? false`: a null socket (mid-reconnect) must read as REFUSED so
 							// the frame is held in unsentDocIds and flushed on rejoin — never
 							// silently dropped as if sent.

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { ensureDocSchema } from "./crdt/schema";
 import { type CrdtWiring, createCrdtWiring } from "./crdt/wiring";
 import { makeCrdtOpSend } from "./crdt-op-dispatch";
 import { type CrdtOp, CrdtOpQueue } from "./crdt-op-queue";
+import { createDebugApi, installDebugApi, uninstallDebugApi } from "./debug-api";
 import { destroyDevLog, devLog, initDevLog } from "./dev-log";
 import { type FeatureFlags, resolveFlags } from "./feature-flags";
 import { setLogSink } from "./has-logging";
@@ -1114,6 +1115,9 @@ export default class EngramSyncPlugin extends Plugin {
 			this.syncInterval = null;
 		}
 		void destroyRemoteLog();
+		// The debug API closes over the CRDT stack; leaving the global behind after
+		// unload hands the next instance's console a handle to dead objects.
+		uninstallDebugApi();
 		// Detach the sink BEFORE the loggers go away: a HasLogging subclass torn
 		// down after this point would otherwise write into a destroyed devLog.
 		setLogSink(null);
@@ -1187,6 +1191,50 @@ export default class EngramSyncPlugin extends Plugin {
 		// setDeviceId(this.deviceId), before any sync runs.
 	}
 
+	/**
+	 * Install or remove `window.__engramDebug` to match the diagnostics setting.
+	 *
+	 * Called from saveSettings (the user toggled diagnostics) and after the CRDT
+	 * stack is rebuilt (the registry it closes over was replaced). Cheap and
+	 * idempotent, so both callers can fire it unconditionally.
+	 */
+	private refreshDebugApi(): void {
+		const registry = this.crdtManager;
+		if (!this.settings.diagnosticsEnabled || !registry) {
+			uninstallDebugApi();
+			return;
+		}
+		installDebugApi(
+			createDebugApi({
+				registry: {
+					hasDoc: (id) => registry.hasDoc(id),
+					projectedText: (id) => registry.projectedText(id),
+					hasHistory: (id) => registry.hasHistory(id),
+					encodeStateVector: (id) => registry.encodeStateVector(id),
+					isSynced: (id) => registry.isSynced(id),
+					hasPendingGap: (id) => registry.hasPendingGap(id),
+					hasUndeliveredOps: (id) => registry.hasUndeliveredOps(id),
+					enrolled: registry.enrolled,
+					removedIds: registry.removedIds,
+					residentIds: () => [...registry.docs.keys()],
+				},
+				idForPath: (path) => this.noteIdMap.get(path),
+				pathForId: (id) => this.noteIdMap.pathForId(id),
+				readDisk: async (path) => {
+					const file = this.app.vault.getAbstractFileByPath(normalizePath(path));
+					if (!(file instanceof TFile)) return null;
+					const content = await this.app.vault.read(file);
+					return { length: content.length, mtime: file.stat.mtime, content };
+				},
+				// exportSyncState() copies the whole map per call. Acceptable: this
+				// runs only when a human invokes the console API, never on a sync path.
+				syncStateFor: (path) => this.syncEngine.exportSyncState()[normalizePath(path)],
+				isLiveBound: (path) => this.crdtLiveViews?.isBound(path) ?? false,
+				pendingPromises: () => this.promiseTracker?.pending() ?? [],
+			}),
+		);
+	}
+
 	async saveSettings(): Promise<void> {
 		this.api.updateConfig(this.settings.apiUrl, this.settings.apiKey);
 		this.api.setVaultId(this.settings.vaultId);
@@ -1194,6 +1242,7 @@ export default class EngramSyncPlugin extends Plugin {
 		this.syncEngine.updateSettings(this.settings);
 		rlog().setLevelThreshold(this.settings.remoteLogLevel);
 		rlog().setEnabled(this.settings.diagnosticsEnabled);
+		this.refreshDebugApi();
 		this.startSyncInterval();
 		this.setupNoteStream();
 		await this.savePluginData(this.syncEngine.getLastSync());
@@ -2067,6 +2116,7 @@ export default class EngramSyncPlugin extends Plugin {
 					// Bind whatever leaves are open now — a fresh stack saw none at build;
 					// a reconnect re-checks in case the open set changed while offline.
 					this.crdtLiveViews?.refresh();
+					this.refreshDebugApi();
 					// Re-point the NEW channel's inbound callbacks at the PERSISTENT wiring
 					// every (re)connect. The wiring (and its box.channel) outlives the socket.
 					const wiring = this.crdtWiring;

--- a/src/offline-queue.ts
+++ b/src/offline-queue.ts
@@ -2,10 +2,64 @@
  * Offline queue — persists failed sync operations for retry when connectivity returns.
  *
  * Deduplicates by composite key "{vaultId}:{path}" (or just "{path}" if no vaultId).
- * Entries are flushed oldest-first.
+ * Entries are flushed by priority, then oldest-first within a priority.
  * Persistence is debounced to avoid O(n²) serialization during rapid enqueues.
+ *
+ * ponytail (#359): this queue was NOT rewritten. Relay's BackgroundSync is 2450
+ * lines of groups, progress snapshots and cancellation, but most of what it adds
+ * we already had — dedup, a persisted retry cap (`attempts`), oldest-first
+ * ordering. Only three things were genuinely missing, and they are here:
+ * priority, an explicit synchronous `cancel`, and `queuedReason`. Rewriting a
+ * battle-tested persisted component to reach parity with a design we do not
+ * need would have been the expensive way to get those.
  */
 import type { QueueEntry } from "./types";
+
+/**
+ * Flush order. Lower runs sooner.
+ *
+ * Numeric rather than a string union so ordering is the comparison itself, and
+ * so a persisted entry from before this existed sorts as `Normal` via `??`
+ * rather than sinking below background work.
+ */
+export const QueuePriority = {
+	/** The note the user currently has open. */
+	OpenNote: 0,
+	/** Ordinary edit-driven sync. The default. */
+	Normal: 10,
+	/** Bulk work: initial import, full push, resync sweeps. */
+	Background: 20,
+} as const;
+
+export type QueuePriorityValue = (typeof QueuePriority)[keyof typeof QueuePriority];
+
+export interface QueueGateState {
+	queued: number;
+	inFlight: number;
+	offline: boolean;
+	syncBlocked: boolean;
+}
+
+export type QueuedReason = "offline" | "sync-blocked" | "in-progress" | "waiting";
+
+/**
+ * Why is this queue not draining?
+ *
+ * Ported from Relay's `queuedReasonForSnapshot`. Cheap, and it removes a whole
+ * class of support ticket: today a held queue is an unexplained spinner, and
+ * "waiting" in particular names the case that currently looks like a hang —
+ * online, unblocked, nothing in flight, work still sitting there.
+ *
+ * Offline outranks sync-blocked because it is the one the user can act on and
+ * the one that resolves itself.
+ */
+export function queuedReason(state: QueueGateState): QueuedReason | null {
+	if (state.queued === 0) return null;
+	if (state.offline) return "offline";
+	if (state.syncBlocked) return "sync-blocked";
+	if (state.inFlight > 0) return "in-progress";
+	return "waiting";
+}
 
 /** Build the composite dedup key: "{vaultId}:{path}" or just "{path}" if no vaultId. */
 function dedupKey(entry: QueueEntry): string;
@@ -60,9 +114,26 @@ export class OfflineQueue {
 		return this.entries.get(dedupKey(path, vaultId))?.action === "delete";
 	}
 
-	/** Get all entries sorted by timestamp (oldest first). */
+	/** Remove a path's queued work immediately, without waiting on a persist
+	 *  round trip. `dequeue` awaits persistence, which is right after a
+	 *  successful sync but wrong for a rename or a vault switch: the caller needs
+	 *  the entry gone before the flush loop can pick up work for a path that no
+	 *  longer exists. Returns whether anything was removed. */
+	cancel(path: string, vaultId?: string): boolean {
+		const removed = this.entries.delete(dedupKey(path, vaultId));
+		if (removed) this.schedulePersist();
+		return removed;
+	}
+
+	/** Get all entries in flush order: priority first, then oldest-first within
+	 *  a priority. An entry with no `priority` (persisted before the field
+	 *  existed) counts as Normal, so an upgrade never demotes pending work. */
 	all(): QueueEntry[] {
-		return Array.from(this.entries.values()).sort((a, b) => a.timestamp - b.timestamp);
+		return Array.from(this.entries.values()).sort(
+			(a, b) =>
+				(a.priority ?? QueuePriority.Normal) - (b.priority ?? QueuePriority.Normal) ||
+				a.timestamp - b.timestamp,
+		);
 	}
 
 	/** Number of queued entries. */

--- a/src/sync-center-render.ts
+++ b/src/sync-center-render.ts
@@ -7,6 +7,7 @@
 import { Notice, normalizePath, Setting } from "obsidian";
 import { type IssueDisposition, issueDisposition, remediation } from "./issue-store";
 import type EngramSyncPlugin from "./main";
+import type { QueuedReason } from "./offline-queue";
 import { SyncPreviewModal } from "./sync-preview-modal";
 import type { SyncIssue, SyncIssueCategory, SyncLogEntry } from "./types";
 
@@ -78,6 +79,15 @@ function groupedByCategory(
 	return CATEGORY_ORDER.filter((c) => groups.has(c)).map((c) => [c, groups.get(c)!]);
 }
 
+/** User-facing wording for each queued reason. Kept beside the render so the
+ *  copy is reviewable in one place rather than inlined into a template. */
+const QUEUED_REASON_TEXT: Record<QueuedReason, string> = {
+	offline: "waiting for a connection",
+	"sync-blocked": "sync is paused",
+	"in-progress": "syncing now",
+	waiting: "waiting to retry",
+};
+
 function renderHeader(parent: HTMLElement, plugin: EngramSyncPlugin): void {
 	const header = parent.createDiv({ cls: "engram-sync-center-header" });
 	const status = plugin.syncEngine.getStatus();
@@ -117,6 +127,15 @@ function renderHeader(parent: HTMLElement, plugin: EngramSyncPlugin): void {
 	if (ignoredCount > 0) {
 		const badge = header.createSpan({ cls: "engram-sync-center-ignored-badge" });
 		badge.setText(`${ignoredCount} ignored`);
+	}
+
+	// Say WHY the queue is holding rather than leaving a bare count that reads
+	// as a hang. "waiting" is the case that previously showed an unexplained
+	// spinner: online, unblocked, nothing in flight, work still sitting there.
+	const reason = plugin.syncEngine.queuedReason();
+	if (reason) {
+		const badge = header.createSpan({ cls: "engram-sync-center-queued-badge" });
+		badge.setText(`${status.queued} queued — ${QUEUED_REASON_TEXT[reason]}`);
 	}
 }
 

--- a/src/sync-recorder.ts
+++ b/src/sync-recorder.ts
@@ -1,0 +1,164 @@
+/**
+ * Ordered capture of what happened at the CRDT sync seams.
+ *
+ * Ported from Relay (`src/merge-hsm/recording/`). The gap it closes: a sync
+ * failure that only reproduces in CI is currently un-unit-testable. With a
+ * timeline it becomes download → replay in Bun → fix → keep the timeline as a
+ * regression fixture.
+ *
+ * **`seq` is a monotonic counter, never a clock reading.** This is the whole
+ * point. Our `[client:*]` log `time` is the batch-SHIP stamp, so ordering by it
+ * scrambles causality — a trap that cost two debugging sessions. A recorded
+ * timeline is ordered by construction and `deserializeTimeline` refuses to load
+ * one whose ordering was broken.
+ *
+ * ponytail: the recorder ships; the REPLAYER lives in `tests/helpers/replay.ts`.
+ * Capture is the half we cannot do at all today, and it has to run inside a
+ * user's session. Replay is a test-harness concern and has no business in the
+ * production bundle.
+ */
+
+/** Seams worth recording. Kept as a closed union so a replayer can exhaustively
+ *  switch and a new seam cannot be added without teaching replay about it. */
+export type SyncEventKind =
+	/** Inbound CRDT frame from the wire. */
+	| "receive"
+	/** Outbound CRDT frame. `accepted:false` means the transport refused it. */
+	| "send"
+	/** Disk content fed into the doc. */
+	| "localEdit"
+	/** Raw Yjs update applied outside the room handshake (vault fan-out). */
+	| "remoteUpdate"
+	/** Room opened (syncStep1 advertised). */
+	| "enroll"
+	/** Room closed. */
+	| "reset"
+	/** Transport connected or dropped. */
+	| "connection"
+	/** A remote merge was written back to disk. */
+	| "flush";
+
+/** Runtime companion to `SyncEventKind`. Kept adjacent to the type so adding a
+ *  kind without listing it here shows up immediately as a load-time rejection
+ *  rather than an unhandled `default` branch deep in a replay. */
+const SYNC_EVENT_KINDS = new Set<string>([
+	"receive",
+	"send",
+	"localEdit",
+	"remoteUpdate",
+	"enroll",
+	"reset",
+	"connection",
+	"flush",
+] satisfies SyncEventKind[]);
+
+function isSyncEventKind(value: string): value is SyncEventKind {
+	return SYNC_EVENT_KINDS.has(value);
+}
+
+export interface SyncEvent {
+	/** Monotonic, assigned at record time. Never a timestamp. */
+	seq: number;
+	kind: SyncEventKind;
+	/** The note this event concerns, or null for vault-wide events. */
+	noteId: string | null;
+	/** Kind-specific payload. Must be JSON-serializable. */
+	data: Record<string, unknown>;
+}
+
+export interface SyncRecorderOpts {
+	/** Read at every record call, so toggling the flag takes effect immediately
+	 *  rather than at the next reload. */
+	enabled: () => boolean;
+	capacity?: number;
+}
+
+const DEFAULT_CAPACITY = 5_000;
+
+export class SyncRecorder {
+	private readonly events: SyncEvent[] = [];
+	private readonly capacity: number;
+	private readonly enabled: () => boolean;
+	private nextSeq = 0;
+
+	constructor(opts: SyncRecorderOpts) {
+		this.enabled = opts.enabled;
+		this.capacity = opts.capacity ?? DEFAULT_CAPACITY;
+	}
+
+	/**
+	 * Append one event.
+	 *
+	 * When recording is off this is a bare predicate call and a return — cheap
+	 * enough to sit on the hot receive path. `nextSeq` deliberately does NOT
+	 * advance for a suppressed event: a timeline captured across a mid-session
+	 * toggle would otherwise show numbering gaps that read as dropped frames.
+	 */
+	record(kind: SyncEventKind, noteId: string | null, data: Record<string, unknown>): void {
+		if (!this.enabled()) return;
+		this.events.push({ seq: this.nextSeq++, kind, noteId, data });
+		if (this.events.length > this.capacity) {
+			this.events.splice(0, this.events.length - this.capacity);
+		}
+	}
+
+	/** Recorded events in causal order, optionally narrowed to one note. The
+	 *  retained window keeps its original seq numbers, so a truncated timeline
+	 *  still reports how much preceded it. */
+	timeline(noteId?: string): SyncEvent[] {
+		const all = [...this.events];
+		return noteId ? all.filter((e) => e.noteId === noteId) : all;
+	}
+
+	/** Drop buffered events. The seq counter keeps going: restarting numbering
+	 *  would make two timelines from one session look like the same events. */
+	clear(): void {
+		this.events.length = 0;
+	}
+}
+
+export function serializeTimeline(events: SyncEvent[]): string {
+	return JSON.stringify(events);
+}
+
+/**
+ * Parse a timeline, rejecting anything that would replay misleadingly.
+ *
+ * Validation is not defensive padding here: a fixture gets hand-edited and
+ * badly merged, and a timeline replayed out of causal order produces a
+ * divergence with no obvious cause. Failing loudly at load is much cheaper than
+ * debugging that.
+ */
+export function deserializeTimeline(json: string): SyncEvent[] {
+	const parsed: unknown = JSON.parse(json);
+	if (!Array.isArray(parsed)) {
+		throw new Error("timeline must be an array");
+	}
+
+	let previousSeq = Number.NEGATIVE_INFINITY;
+	return parsed.map((raw, index) => {
+		// Read through `unknown`, not `Partial<SyncEvent>`. Asserting the shape up
+		// front makes `kind` LOOK like the union to the compiler while the runtime
+		// value is still an arbitrary string, so an unknown kind would sail through
+		// validation and reach a replayer that promises to switch exhaustively.
+		const e = raw as Record<string, unknown>;
+		if (typeof e.seq !== "number" || typeof e.kind !== "string" || !("data" in e)) {
+			throw new Error(`timeline entry ${index} is missing seq, kind or data`);
+		}
+		if (!isSyncEventKind(e.kind)) {
+			throw new Error(`timeline entry ${index} has unknown kind ${JSON.stringify(e.kind)}`);
+		}
+		if (e.seq <= previousSeq) {
+			throw new Error(
+				`timeline is out of order at entry ${index}: seq ${e.seq} follows ${previousSeq}`,
+			);
+		}
+		previousSeq = e.seq;
+		return {
+			seq: e.seq,
+			kind: e.kind,
+			noteId: typeof e.noteId === "string" ? e.noteId : null,
+			data: (e.data ?? {}) as Record<string, unknown>,
+		};
+	});
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -23,7 +23,15 @@ import {
 	shouldRetryAfterFailure,
 } from "./issue-store";
 import { isTextAttachment } from "./mime";
-import { OfflineQueue } from "./offline-queue";
+import {
+	// Aliased: the SyncEngine method below has the same name, and an unqualified
+	// call resolving to the module function while `this.queuedReason` resolves to
+	// the method is exactly the kind of thing that reads wrong at 3am.
+	queuedReason as computeQueuedReason,
+	OfflineQueue,
+	type QueuedReason,
+	QueuePriority,
+} from "./offline-queue";
 import { attachmentCapabilityGained, type PlanState } from "./plan-state";
 import { rlog } from "./remote-log";
 import type { SyncLog } from "./sync-log";
@@ -341,6 +349,9 @@ export class SyncEngine {
 	private syncBlocked = false;
 	private activePushCount = 0;
 	private maxConcurrentPushes = 5;
+	/** >0 while a bulk sweep (pushAll / fullSync) is running. Queue entries it
+	 *  produces get Background priority — see priorityForPath. */
+	private bulkDepth = 0;
 	private pushWaiters: (() => void)[] = [];
 	readonly queue: OfflineQueue = new OfflineQueue();
 
@@ -6152,6 +6163,12 @@ export class SyncEngine {
 
 	/** Full bidirectional sync: pull remote changes, then push local changes. */
 	async fullSync(): Promise<{ pulled: number; pushed: number }> {
+		// Thin wrapper so the sweep is marked without reindenting the whole body.
+		// fullSync calls pushAll, so bulkDepth nests — hence a counter, not a flag.
+		return this.inBulkSweep(() => this.fullSyncInner());
+	}
+
+	private async fullSyncInner(): Promise<{ pulled: number; pushed: number }> {
 		if (this.syncBlocked) {
 			devLog().log("sync-blocked", "fullSync short-circuited — gate closed");
 			return { pulled: 0, pushed: 0 };
@@ -6785,6 +6802,13 @@ export class SyncEngine {
 	async pushAll(
 		opts: { replaceRemote?: boolean; localSnapshot?: Set<string> } = {},
 	): Promise<number> {
+		// Thin wrapper so the sweep is marked without reindenting the whole body.
+		return this.inBulkSweep(() => this.pushAllInner(opts));
+	}
+
+	private async pushAllInner(
+		opts: { replaceRemote?: boolean; localSnapshot?: Set<string> } = {},
+	): Promise<number> {
 		if (this.syncBlocked) {
 			devLog().log("sync-blocked", "pushAll short-circuited — gate closed");
 			return 0;
@@ -7071,9 +7095,52 @@ export class SyncEngine {
 
 	// --- Offline queue ---
 
-	/** Queue a change for retry and go offline. */
+	/** Flush priority for a path.
+	 *
+	 *  A live-bound path is one the user has open in an editor — the single case
+	 *  where queue latency is directly visible — so it outranks everything even
+	 *  during a bulk sweep. Otherwise, work generated inside a bulk sweep sinks
+	 *  to Background so an interactive edit made mid-import is not stuck behind
+	 *  thousands of retries. */
+	private priorityForPath(path: string): number {
+		if (this.isLiveBound?.(path)) return QueuePriority.OpenNote;
+		return this.bulkDepth > 0 ? QueuePriority.Background : QueuePriority.Normal;
+	}
+
+	/** Run `fn` with queue entries it produces marked as bulk work. A counter
+	 *  rather than a boolean because fullSync calls pushAll — a boolean would be
+	 *  cleared by the inner call while the outer sweep was still running. */
+	private async inBulkSweep<T>(fn: () => Promise<T>): Promise<T> {
+		this.bulkDepth += 1;
+		try {
+			return await fn();
+		} finally {
+			this.bulkDepth -= 1;
+		}
+	}
+
+	/** Why the queue is not draining, or null when nothing is queued. Surfaced
+	 *  in the Sync Center so a held queue reads as a reason instead of a
+	 *  spinner. */
+	queuedReason(): QueuedReason | null {
+		return computeQueuedReason({
+			queued: this.queue.size,
+			inFlight: this.pushing.size,
+			offline: this.offline,
+			syncBlocked: this.syncBlocked,
+		});
+	}
+
+	/** Queue a change for retry and go offline.
+	 *
+	 *  Assigns a flush priority when the caller did not: the note the user has
+	 *  open jumps ahead of everything else, so a bulk import cannot make the file
+	 *  being edited wait behind thousands of background entries. */
 	private async enqueueChange(entry: QueueEntry): Promise<void> {
-		await this.queue.enqueue(entry);
+		await this.queue.enqueue({
+			...entry,
+			priority: entry.priority ?? this.priorityForPath(entry.path),
+		});
 		// Enqueuing a retry does NOT by itself mean we're disconnected — a single
 		// file's server-side error (e.g. a storage 502) leaves the backend
 		// perfectly reachable. The offline transition is decided separately via

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -35,6 +35,7 @@ import {
 import { attachmentCapabilityGained, type PlanState } from "./plan-state";
 import { rlog } from "./remote-log";
 import type { SyncLog } from "./sync-log";
+import { SyncedFileTable } from "./synced-file";
 import { DefaultTimeProvider, type TimeProvider } from "./time-provider";
 import type {
 	AttachmentChange,
@@ -308,21 +309,15 @@ export class SyncEngine {
 	private degradedNoticeTimer: number | null = null;
 	private ignorePatterns: string[] = [];
 	private pushing: Set<string> = new Set();
-	private recentlyPushed: Map<string, number> = new Map();
-	/** Paths whose local trash APPLIED a remote change (WS delete, pull
-	 *  tombstone, relocation/orphan cleanup). The vault 'delete' event that
-	 *  trash fires must not push a DELETE back to the server: the server
-	 *  already knows, and the path-keyed CAS-less delete would kill a note
-	 *  recreated at the same path in between (wipe→re-push, delete→recreate).
-	 *  Found by test_86's settle assert: B's echo-push landed after A's
-	 *  replace-remote re-upload and tombstoned the fresh note. */
-	private remotelyDeleted: Map<string, number> = new Map();
-	/** Paths just written to disk by flushFromCrdt (remote CRDT update → disk).
-	 *  Distinct from recentlyPushed (WS echo suppression after a push): only the
-	 *  CRDT disk-write echo must be swallowed by handleModify. Folding this into
-	 *  recentlyPushed would make handleModify drop REAL user edits within the
-	 *  post-push cooldown — silently losing edits and breaking conflict detection. */
-	private recentlyFlushed: Map<string, number> = new Map();
+	/** Per-path echo-suppression markers (#358). Replaces three parallel
+	 *  path-keyed TTL maps — `recentlyPushed`, `remotelyDeleted`,
+	 *  `recentlyFlushed` — with one object per file. See synced-file.ts for the
+	 *  meaning of each marker and why `flushed` must stay distinct from `pushed`.
+	 *  Unlike the maps it replaces, its timers are cancelled on destroy(). */
+	private readonly files = new SyncedFileTable({
+		setTimeout: (cb, ms) => this.time.setTimeout(cb, ms),
+		clearTimeout: (id) => this.time.clearTimeout(id),
+	});
 	/** note_ids THIS device recently deleted. Both CRDT convergence paths
 	 *  (the op-log replay's `applyOp` and `applyPushedNoteUpdate`'s fan-out)
 	 *  refuse to resurrect an id in here for RECENT_DELETE_COOLDOWN_MS. A stale
@@ -2087,7 +2082,7 @@ export class SyncEngine {
 		// be wrongly dropped here and never reach the CRDT path. So only apply the
 		// guard off the CRDT path (legacy writes, attachments).
 		const crdtManaged = !!this.crdt && this.isCrdtEligible(file);
-		if (!crdtManaged && this.recentlyFlushed.has(file.path)) {
+		if (!crdtManaged && this.files.has(file.path, "flushed")) {
 			rlog().info("sync", `Modify echo skip (recently flushed from CRDT): ${file.path}`);
 			return;
 		}
@@ -2194,8 +2189,8 @@ export class SyncEngine {
 		// (replace-remote wipe→re-push, delete→recreate) and tombstones the
 		// FRESH note. Local bookkeeping above still ran; mirror the CRDT
 		// teardown the push path would have done and stop.
-		if (this.remotelyDeleted.has(file.path)) {
-			this.remotelyDeleted.delete(file.path);
+		if (this.files.has(file.path, "remotelyDeleted")) {
+			this.files.clearMarker(file.path, "remotelyDeleted");
 			rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`);
 			if (this.isCrdtEligible(file) && crdtNoteId) {
 				await this.crdt?.removeDoc(crdtNoteId);
@@ -3279,26 +3274,26 @@ export class SyncEngine {
 	 *  handleDelete — every sync-applied deletion must route through here, or
 	 *  its echo-push can tombstone a note recreated at the path since. */
 	private async trashRemotelyDeleted(file: TAbstractFile): Promise<void> {
-		this.markWithTtl(this.remotelyDeleted, file.path, ECHO_COOLDOWN_MS);
+		this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS);
 		await this.app.fileManager.trashFile(file);
 	}
 
 	/** Suppress WebSocket echoes for a path for ECHO_COOLDOWN_MS after push. */
 	private markRecentlyPushed(path: string): void {
-		this.markWithTtl(this.recentlyPushed, path, ECHO_COOLDOWN_MS);
+		this.files.mark(path, "pushed", ECHO_COOLDOWN_MS);
 	}
 
 	/** Check if a path was recently pushed (for echo suppression). */
 	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: read by tests/sync.test.ts via (engine as any)
 	private isRecentlyPushed(path: string): boolean {
-		return this.recentlyPushed.has(path);
+		return this.files.has(path, "pushed");
 	}
 
 	/** Suppress the handleModify echo of a flushFromCrdt disk write for
 	 *  ECHO_COOLDOWN_MS. Separate from recentlyPushed so a post-push cooldown
 	 *  never swallows a genuine local edit. */
 	private markRecentlyFlushed(path: string): void {
-		this.markWithTtl(this.recentlyFlushed, path, ECHO_COOLDOWN_MS);
+		this.files.mark(path, "flushed", ECHO_COOLDOWN_MS);
 	}
 
 	/** Record a note_id THIS device just deleted so neither CRDT convergence
@@ -3328,7 +3323,7 @@ export class SyncEngine {
 		return (
 			!!this.noteIdMap &&
 			!this.noteIdMap.get(path) &&
-			this.recentlyFlushed.has(normalizePath(path))
+			this.files.has(normalizePath(path), "flushed")
 		);
 	}
 
@@ -4483,7 +4478,7 @@ export class SyncEngine {
 				rlog().info("ws", `Echo skip (pushing): ${event.path}`);
 				return;
 			}
-			if (this.recentlyPushed.has(event.path)) {
+			if (this.files.has(event.path, "pushed")) {
 				rlog().info("ws", `Echo skip (recently pushed): ${event.path}`);
 				return;
 			}
@@ -7565,18 +7560,8 @@ export class SyncEngine {
 			this.time.clearTimeout(timer);
 		}
 		this.debounceTimers.clear();
-		for (const timer of this.recentlyPushed.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.recentlyPushed.clear();
-		for (const timer of this.recentlyFlushed.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.recentlyFlushed.clear();
-		for (const timer of this.remotelyDeleted.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.remotelyDeleted.clear();
+		// Was three near-identical clear-every-timer loops, one per marker map.
+		this.files.destroy();
 		for (const timer of this.recentlyDeleted.values()) {
 			this.time.clearTimeout(timer);
 		}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4,6 +4,7 @@
 import { type App, Notice, normalizePath, type TAbstractFile, TFile, TFolder } from "obsidian";
 import { arrayBufferToBase64, base64ToArrayBuffer, type EngramApi } from "./api";
 import type { BaseStore } from "./base-store";
+import { fnv1a } from "./content-hash";
 import type { NoteIdMap } from "./crdt/note-id-map";
 import type { DocKind, ProviderRegistry } from "./crdt/provider-registry";
 import { uuid7 } from "./crdt/uuid7";
@@ -241,15 +242,9 @@ const DEGRADED_NOTICE_DURATION_MS = 10_000;
  *  shouldIgnore() reads `app.vault.configDir` at runtime to handle that. */
 const ALWAYS_IGNORED = [".trash/", ".git/"];
 
-/** Fast string hash (FNV-1a 32-bit). Not cryptographic — just for content change detection. */
-export function fnv1a(s: string): number {
-	let h = 0x811c9dc5;
-	for (let i = 0; i < s.length; i++) {
-		h ^= s.charCodeAt(i);
-		h = Math.imul(h, 0x01000193);
-	}
-	return h >>> 0;
-}
+// Re-exported so existing importers keep working; the implementation moved to
+// content-hash.ts to stop a hash-only consumer pulling this module in.
+export { fnv1a };
 
 /** Binary file extensions that sync as attachments. */
 const BINARY_EXTENSIONS = new Set([

--- a/src/synced-file.ts
+++ b/src/synced-file.ts
@@ -80,7 +80,13 @@ export class SyncedFileTable {
 				file.markers.delete(marker);
 				// Drop the entry once its last marker expires, so a long session does
 				// not accumulate one empty object per path ever touched.
-				if (file.empty) this.files.delete(path);
+				//
+				// Identity-checked, not just `files.delete(path)`. This closure captured
+				// `path` at mark time, but rename() moves the same object to a different
+				// key — so a timer armed before a rename would otherwise delete whatever
+				// entry now sits at the OLD path, which may be a newer, unrelated file.
+				// Silently dropping that entry loses its echo suppression.
+				if (file.empty && this.files.get(path) === file) this.files.delete(path);
 			}, ms),
 		);
 	}

--- a/src/synced-file.ts
+++ b/src/synced-file.ts
@@ -1,0 +1,125 @@
+/**
+ * Per-file sync state, as an object rather than N parallel side tables.
+ *
+ * The shape this replaces (#358): `SyncEngine` carries 104 fields, ~19 of them
+ * `Map`/`Set` containers keyed by path or note_id. Every one is a per-file field
+ * hoisted into a global side table, which means there is no single place to ask
+ * "what is the state of this file", and cleanup has to remember to touch all of
+ * them. Relay models the same domain as objects with lifetimes (`IFile`, 15
+ * lines, implemented by Document / SyncFile / SyncFolder).
+ *
+ * This is the first slice: the TTL marker family (`recentlyPushed`,
+ * `recentlyFlushed`, `remotelyDeleted`). They all routed through one
+ * `markWithTtl` helper plus a `.has()`, so the migration is mechanical and the
+ * behaviour is pinned by tests. The remaining maps move in later passes — see
+ * the follow-up list on #358.
+ *
+ * Teardown collapses too: the three maps each needed their own
+ * clear-every-timer loop in `SyncEngine.destroy()`, and adding a fourth marker
+ * meant remembering to add a fourth loop. `destroy()` here is one call that
+ * cannot be forgotten.
+ *
+ * It also removes an entry once its last marker expires. The maps it replaces
+ * deleted the key from each callback, which was equivalent; keeping that
+ * property explicit matters more now that one entry can hold several markers.
+ *
+ * NOT included here: `recentlyDeleted`, which is keyed by note_id rather than
+ * path. Folding an id-keyed set into a path-keyed file object would be the same
+ * category error this class exists to fix.
+ */
+
+/** Timer functions, injected so TTL expiry is testable without sleeping.
+ *  Matches the subset of `TimeProvider` the engine already passes around. */
+export interface MarkerClock {
+	setTimeout(cb: () => void, ms: number): number;
+	clearTimeout(id: number): void;
+}
+
+/**
+ * Why a path is currently being ignored by an event handler.
+ *
+ * - `pushed` — we just pushed it; suppress the WebSocket echo.
+ * - `flushed` — we just wrote it from a CRDT merge; suppress the resulting
+ *   vault modify/create event. Deliberately distinct from `pushed`: reusing one
+ *   marker for both made `handleModify` drop real user edits inside the window.
+ * - `remotelyDeleted` — deleted by a remote peer; suppress the local delete echo.
+ */
+export type FileMarker = "pushed" | "flushed" | "remotelyDeleted";
+
+/** One file's live sync state. Currently just markers; later passes add the
+ *  debounce timer, in-flight push state, and the per-path heal counters. */
+class SyncedFile {
+	/** Marker → pending expiry timer id. */
+	readonly markers = new Map<FileMarker, number>();
+
+	get empty(): boolean {
+		return this.markers.size === 0;
+	}
+}
+
+export class SyncedFileTable {
+	private readonly files = new Map<string, SyncedFile>();
+
+	constructor(private readonly clock: MarkerClock) {}
+
+	get size(): number {
+		return this.files.size;
+	}
+
+	/** Set `marker` on `path` for `ms`. Re-marking REPLACES the pending timer
+	 *  rather than stacking a second one — two live timers for one marker means
+	 *  the first expiry closes a window the second call had just extended. */
+	mark(path: string, marker: FileMarker, ms: number): void {
+		const file = this.files.get(path) ?? new SyncedFile();
+		this.files.set(path, file);
+		const existing = file.markers.get(marker);
+		if (existing !== undefined) this.clock.clearTimeout(existing);
+		file.markers.set(
+			marker,
+			this.clock.setTimeout(() => {
+				file.markers.delete(marker);
+				// Drop the entry once its last marker expires, so a long session does
+				// not accumulate one empty object per path ever touched.
+				if (file.empty) this.files.delete(path);
+			}, ms),
+		);
+	}
+
+	has(path: string, marker: FileMarker): boolean {
+		return this.files.get(path)?.markers.has(marker) ?? false;
+	}
+
+	/** Drop `marker` now and cancel its pending expiry. */
+	clearMarker(path: string, marker: FileMarker): void {
+		const file = this.files.get(path);
+		const timer = file?.markers.get(marker);
+		if (!file || timer === undefined) return;
+		this.clock.clearTimeout(timer);
+		file.markers.delete(marker);
+		if (file.empty) this.files.delete(path);
+	}
+
+	/** Move a path's state. Any state already at `newPath` is discarded, with its
+	 *  timers cancelled — orphaning them would fire callbacks against an entry
+	 *  no longer in the table. */
+	rename(oldPath: string, newPath: string): void {
+		const file = this.files.get(oldPath);
+		if (!file) return;
+		this.forget(newPath);
+		this.files.delete(oldPath);
+		this.files.set(newPath, file);
+	}
+
+	/** Drop a path entirely, cancelling its timers. */
+	forget(path: string): void {
+		const file = this.files.get(path);
+		if (!file) return;
+		for (const timer of file.markers.values()) this.clock.clearTimeout(timer);
+		this.files.delete(path);
+	}
+
+	/** Cancel every outstanding timer. Call on teardown. */
+	destroy(): void {
+		for (const path of [...this.files.keys()]) this.forget(path);
+	}
+}

--- a/src/tabs/advanced-tab.ts
+++ b/src/tabs/advanced-tab.ts
@@ -1,4 +1,5 @@
 import { Notice, Setting, TFolder } from "obsidian";
+import { visibleFlags } from "../feature-flags";
 import type { EngramSyncSettings } from "../types";
 import type { TabContext } from "./types";
 
@@ -99,6 +100,8 @@ export function renderAdvancedTab(ctx: TabContext): void {
 				}),
 		);
 
+	renderFeatureFlags(ctx);
+
 	// ── About ──
 	new Setting(containerEl).setName("About").setHeading();
 
@@ -117,6 +120,43 @@ export function renderAdvancedTab(ctx: TabContext): void {
 
 	const licenseItem = aboutList.createEl("li");
 	licenseItem.createSpan({ text: "License: MIT" });
+}
+
+/**
+ * Feature-flag toggles, grouped by the schema's category.
+ *
+ * `labs` flags are always visible. `debugging` and `danger` appear only once
+ * diagnostics are on — a user who has not opted into diagnostics has no reason
+ * to see instrumentation switches, and every way of finding a danger flag
+ * should pass through a deliberate step first.
+ */
+function renderFeatureFlags(ctx: TabContext): void {
+	const { containerEl, plugin } = ctx;
+	const visible = visibleFlags(plugin.settings.diagnosticsEnabled);
+	if (visible.length === 0) return;
+
+	new Setting(containerEl).setName("Feature flags").setHeading();
+
+	for (const [key, schema] of visible) {
+		const setting = new Setting(containerEl)
+			.setName(schema.title)
+			.setDesc(schema.description)
+			.addToggle((toggle) =>
+				toggle.setValue(plugin.flags[key]).onChange(async (value) => {
+					// Store sparsely: only what the user actually touched, so a later
+					// change to a flag's DEFAULT still reaches installs that never
+					// toggled it.
+					plugin.settings.featureFlags = {
+						...plugin.settings.featureFlags,
+						[key]: value,
+					};
+					await plugin.saveSettings();
+				}),
+			);
+		if (schema.category === "danger") {
+			setting.settingEl.addClass("engram-status-warning");
+		}
+	}
 }
 
 /** Scan vault for problematic directories and render warnings with add-to-ignore buttons. */

--- a/src/track-promise.ts
+++ b/src/track-promise.ts
@@ -1,0 +1,135 @@
+/**
+ * Labelled registry of in-flight promises, plus a bounded ring of recent
+ * completions.
+ *
+ * Ported from Relay (`src/trackPromise.ts`). It answers one question we
+ * currently cannot answer at all: *what async work is still outstanding right
+ * now?* A wedged sync shows up as a pending entry with a large `ageMs`, which
+ * is a far shorter path than reading the logs backwards trying to infer which
+ * await never returned.
+ *
+ * ponytail: gated on the existing `DEV_MODE` esbuild define rather than a new
+ * `BUILD_TYPE` one. `trackPromise` compiles to an identity function in
+ * production, so instrumenting a hot path costs nothing shipped.
+ */
+
+declare const DEV_MODE: boolean;
+
+interface TrackedEntry {
+	label: string;
+	created: number;
+}
+
+export interface PendingEntry {
+	label: string;
+	ageMs: number;
+}
+
+export interface CompletedEntry {
+	label: string;
+	created: number;
+	settledAt: number;
+	state: "fulfilled" | "rejected";
+}
+
+export interface PromiseTrackerOpts {
+	/** Ring capacity for completions. */
+	capacity?: number;
+	/** Injected clock, so age assertions don't depend on wall time. */
+	now?: () => number;
+}
+
+const DEFAULT_CAPACITY = 500;
+
+export class PromiseTracker {
+	private readonly tracked = new Map<number, TrackedEntry>();
+	private readonly completed: CompletedEntry[] = [];
+	private readonly capacity: number;
+	private readonly now: () => number;
+	private nextId = 0;
+	private destroyed = false;
+
+	constructor(opts: PromiseTrackerOpts = {}) {
+		this.capacity = opts.capacity ?? DEFAULT_CAPACITY;
+		this.now = opts.now ?? (() => Date.now());
+	}
+
+	/**
+	 * Register `p` under `label` and hand it straight back.
+	 *
+	 * The returned promise is the SAME promise, not a wrapper — the caller keeps
+	 * ownership of the rejection. The internal `.then` attaches its own handlers
+	 * so a tracked rejection is observed here (no spurious unhandled-rejection
+	 * warning from the tracking itself) while still rejecting for the caller.
+	 */
+	track<T>(label: string, p: Promise<T>): Promise<T> {
+		if (this.destroyed) return p;
+		const id = this.nextId++;
+		const entry: TrackedEntry = { label, created: this.now() };
+		this.tracked.set(id, entry);
+		p.then(
+			() => this.settle(id, entry, "fulfilled"),
+			() => this.settle(id, entry, "rejected"),
+		);
+		return p;
+	}
+
+	private settle(id: number, entry: TrackedEntry, state: "fulfilled" | "rejected"): void {
+		// `destroyed` is checked here as well as in track(): a promise registered
+		// before teardown can settle after it, and repopulating the ring at that
+		// point would resurrect state the caller asked us to drop.
+		if (this.destroyed || !this.tracked.delete(id)) return;
+		this.completed.push({
+			label: entry.label,
+			created: entry.created,
+			settledAt: this.now(),
+			state,
+		});
+		if (this.completed.length > this.capacity) {
+			this.completed.splice(0, this.completed.length - this.capacity);
+		}
+	}
+
+	/** Work still outstanding, oldest first by insertion. */
+	pending(): PendingEntry[] {
+		const now = this.now();
+		return [...this.tracked.values()].map((e) => ({
+			label: e.label,
+			ageMs: now - e.created,
+		}));
+	}
+
+	recent(): CompletedEntry[] {
+		return [...this.completed];
+	}
+
+	destroy(): void {
+		this.destroyed = true;
+		this.tracked.clear();
+		this.completed.length = 0;
+	}
+}
+
+let active: PromiseTracker | null = null;
+
+/** Install the tracker the free-function helper routes to. Called from main.ts
+ *  in dev builds; left null in production, where `trackPromise` is identity. */
+export function setActiveTracker(tracker: PromiseTracker | null): void {
+	active = tracker;
+}
+
+export function activeTracker(): PromiseTracker | null {
+	return active;
+}
+
+/**
+ * Track `p` if a tracker is installed, otherwise return it unchanged.
+ *
+ * The `DEV_MODE` guard is what makes this free to sprinkle on hot paths: in a
+ * production bundle the whole body folds to `return p` and the tracker module
+ * is tree-shaken out.
+ */
+export function trackPromise<T>(label: string, p: Promise<T>): Promise<T> {
+	if (!DEV_MODE) return p;
+	return active ? active.track(label, p) : p;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { FeatureFlags } from "./feature-flags";
 import type { PlanState } from "./plan-state";
 
 /** Plugin settings stored in data.json */
@@ -57,6 +58,12 @@ export interface EngramSyncSettings {
 	/** True once the first-run waitlist popup has been shown (submitted OR
 	 *  dismissed). Set once, never re-shown. */
 	waitlistPromptSeen?: boolean;
+	/** Feature-flag overrides. Sparse on purpose: only flags the user has
+	 *  actually toggled are stored, so a change to a flag's DEFAULT reaches
+	 *  every install that never touched it. Read through `resolveFlags` — never
+	 *  index this directly, or a retired key in an old data.json leaks through.
+	 *  See `feature-flags.ts`. */
+	featureFlags?: Partial<FeatureFlags>;
 }
 
 /** Which search backend the panel uses. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -279,6 +279,11 @@ export interface QueueEntry {
 	 *  is parked after RETRY_CAP attempts instead of retrying forever across
 	 *  reloads. Absent = never failed. */
 	attempts?: number;
+	/** Flush order (see `QueuePriority` in offline-queue.ts). Lower runs sooner.
+	 *  Absent = Normal, which is what every entry persisted before this field
+	 *  existed reads as — so an upgrade never demotes pending work below a bulk
+	 *  import. */
+	priority?: number;
 }
 
 /** Request body for POST /search */

--- a/styles.css
+++ b/styles.css
@@ -967,6 +967,17 @@ body.is-mobile .engram-support-buttons > a {
 	font-weight: 600;
 }
 
+/* Queue-held badge — states WHY work is waiting. Muted: a held queue is
+   information, not a fault. */
+.engram-sync-center-queued-badge {
+	background: var(--background-modifier-border);
+	color: var(--text-muted);
+	border-radius: 10px;
+	padding: 2px 8px;
+	font-size: 11px;
+	font-weight: 600;
+}
+
 /* "Not synced on your plan" badge — calm/info, never error-red. */
 .engram-sync-center-plan-badge {
 	background: var(--background-modifier-form-field);

--- a/tests/crdt/lca-apply-local-edit.test.ts
+++ b/tests/crdt/lca-apply-local-edit.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import "fake-indexeddb/auto";
+import { ProviderRegistry } from "../../src/crdt/provider-registry";
+
+const settle = () => new Promise<void>((r) => setTimeout(r, 20));
+
+interface Opts {
+	lca: string | null;
+	enabled?: boolean;
+	dbPrefix: string;
+}
+
+function registryWith({ lca, enabled = true, dbPrefix }: Opts) {
+	const dirty: string[] = [];
+	const registry = new ProviderRegistry({
+		dbPrefix,
+		send: () => true,
+		onFlushToDisk: () => true,
+		lcaFor: () => lca,
+		lcaMergeEnabled: () => enabled,
+		onDirtyMerge: (id) => dirty.push(id),
+	});
+	return { registry, dirty };
+}
+
+describe("applyLocalEdit with an LCA", () => {
+	test("keeps a remote edit that the disk snapshot predates", async () => {
+		// The regression the whole change exists for. The doc has remote content
+		// the disk read never saw; applying the disk delta relative to the base
+		// must not delete it.
+		const { registry } = registryWith({ lca: "line one\n", dbPrefix: "lca1" });
+		await registry.applyLocalEdit("n1", "line one\nremote\n");
+		await settle();
+
+		await registry.applyLocalEdit("n1", "line one\nlocal\n");
+		const text = await registry.projectedText("n1");
+
+		expect(text).toContain("remote");
+		expect(text).toContain("local");
+		await registry.destroyAll();
+	});
+
+	test("applies a plain disk edit when the doc has not moved", async () => {
+		const { registry } = registryWith({ lca: "base\n", dbPrefix: "lca2" });
+		await registry.applyLocalEdit("n2", "base\n");
+		await settle();
+
+		await registry.applyLocalEdit("n2", "base\nappended\n");
+
+		expect(await registry.projectedText("n2")).toContain("appended");
+		await registry.destroyAll();
+	});
+
+	test("falls back to the pre-LCA path when the flag is off", async () => {
+		const { registry } = registryWith({
+			lca: "line one\n",
+			enabled: false,
+			dbPrefix: "lca3",
+		});
+		await registry.applyLocalEdit("n3", "line one\nremote\n");
+		await settle();
+
+		// Flag off: the two-way diff forces the doc to equal the disk snapshot, so
+		// the remote line is lost. Pinned deliberately — this is the behaviour the
+		// flag exists to replace, and it must stay reachable while the flag is off.
+		await registry.applyLocalEdit("n3", "line one\nlocal\n");
+
+		expect(await registry.projectedText("n3")).not.toContain("remote");
+		await registry.destroyAll();
+	});
+
+	test("falls back when no base has been recorded yet", async () => {
+		const { registry } = registryWith({ lca: null, dbPrefix: "lca4" });
+
+		await registry.applyLocalEdit("n4", "fresh note\n");
+
+		expect(await registry.projectedText("n4")).toContain("fresh note");
+		await registry.destroyAll();
+	});
+
+	test("reports a dirty merge instead of writing mangled content", async () => {
+		const { registry, dirty } = registryWith({
+			lca: "the quick brown fox jumps over the lazy dog",
+			dbPrefix: "lca5",
+		});
+		await registry.applyLocalEdit("n5", "totally unrelated replacement text here");
+		await settle();
+
+		await registry.applyLocalEdit("n5", "the SLOW brown fox jumps over the lazy dog");
+
+		expect(dirty).toContain("n5");
+		await registry.destroyAll();
+	});
+
+	test("an unchanged disk read is a no-op rather than a revert", async () => {
+		const { registry } = registryWith({ lca: "base\n", dbPrefix: "lca6" });
+		await registry.applyLocalEdit("n6", "base\nremote arrived\n");
+		await settle();
+
+		// Disk still says exactly the base. There is no local delta, so the doc
+		// must keep the remote content rather than being dragged back.
+		await registry.applyLocalEdit("n6", "base\n");
+
+		expect(await registry.projectedText("n6")).toContain("remote arrived");
+		await registry.destroyAll();
+	});
+});

--- a/tests/crdt/lca-apply-local-edit.test.ts
+++ b/tests/crdt/lca-apply-local-edit.test.ts
@@ -78,6 +78,28 @@ describe("applyLocalEdit with an LCA", () => {
 		await registry.destroyAll();
 	});
 
+	test("a history-less doc whose disk equals the base returns the DISK content, not an empty projection", async () => {
+		// The caller records fnv1a(returned) as the last-synced baseline hash
+		// (sync.ts applyCrdtCreateAck). A fresh doc projects to "", so returning
+		// the projection here would record the hash of "" as the baseline for a
+		// note that actually has content — which makes isUnchangedSynced false
+		// forever after and re-opens the #846 doubling path. The adopt-first gate
+		// owns this case and must not be bypassed by the LCA branch.
+		const registry = new ProviderRegistry({
+			dbPrefix: "lca7",
+			send: () => true,
+			onFlushToDisk: () => true,
+			lcaFor: () => "same content\n",
+			lcaMergeEnabled: () => true,
+			isUnchangedSynced: () => true,
+		});
+
+		const consumed = await registry.applyLocalEdit("n7", "same content\n");
+
+		expect(consumed).toBe("same content\n");
+		await registry.destroyAll();
+	});
+
 	test("reports a dirty merge instead of writing mangled content", async () => {
 		const { registry, dirty } = registryWith({
 			lca: "the quick brown fox jumps over the lazy dog",

--- a/tests/crdt/lca-merge.test.ts
+++ b/tests/crdt/lca-merge.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { mergeDiskOntoDoc } from "../../src/crdt/lca-merge";
+
+describe("mergeDiskOntoDoc", () => {
+	test("applies a disk-side edit that the doc has not seen", () => {
+		const r = mergeDiskOntoDoc("hello", "hello world", "hello");
+
+		expect(r.text).toBe("hello world");
+		expect(r.clean).toBe(true);
+	});
+
+	test("PRESERVES a remote edit the disk snapshot predates", () => {
+		// The whole point. Two-way diff(current -> disk) would delete " remote"
+		// because the disk snapshot was read before the remote merge landed. This
+		// is the stale-snapshot revert class (e2e test_83), and the reason
+		// applyLocalEdit needs a 3-attempt retry loop without an LCA.
+		const lca = "line one\n";
+		const disk = "line one\nlocal\n";
+		const current = "line one\nremote\n";
+
+		const r = mergeDiskOntoDoc(lca, disk, current);
+
+		expect(r.text).toContain("remote");
+		expect(r.text).toContain("local");
+	});
+
+	test("is a no-op when disk matches the base", () => {
+		const r = mergeDiskOntoDoc("same", "same", "doc has moved on");
+
+		// No disk-side delta means nothing to apply — the doc keeps its own state
+		// rather than being dragged back to a stale snapshot.
+		expect(r.text).toBe("doc has moved on");
+		expect(r.clean).toBe(true);
+	});
+
+	test("returns the disk content unchanged when doc equals base", () => {
+		const r = mergeDiskOntoDoc("base", "edited on disk", "base");
+
+		expect(r.text).toBe("edited on disk");
+	});
+
+	test("applies a pure deletion made on disk", () => {
+		const r = mergeDiskOntoDoc("a\nb\nc\n", "a\nc\n", "a\nb\nc\n");
+
+		expect(r.text).toBe("a\nc\n");
+		expect(r.clean).toBe(true);
+	});
+
+	test("keeps a remote insertion while applying a disk deletion elsewhere", () => {
+		const lca = "one\ntwo\nthree\n";
+		const disk = "one\nthree\n"; // deleted "two"
+		const current = "one\ntwo\nthree\nfour\n"; // remote appended "four"
+
+		const r = mergeDiskOntoDoc(lca, disk, current);
+
+		expect(r.text).toContain("four");
+		expect(r.text).not.toContain("two");
+	});
+
+	test("reports clean=false when a hunk could not be applied", () => {
+		// Overlapping edits to the same region. The merge still returns usable
+		// text, but the caller needs to know it was not a clean apply so it can
+		// fall back rather than silently shipping a mangled note.
+		const lca = "the quick brown fox jumps over the lazy dog";
+		const disk = "the SLOW brown fox jumps over the lazy dog";
+		const current = "totally different content with no relation whatsoever";
+
+		const r = mergeDiskOntoDoc(lca, disk, current);
+
+		expect(r.clean).toBe(false);
+	});
+
+	test("handles an empty base without throwing", () => {
+		const r = mergeDiskOntoDoc("", "new content", "");
+
+		expect(r.text).toBe("new content");
+	});
+
+	test("handles emptying a file on disk", () => {
+		const r = mergeDiskOntoDoc("content", "", "content");
+
+		expect(r.text).toBe("");
+	});
+
+	test("is stable when all three inputs are identical", () => {
+		const r = mergeDiskOntoDoc("x", "x", "x");
+
+		expect(r.text).toBe("x");
+		expect(r.clean).toBe(true);
+	});
+});

--- a/tests/debug-snapshot.test.ts
+++ b/tests/debug-snapshot.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, test } from "bun:test";
+import { buildNoteSnapshot, buildVaultSnapshot, type SnapshotDeps } from "../src/debug-snapshot";
+
+const DOC_TEXT = "# Title\n\nbody\n";
+
+function deps(over: Partial<SnapshotDeps> = {}): SnapshotDeps {
+	return {
+		idForPath: () => "note-1",
+		pathForId: () => "notes/a.md",
+		registry: {
+			hasDoc: () => true,
+			projectedText: async () => DOC_TEXT,
+			hasHistory: async () => true,
+			encodeStateVector: async () => new Uint8Array([1, 2, 3]),
+			isSynced: () => true,
+			hasPendingGap: async () => false,
+			hasUndeliveredOps: () => false,
+			enrolled: new Set(["note-1"]),
+			removedIds: new Set<string>(),
+			residentIds: () => ["note-1"],
+		},
+		readDisk: async () => ({ length: DOC_TEXT.length, mtime: 1000, content: DOC_TEXT }),
+		syncStateFor: () => ({ hash: 42, crdtHead: "head-abc", serverHash: "sh", seq: 9 }),
+		isLiveBound: () => false,
+		pendingPromises: () => [],
+		...over,
+	};
+}
+
+describe("buildNoteSnapshot", () => {
+	test("resolves a path to its note_id and reports both directions", async () => {
+		const snap = await buildNoteSnapshot("notes/a.md", deps());
+
+		expect(snap.path).toBe("notes/a.md");
+		expect(snap.noteId).toBe("note-1");
+		expect(snap.idmap.bijective).toBe(true);
+	});
+
+	test("accepts a note_id as the lookup key too", async () => {
+		const snap = await buildNoteSnapshot("note-1", deps({ idForPath: () => null }));
+
+		expect(snap.path).toBe("notes/a.md");
+		expect(snap.noteId).toBe("note-1");
+	});
+
+	test("flags a broken id map instead of silently reporting one direction", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({ pathForId: () => "notes/OTHER.md" }),
+		);
+
+		expect(snap.idmap.bijective).toBe(false);
+		expect(snap.idmap.pathForId).toBe("notes/OTHER.md");
+	});
+
+	test("a half-mapped id (forward only, no reverse) is NOT bijective", async () => {
+		// path->id resolves but id->path does not. Nothing contradicts the forward
+		// direction, so a naive check reads this as healthy — it is the exact
+		// half-populated state that strands a flush with nowhere to write.
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({ idForPath: () => "note-1", pathForId: () => null }),
+		);
+
+		expect(snap.idmap.bijective).toBe(false);
+	});
+
+	test("an unmapped path is vacuously bijective — there is nothing to disagree about", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/ghost.md",
+			deps({ idForPath: () => null, pathForId: () => null }),
+		);
+
+		expect(snap.idmap.bijective).toBe(true);
+	});
+
+	test("reports doc and disk as converged when their content matches", async () => {
+		const snap = await buildNoteSnapshot("notes/a.md", deps());
+
+		expect(snap.docMatchesDisk).toBe(true);
+		expect(snap.doc?.length).toBe(DOC_TEXT.length);
+		expect(snap.disk?.length).toBe(DOC_TEXT.length);
+	});
+
+	test("reports divergence when doc and disk differ — the question every incident starts with", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({ readDisk: async () => ({ length: 3, mtime: 1, content: "old" }) }),
+		);
+
+		expect(snap.docMatchesDisk).toBe(false);
+	});
+
+	test("omits content by default and includes it only on request", async () => {
+		const withoutContent = await buildNoteSnapshot("notes/a.md", deps());
+		const withContent = await buildNoteSnapshot("notes/a.md", deps(), { includeContent: true });
+
+		// Note bodies are private. A snapshot pasted into a support ticket must
+		// not carry them unless the user deliberately asked.
+		expect(withoutContent.doc?.content).toBeUndefined();
+		expect(withoutContent.disk?.content).toBeUndefined();
+		expect(withContent.doc?.content).toBe(DOC_TEXT);
+		expect(withContent.disk?.content).toBe(DOC_TEXT);
+	});
+
+	test("hashes content even when it is withheld, so two sides stay comparable", async () => {
+		const snap = await buildNoteSnapshot("notes/a.md", deps());
+
+		expect(snap.doc?.hash).toBeDefined();
+		expect(snap.doc?.hash).toBe(snap.disk?.hash as string);
+	});
+
+	test("reports room state", async () => {
+		const snap = await buildNoteSnapshot("notes/a.md", deps());
+
+		expect(snap.room).toMatchObject({
+			resident: true,
+			enrolled: true,
+			synced: true,
+			pendingGap: false,
+			undelivered: false,
+			removed: false,
+			liveBound: false,
+		});
+	});
+
+	test("surfaces a tombstoned note as removed rather than just absent", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({
+				registry: {
+					...deps().registry,
+					hasDoc: () => false,
+					removedIds: new Set(["note-1"]),
+				},
+			}),
+		);
+
+		expect(snap.room.removed).toBe(true);
+		expect(snap.room.resident).toBe(false);
+		expect(snap.doc).toBeNull();
+	});
+
+	test("reports the server view from sync state", async () => {
+		const snap = await buildNoteSnapshot("notes/a.md", deps());
+
+		expect(snap.server).toMatchObject({ crdtHead: "head-abc", serverHash: "sh", seq: 9 });
+		expect(snap.hasServerNote).toBe(true);
+	});
+
+	test("hasServerNote is false when no crdtHead has ever been recorded", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({ syncStateFor: () => ({ hash: 1 }) }),
+		);
+
+		expect(snap.hasServerNote).toBe(false);
+	});
+
+	test("returns a usable snapshot for a path with no mapping at all", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/ghost.md",
+			deps({ idForPath: () => null, pathForId: () => null }),
+		);
+
+		expect(snap.noteId).toBeNull();
+		expect(snap.doc).toBeNull();
+		expect(snap.room.resident).toBe(false);
+	});
+
+	test("a doc-layer failure degrades that section instead of failing the snapshot", async () => {
+		// A snapshot is a debugging tool. If it throws on the exact broken state
+		// it exists to describe, it is useless precisely when it is needed.
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({
+				registry: {
+					...deps().registry,
+					projectedText: async () => {
+						throw new Error("doc destroyed");
+					},
+				},
+			}),
+		);
+
+		expect(snap.doc).toBeNull();
+		expect(snap.errors).toContain("doc: doc destroyed");
+	});
+
+	test("a disk read failure degrades that section too", async () => {
+		const snap = await buildNoteSnapshot(
+			"notes/a.md",
+			deps({
+				readDisk: async () => {
+					throw new Error("EACCES");
+				},
+			}),
+		);
+
+		expect(snap.disk).toBeNull();
+		expect(snap.errors).toContain("disk: EACCES");
+		expect(snap.docMatchesDisk).toBeNull();
+	});
+});
+
+describe("buildVaultSnapshot", () => {
+	test("summarises room counts and outstanding async work", async () => {
+		const snap = buildVaultSnapshot(
+			deps({
+				pendingPromises: () => [{ label: "pull:notes/a.md", ageMs: 61_000 }],
+			}),
+		);
+
+		expect(snap.rooms).toEqual({ resident: 1, enrolled: 1, removed: 0 });
+		expect(snap.pending).toEqual([{ label: "pull:notes/a.md", ageMs: 61_000 }]);
+	});
+
+	test("orders pending work oldest first — the wedged one is what you want on top", () => {
+		const snap = buildVaultSnapshot(
+			deps({
+				pendingPromises: () => [
+					{ label: "young", ageMs: 10 },
+					{ label: "wedged", ageMs: 90_000 },
+					{ label: "middle", ageMs: 500 },
+				],
+			}),
+		);
+
+		expect(snap.pending.map((p) => p.label)).toEqual(["wedged", "middle", "young"]);
+	});
+});

--- a/tests/feature-flags.test.ts
+++ b/tests/feature-flags.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type FeatureFlags,
+	FLAG_SCHEMA,
+	flagsForCategory,
+	resolveFlags,
+	visibleFlags,
+} from "../src/feature-flags";
+
+describe("resolveFlags", () => {
+	test("applies schema defaults when settings carry no overrides", () => {
+		const flags = resolveFlags(undefined);
+
+		for (const key of Object.keys(FLAG_SCHEMA) as (keyof FeatureFlags)[]) {
+			expect(flags[key]).toBe(FLAG_SCHEMA[key].default);
+		}
+	});
+
+	test("a stored override wins over the default", () => {
+		const flags = resolveFlags({ crdtRecording: true });
+
+		expect(flags.crdtRecording).toBe(true);
+	});
+
+	test("ignores unknown keys — a removed flag left in data.json must not leak through", () => {
+		const flags = resolveFlags({ someRetiredFlag: true } as Partial<FeatureFlags>);
+
+		expect("someRetiredFlag" in flags).toBe(false);
+	});
+
+	test("ignores a non-boolean stored value rather than trusting it", () => {
+		// data.json is user-editable; a hand-edited "true" must not turn a danger
+		// flag on by truthiness.
+		const flags = resolveFlags({ crdtRecording: "true" } as unknown as Partial<FeatureFlags>);
+
+		expect(flags.crdtRecording).toBe(FLAG_SCHEMA.crdtRecording.default);
+	});
+});
+
+describe("FLAG_SCHEMA", () => {
+	test("every flag declares a category, title and description", () => {
+		for (const [key, entry] of Object.entries(FLAG_SCHEMA)) {
+			expect(entry.category, `${key} category`).toBeOneOf(["labs", "debugging", "danger"]);
+			expect(entry.title.length, `${key} title`).toBeGreaterThan(0);
+			expect(entry.description.length, `${key} description`).toBeGreaterThan(0);
+		}
+	});
+
+	test("no flag ships defaulted-on in the danger category", () => {
+		// A danger flag changes persistence or sync semantics. Shipping one on by
+		// default makes it an un-reviewed migration, not a flag.
+		for (const [key, entry] of Object.entries(FLAG_SCHEMA)) {
+			if (entry.category === "danger") {
+				expect(entry.default, `${key} must default off`).toBe(false);
+			}
+		}
+	});
+});
+
+describe("visibleFlags", () => {
+	test("hides debugging and danger flags while diagnostics are off", () => {
+		const visible = visibleFlags(false).map(([key]) => key);
+
+		for (const key of visible) {
+			expect(FLAG_SCHEMA[key].category).toBe("labs");
+		}
+	});
+
+	test("shows every flag once diagnostics are on", () => {
+		expect(visibleFlags(true)).toHaveLength(Object.keys(FLAG_SCHEMA).length);
+	});
+});
+
+describe("flagsForCategory", () => {
+	test("groups by category and keeps schema order stable", () => {
+		const danger = flagsForCategory("danger").map(([key]) => key);
+		const all = Object.keys(FLAG_SCHEMA) as (keyof FeatureFlags)[];
+
+		expect(danger).toEqual(all.filter((k) => FLAG_SCHEMA[k].category === "danger"));
+	});
+});

--- a/tests/has-logging.test.ts
+++ b/tests/has-logging.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { HasLogging, setLogSink } from "../src/has-logging";
+
+interface Line {
+	level: string;
+	category: string;
+	message: string;
+}
+
+/** Install a capturing sink for the duration of `fn`, then restore. */
+function capture(fn: (lines: Line[]) => void): void {
+	const lines: Line[] = [];
+	setLogSink((level, category, message) => lines.push({ level, category, message }));
+	try {
+		fn(lines);
+	} finally {
+		setLogSink(null);
+	}
+}
+
+/** The loggers are `protected` — they exist for subclasses, not callers. This
+ *  stand-in re-exposes them so the tests can drive them the way real code does. */
+class Widget extends HasLogging {
+	debug = (...args: unknown[]) => super.debug(...args);
+	log = (...args: unknown[]) => super.log(...args);
+	warn = (...args: unknown[]) => super.warn(...args);
+	error = (...args: unknown[]) => super.error(...args);
+	retag = (context: string) => super.setLoggers(context);
+}
+
+describe("HasLogging", () => {
+	test("tags lines with the subclass name by default", () => {
+		capture((lines) => {
+			new Widget().log("hello");
+
+			expect(lines).toEqual([{ level: "info", category: "Widget", message: "hello" }]);
+		});
+	});
+
+	test("an explicit context overrides the class name", () => {
+		capture((lines) => {
+			new Widget("sync-engine").warn("careful");
+
+			expect(lines[0]).toEqual({
+				level: "warn",
+				category: "sync-engine",
+				message: "careful",
+			});
+		});
+	});
+
+	test("setLoggers retags subsequent lines — a renamed object relabels itself", () => {
+		capture((lines) => {
+			const w = new Widget("notes/a.md");
+			w.log("before");
+			w.retag("notes/b.md");
+			w.log("after");
+
+			expect(lines.map((l) => l.category)).toEqual(["notes/a.md", "notes/b.md"]);
+		});
+	});
+
+	test("routes each level to the sink under its own name", () => {
+		capture((lines) => {
+			const w = new Widget("w");
+			w.debug("d");
+			w.log("l");
+			w.warn("wa");
+			w.error("e");
+
+			expect(lines.map((l) => l.level)).toEqual(["debug", "info", "warn", "error"]);
+		});
+	});
+
+	test("joins extra arguments into the message", () => {
+		capture((lines) => {
+			new Widget("w").log("applied", 3, "ops");
+
+			expect(lines[0].message).toBe("applied 3 ops");
+		});
+	});
+
+	test("serializes an object argument instead of emitting [object Object]", () => {
+		capture((lines) => {
+			new Widget("w").log("state", { seq: 7 });
+
+			expect(lines[0].message).toBe('state {"seq":7}');
+		});
+	});
+
+	test("survives an unserializable argument rather than throwing at a log site", () => {
+		capture((lines) => {
+			const cyclic: Record<string, unknown> = {};
+			cyclic.self = cyclic;
+
+			expect(() => new Widget("w").log("cyclic", cyclic)).not.toThrow();
+			// Names what was dropped. `[object Object]` would tell the reader nothing.
+			expect(lines[0].message).toBe("cyclic [unserializable Object]");
+		});
+	});
+
+	test("is a no-op with no sink installed — logging must never throw", () => {
+		expect(() => new Widget("w").error("boom")).not.toThrow();
+	});
+});

--- a/tests/helpers/replay.ts
+++ b/tests/helpers/replay.ts
@@ -1,0 +1,187 @@
+/**
+ * Replay a recorded sync timeline into a fresh ProviderRegistry and report where
+ * behaviour diverged.
+ *
+ * Lives in `tests/`, not `src/`: capture has to run inside a user's session, but
+ * replay is purely a harness concern and has no business in the shipped bundle.
+ * (Relay puts both in `src/merge-hsm/recording/`; we do not need to.)
+ *
+ * The workflow this exists for:
+ *   1. an e2e run fails, and its recorder timeline is uploaded as a CI artifact
+ *   2. `replayTimeline(JSON.parse(artifact))` reproduces it deterministically
+ *   3. fix the bug, keep the timeline as a regression fixture
+ *
+ * Only wire-driven events are replayable. A `send` is an OUTPUT of the system
+ * under test, so replay asserts against it rather than performing it — that
+ * comparison is the actual test.
+ */
+
+import { ProviderRegistry } from "../../src/crdt/provider-registry";
+import { fromB64 } from "../../src/crdt/wire";
+import type { SyncEvent } from "../../src/sync-recorder";
+
+export interface ReplayDivergence {
+	seq: number;
+	noteId: string | null;
+	/** What the recording said happened. */
+	expected: string;
+	/** What this replay produced. */
+	actual: string;
+}
+
+export interface ReplayResult {
+	divergences: ReplayDivergence[];
+	/** Final projected text per note, for a caller that wants to assert content. */
+	finalText: Record<string, string>;
+	/** Events the harness could not act on, by kind. */
+	skipped: Record<string, number>;
+}
+
+export interface ReplayOpts {
+	/** IndexedDB namespace. Give each replay its own so runs cannot bleed. */
+	dbPrefix?: string;
+	/** Stop at the first divergence rather than collecting all of them. */
+	stopOnDivergence?: boolean;
+	/** Disk content a `localEdit` should feed in, keyed by the recorded hash.
+	 *  Timelines carry hashes rather than note bodies, so a caller replaying a
+	 *  content-sensitive scenario has to supply the text. Unknown hashes make the
+	 *  localEdit a skip instead of a silent empty write. */
+	contentByHash?: Record<string, string>;
+}
+
+const settle = () => new Promise<void>((r) => setTimeout(r, 15));
+
+export async function replayTimeline(
+	events: SyncEvent[],
+	opts: ReplayOpts = {},
+): Promise<ReplayResult> {
+	const divergences: ReplayDivergence[] = [];
+	const skipped: Record<string, number> = {};
+	const sends: { noteId: string; kind: string }[] = [];
+	const flushed: Record<string, string> = {};
+
+	const registry = new ProviderRegistry({
+		dbPrefix: opts.dbPrefix ?? "replay",
+		// Capture rather than transmit: outbound frames are the output being
+		// checked, and there is no peer in a replay.
+		send: (noteId, _frame, kind) => {
+			sends.push({ noteId, kind });
+			return true;
+		},
+		onFlushToDisk: (noteId, content) => {
+			flushed[noteId] = content;
+		},
+	});
+
+	const skip = (kind: string) => {
+		skipped[kind] = (skipped[kind] ?? 0) + 1;
+	};
+
+	try {
+		for (const event of events) {
+			const { noteId } = event;
+			switch (event.kind) {
+				case "receive":
+					if (noteId && typeof event.data.frame === "string") {
+						await registry.receive(noteId, event.data.frame);
+					} else skip(event.kind);
+					break;
+
+				case "remoteUpdate":
+					// Raw bytes are not in the timeline (only a length), so this is
+					// replayable only when a caller supplied the frame.
+					if (noteId && typeof event.data.frame === "string") {
+						await registry.applyRemoteUpdate(noteId, fromB64(event.data.frame));
+					} else skip(event.kind);
+					break;
+
+				case "localEdit": {
+					const hash = event.data.hash as string | undefined;
+					const content = hash ? opts.contentByHash?.[hash] : undefined;
+					if (noteId && content !== undefined) {
+						await registry.applyLocalEdit(noteId, content);
+					} else skip(event.kind);
+					break;
+				}
+
+				case "enroll":
+					if (noteId) await registry.startSync(noteId);
+					else skip(event.kind);
+					break;
+
+				case "reset":
+					if (noteId) registry.reset(noteId);
+					else skip(event.kind);
+					break;
+
+				case "connection":
+					registry.setConnected(event.data.connected === true);
+					break;
+
+				case "send": {
+					// An assertion point, not an action. The recorded frame should have
+					// been produced by the events replayed so far.
+					await settle();
+					const actual = sends.shift();
+					const expectedKind = String(event.data.kind);
+					if (!actual) {
+						divergences.push({
+							seq: event.seq,
+							noteId,
+							expected: `send ${expectedKind}`,
+							actual: "no frame sent",
+						});
+					} else if (actual.noteId !== noteId || actual.kind !== expectedKind) {
+						divergences.push({
+							seq: event.seq,
+							noteId,
+							expected: `send ${expectedKind} for ${noteId}`,
+							actual: `send ${actual.kind} for ${actual.noteId}`,
+						});
+					}
+					break;
+				}
+
+				case "flush": {
+					await settle();
+					const expectedLength = event.data.length as number | undefined;
+					const actualContent = noteId ? flushed[noteId] : undefined;
+					if (actualContent === undefined) {
+						divergences.push({
+							seq: event.seq,
+							noteId,
+							expected: `flush of ${expectedLength} chars`,
+							actual: "no flush",
+						});
+					} else if (
+						expectedLength !== undefined &&
+						actualContent.length !== expectedLength
+					) {
+						divergences.push({
+							seq: event.seq,
+							noteId,
+							expected: `flush of ${expectedLength} chars`,
+							actual: `flush of ${actualContent.length} chars`,
+						});
+					}
+					break;
+				}
+
+				default:
+					skip(event.kind);
+			}
+
+			if (opts.stopOnDivergence && divergences.length > 0) break;
+		}
+
+		await settle();
+
+		const finalText: Record<string, string> = {};
+		for (const noteId of registry.docs.keys()) {
+			finalText[noteId] = await registry.projectedText(noteId);
+		}
+		return { divergences, finalText, skipped };
+	} finally {
+		await registry.destroyAll();
+	}
+}

--- a/tests/offline-queue-priority.test.ts
+++ b/tests/offline-queue-priority.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { OfflineQueue, QueuePriority, queuedReason } from "../src/offline-queue";
+import type { QueueEntry } from "../src/types";
+
+function entry(path: string, over: Partial<QueueEntry> = {}): QueueEntry {
+	return { path, action: "upsert", timestamp: 1000, ...over };
+}
+
+describe("queue priority", () => {
+	test("still orders oldest-first within one priority", async () => {
+		const q = new OfflineQueue();
+		await q.enqueue(entry("b.md", { timestamp: 2000 }));
+		await q.enqueue(entry("a.md", { timestamp: 1000 }));
+
+		expect(q.all().map((e) => e.path)).toEqual(["a.md", "b.md"]);
+	});
+
+	test("a higher-priority entry jumps ahead of an older background one", async () => {
+		const q = new OfflineQueue();
+		await q.enqueue(entry("bulk.md", { timestamp: 1000, priority: QueuePriority.Background }));
+		await q.enqueue(entry("open.md", { timestamp: 5000, priority: QueuePriority.OpenNote }));
+
+		// The note the user is looking at should not wait behind a bulk import.
+		expect(q.all().map((e) => e.path)).toEqual(["open.md", "bulk.md"]);
+	});
+
+	test("entries with no priority default to Normal", async () => {
+		const q = new OfflineQueue();
+		await q.enqueue(entry("legacy.md", { timestamp: 5000 }));
+		await q.enqueue(entry("bg.md", { timestamp: 1000, priority: QueuePriority.Background }));
+		await q.enqueue(entry("open.md", { timestamp: 9000, priority: QueuePriority.OpenNote }));
+
+		// A persisted entry written before priority existed must not sink below
+		// background work just because it lacks the field.
+		expect(q.all().map((e) => e.path)).toEqual(["open.md", "legacy.md", "bg.md"]);
+	});
+
+	test("re-enqueueing a path can raise its priority", async () => {
+		const q = new OfflineQueue();
+		await q.enqueue(entry("a.md", { priority: QueuePriority.Background }));
+		await q.enqueue(entry("a.md", { priority: QueuePriority.OpenNote }));
+
+		expect(q.size).toBe(1);
+		expect(q.all()[0].priority).toBe(QueuePriority.OpenNote);
+	});
+
+	test("survives a load of persisted entries that predate the priority field", () => {
+		const q = new OfflineQueue();
+		q.load([entry("old.md", { timestamp: 1 })]);
+
+		expect(q.all()).toHaveLength(1);
+		expect(() => q.all()).not.toThrow();
+	});
+});
+
+describe("cancel", () => {
+	test("removes a queued entry for a path", async () => {
+		const q = new OfflineQueue();
+		await q.enqueue(entry("a.md"));
+
+		expect(q.cancel("a.md")).toBe(true);
+		expect(q.size).toBe(0);
+	});
+
+	test("reports false when there was nothing to cancel", async () => {
+		const q = new OfflineQueue();
+
+		expect(q.cancel("ghost.md")).toBe(false);
+	});
+
+	test("respects vault scoping so one vault cannot cancel another's work", async () => {
+		const q = new OfflineQueue();
+		await q.enqueue(entry("a.md", { vaultId: "v1" }));
+
+		expect(q.cancel("a.md", "v2")).toBe(false);
+		expect(q.size).toBe(1);
+	});
+
+	test("cancelling is synchronous — a rename must not race the flush loop", async () => {
+		// dequeue() awaits a persist round trip. A caller reacting to a vault
+		// rename needs the entry gone NOW, before the flush loop can pick up work
+		// for a path that no longer exists.
+		const q = new OfflineQueue();
+		await q.enqueue(entry("a.md"));
+		q.cancel("a.md");
+
+		expect(q.all()).toEqual([]);
+	});
+});
+
+describe("queuedReason", () => {
+	test("explains a queue held by being offline", () => {
+		expect(queuedReason({ queued: 3, inFlight: 0, offline: true, syncBlocked: false })).toBe(
+			"offline",
+		);
+	});
+
+	test("explains a queue held by the sync gate", () => {
+		expect(queuedReason({ queued: 3, inFlight: 0, offline: false, syncBlocked: true })).toBe(
+			"sync-blocked",
+		);
+	});
+
+	test("reports work in progress rather than a stall", () => {
+		expect(queuedReason({ queued: 3, inFlight: 2, offline: false, syncBlocked: false })).toBe(
+			"in-progress",
+		);
+	});
+
+	test("returns null when there is nothing queued", () => {
+		expect(
+			queuedReason({ queued: 0, inFlight: 0, offline: true, syncBlocked: false }),
+		).toBeNull();
+	});
+
+	test("prefers offline over sync-blocked when both hold", () => {
+		// Offline is the one the user can act on, and the one that resolves itself.
+		expect(queuedReason({ queued: 1, inFlight: 0, offline: true, syncBlocked: true })).toBe(
+			"offline",
+		);
+	});
+
+	test("names the stall when work is queued, online, unblocked and idle", () => {
+		// The case that currently shows an unexplained spinner.
+		expect(queuedReason({ queued: 5, inFlight: 0, offline: false, syncBlocked: false })).toBe(
+			"waiting",
+		);
+	});
+});

--- a/tests/sync-center-render.test.ts
+++ b/tests/sync-center-render.test.ts
@@ -117,6 +117,9 @@ function makeMockPlugin(issues: SyncIssue[]): any {
 				lastSync: "",
 				error: undefined,
 			}),
+			// Matches the real engine: null when nothing is queued, which is the
+			// state `getStatus` above reports.
+			queuedReason: () => null,
 			issues: {
 				all: () => issues,
 				count: (cat?: string) =>

--- a/tests/sync-crdt-gate.test.ts
+++ b/tests/sync-crdt-gate.test.ts
@@ -24,6 +24,7 @@ import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { NoteIdMap } from "../src/crdt/note-id-map";
 import { fnv1a, SyncEngine } from "../src/sync";
+import type { SyncedFileTable } from "../src/synced-file";
 import { DEFAULT_SETTINGS } from "../src/types";
 
 /** Cast engine to access private syncState for test setup. */
@@ -860,9 +861,12 @@ describe("Graceful degradation: channel join gate — CRDT not connected", () =>
 // P0-2 — sync gate blocks all CRDT inbound paths
 // ---------------------------------------------------------------------------
 
-/** Access private recentlyFlushed map via type cast (same pattern as seedSyncState). */
-function getRecentlyFlushed(engine: SyncEngine): Map<string, number> {
-	return (engine as unknown as { recentlyFlushed: Map<string, number> }).recentlyFlushed;
+/** Access the private per-file marker table via type cast (same pattern as
+ *  seedSyncState). Shaped like the old Map so the assertions below read the
+ *  same: `.has(path)` now means "carries the flushed marker". */
+function getRecentlyFlushed(engine: SyncEngine): { has(path: string): boolean } {
+	const files = (engine as unknown as { files: SyncedFileTable }).files;
+	return { has: (path: string) => files.has(path, "flushed") };
 }
 
 describe("flushFromCrdt — idempotent: skips rewrite when disk already matches", () => {

--- a/tests/sync-crdt-route.test.ts
+++ b/tests/sync-crdt-route.test.ts
@@ -18,6 +18,7 @@ import {
 	routeModify,
 	SyncEngine,
 } from "../src/sync";
+import type { SyncedFileTable } from "../src/synced-file";
 import { DEFAULT_SETTINGS } from "../src/types";
 
 // ---------------------------------------------------------------------------
@@ -1230,9 +1231,10 @@ describe("Task 4: local delete enqueues a durable crdt_delete", () => {
 		engine.setCrdtEnqueue((op) => enqueued.push(op));
 		// Simulate trashRemotelyDeleted having marked the path before the vault
 		// 'delete' event fires — the remote-echo early-return in handleDelete.
-		(engine as unknown as { remotelyDeleted: Map<string, number> }).remotelyDeleted.set(
+		(engine as unknown as { files: SyncedFileTable }).files.mark(
 			"Notes/gone.md",
-			0,
+			"remotelyDeleted",
+			60_000,
 		);
 
 		const file = new TFile("Notes/gone.md");

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -164,7 +164,7 @@ describe("pushGenesisBatch — direct", () => {
 		const file = new TFile("Notes/Flushed.md", Date.now());
 		const { engine } = makeEngine([file], { "Notes/Flushed.md": "# F" });
 		// shouldDeferMint = mapped-map + no id for path + path recentlyFlushed.
-		(engine as any).recentlyFlushed.set("Notes/Flushed.md", Date.now());
+		(engine as any).files.mark("Notes/Flushed.md", "flushed", 60_000);
 		let called = 0;
 		engine.setCrdtCreateBatch(async (creates) => {
 			called++;

--- a/tests/sync-recorder.test.ts
+++ b/tests/sync-recorder.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import { deserializeTimeline, SyncRecorder, serializeTimeline } from "../src/sync-recorder";
+
+describe("SyncRecorder", () => {
+	test("stamps a monotonic seq, not a clock reading", () => {
+		// The load-bearing property. `[client:*]` log `time` is the batch-SHIP
+		// stamp, so ordering a timeline by it scrambles causality — that trap cost
+		// two debugging sessions. seq is assigned at record time and never
+		// reordered.
+		const rec = new SyncRecorder({ enabled: () => true });
+		rec.record("receive", "n1", {});
+		rec.record("send", "n2", {});
+		rec.record("receive", "n1", {});
+
+		expect(rec.timeline().map((e) => e.seq)).toEqual([0, 1, 2]);
+	});
+
+	test("seq keeps advancing across notes and event kinds", () => {
+		const rec = new SyncRecorder({ enabled: () => true });
+		for (let i = 0; i < 5; i++) rec.record("send", `n${i}`, {});
+
+		expect(rec.timeline().at(-1)?.seq).toBe(4);
+	});
+
+	test("records nothing while disabled", () => {
+		const rec = new SyncRecorder({ enabled: () => false });
+		rec.record("receive", "n1", {});
+
+		expect(rec.timeline()).toHaveLength(0);
+	});
+
+	test("picks up a flag flipped on at runtime without a reload", () => {
+		let on = false;
+		const rec = new SyncRecorder({ enabled: () => on });
+		rec.record("receive", "n1", {});
+		on = true;
+		rec.record("receive", "n2", {});
+
+		expect(rec.timeline().map((e) => e.noteId)).toEqual(["n2"]);
+	});
+
+	test("seq does not advance for suppressed events", () => {
+		// Otherwise a timeline captured with recording toggled mid-session shows
+		// gaps that read as dropped frames.
+		let on = false;
+		const rec = new SyncRecorder({ enabled: () => on });
+		rec.record("receive", "skipped", {});
+		on = true;
+		rec.record("receive", "kept", {});
+
+		expect(rec.timeline()[0].seq).toBe(0);
+	});
+
+	test("bounds the ring so a long session cannot grow it without limit", () => {
+		const rec = new SyncRecorder({ enabled: () => true, capacity: 3 });
+		for (let i = 0; i < 10; i++) rec.record("send", `n${i}`, {});
+
+		const timeline = rec.timeline();
+		expect(timeline).toHaveLength(3);
+		// The retained window keeps its ORIGINAL seq numbers, so a truncated
+		// timeline still says how much came before it.
+		expect(timeline.map((e) => e.seq)).toEqual([7, 8, 9]);
+	});
+
+	test("filters a timeline down to one note", () => {
+		const rec = new SyncRecorder({ enabled: () => true });
+		rec.record("receive", "n1", {});
+		rec.record("receive", "n2", {});
+		rec.record("send", "n1", {});
+
+		expect(rec.timeline("n1").map((e) => e.seq)).toEqual([0, 2]);
+	});
+
+	test("carries event detail through verbatim", () => {
+		const rec = new SyncRecorder({ enabled: () => true });
+		rec.record("send", "n1", { kind: "handshake", accepted: false });
+
+		expect(rec.timeline()[0].data).toEqual({ kind: "handshake", accepted: false });
+	});
+
+	test("clear resets the buffer but not the seq counter", () => {
+		// A cleared recorder must not restart numbering: two timelines from one
+		// session would otherwise both start at 0 and look like the same events.
+		const rec = new SyncRecorder({ enabled: () => true });
+		rec.record("send", "n1", {});
+		rec.clear();
+		rec.record("send", "n2", {});
+
+		expect(rec.timeline()[0].seq).toBe(1);
+	});
+});
+
+describe("timeline serialization", () => {
+	test("round-trips through JSON", () => {
+		const rec = new SyncRecorder({ enabled: () => true });
+		rec.record("receive", "n1", { frame: "AQID" });
+		rec.record("localEdit", "n1", { hash: "abc", consumed: true });
+
+		const restored = deserializeTimeline(serializeTimeline(rec.timeline()));
+
+		expect(restored).toEqual(rec.timeline());
+	});
+
+	test("serializes to a stable, diffable shape", () => {
+		const rec = new SyncRecorder({ enabled: () => true });
+		rec.record("receive", "n1", { frame: "AQID" });
+
+		expect(JSON.parse(serializeTimeline(rec.timeline()))).toEqual([
+			{ seq: 0, kind: "receive", noteId: "n1", data: { frame: "AQID" } },
+		]);
+	});
+
+	test("rejects a malformed timeline instead of half-loading it", () => {
+		expect(() => deserializeTimeline('{"not":"an array"}')).toThrow();
+		expect(() => deserializeTimeline("[{}]")).toThrow();
+	});
+
+	test("rejects an unknown event kind rather than typing it as valid", () => {
+		// The cast at the parse boundary makes `kind` LOOK like the union to the
+		// compiler; only this check makes it actually be one. Without it a replayer
+		// that promises an exhaustive switch silently hits its default branch.
+		const bogus = JSON.stringify([{ seq: 0, kind: "teleport", noteId: "n1", data: {} }]);
+
+		expect(() => deserializeTimeline(bogus)).toThrow(/unknown kind/i);
+	});
+
+	test("rejects a timeline whose seq ordering was scrambled", () => {
+		// A hand-edited or badly-merged fixture must not replay out of causal
+		// order and produce a mystery divergence.
+		const scrambled = JSON.stringify([
+			{ seq: 3, kind: "receive", noteId: "n1", data: {} },
+			{ seq: 1, kind: "receive", noteId: "n1", data: {} },
+		]);
+
+		expect(() => deserializeTimeline(scrambled)).toThrow(/seq/i);
+	});
+});

--- a/tests/sync-replay-cas-enroll.test.ts
+++ b/tests/sync-replay-cas-enroll.test.ts
@@ -21,6 +21,7 @@ import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { NoteIdMap } from "../src/crdt/note-id-map";
 import { SyncEngine } from "../src/sync";
+import type { SyncedFileTable } from "../src/synced-file";
 import { DEFAULT_SETTINGS } from "../src/types";
 
 const mockApi = {
@@ -202,9 +203,10 @@ describe("replay mint refusal (#972/#217 guard parity)", () => {
 		// was relocated away (#972 class). Live pushes and batch genesis refuse to
 		// mint here (shouldDeferMint) — the replay path must too, or a stale
 		// queued entry mints a FRESH id and creates a duplicate server row.
-		(engine as unknown as { recentlyFlushed: Map<string, number> }).recentlyFlushed.set(
+		(engine as unknown as { files: SyncedFileTable }).files.mark(
 			"flushed.md",
-			1,
+			"flushed",
+			60_000,
 		);
 
 		engine.queue.load([

--- a/tests/sync-replay.test.ts
+++ b/tests/sync-replay.test.ts
@@ -4,7 +4,24 @@ import { ProviderRegistry } from "../src/crdt/provider-registry";
 import { deserializeTimeline, SyncRecorder, serializeTimeline } from "../src/sync-recorder";
 import { replayTimeline } from "./helpers/replay";
 
-const settle = () => new Promise<void>((r) => setTimeout(r, 25));
+/**
+ * Poll until `cond` holds.
+ *
+ * NOT a bigger sleep. The STEP1/STEP2 handshake spans several async turns (two
+ * IndexeddbPersistence.whenSynced resolutions plus the relay's queueMicrotask
+ * hops), so a fixed sleep is racy under parallel load — the sibling
+ * provider-registry.test.ts and wiring.test.ts carry the same helper and the
+ * same warning. Tearing a registry down mid-handshake abandons the in-flight
+ * entry() await, and its NoteDestroyedError surfaces as a test failure with a
+ * stack pointing at destroyAll rather than at the real cause.
+ */
+async function waitFor(cond: () => boolean, label: string): Promise<void> {
+	for (let i = 0; i < 200; i++) {
+		if (cond()) return;
+		await new Promise<void>((r) => setTimeout(r, 5));
+	}
+	throw new Error(`waitFor timed out: ${label}`);
+}
 
 /** Record a real two-device exchange, then hand back its timeline. This is the
  *  loop the whole feature exists for: a live session produces a timeline, and
@@ -40,7 +57,9 @@ async function recordExchange(dbPrefix: string) {
 	await A.applyLocalEdit("note-1", "hello world");
 	A.enroll("note-1");
 	B.enroll("note-1");
-	await settle();
+	// Wait for the exchange to actually COMPLETE, not for a fixed duration:
+	// B receiving the content is the observable end of the handshake.
+	await waitFor(() => flushedB["note-1"] === "hello world", "B flushed A's content");
 
 	const timeline = recorder.timeline();
 	await A.destroyAll();

--- a/tests/sync-replay.test.ts
+++ b/tests/sync-replay.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import "fake-indexeddb/auto";
+import { ProviderRegistry } from "../src/crdt/provider-registry";
+import { deserializeTimeline, SyncRecorder, serializeTimeline } from "../src/sync-recorder";
+import { replayTimeline } from "./helpers/replay";
+
+const settle = () => new Promise<void>((r) => setTimeout(r, 25));
+
+/** Record a real two-device exchange, then hand back its timeline. This is the
+ *  loop the whole feature exists for: a live session produces a timeline, and
+ *  the timeline reproduces the session. */
+async function recordExchange(dbPrefix: string) {
+	const recorder = new SyncRecorder({ enabled: () => true });
+	let A: ProviderRegistry;
+	let B: ProviderRegistry;
+	const flushedB: Record<string, string> = {};
+
+	A = new ProviderRegistry({
+		dbPrefix: `${dbPrefix}-A`,
+		recorder,
+		send: (id, frame) => {
+			queueMicrotask(() => void B.receive(id, frame));
+			return true;
+		},
+		onFlushToDisk: () => true,
+	});
+	B = new ProviderRegistry({
+		dbPrefix: `${dbPrefix}-B`,
+		send: (id, frame) => {
+			queueMicrotask(() => void A.receive(id, frame));
+			return true;
+		},
+		onFlushToDisk: (id, content) => {
+			flushedB[id] = content;
+		},
+	});
+
+	A.setConnected(true);
+	B.setConnected(true);
+	await A.applyLocalEdit("note-1", "hello world");
+	A.enroll("note-1");
+	B.enroll("note-1");
+	await settle();
+
+	const timeline = recorder.timeline();
+	await A.destroyAll();
+	await B.destroyAll();
+	return { timeline, flushedB };
+}
+
+describe("recorder → replay round trip", () => {
+	test("a live exchange produces a timeline that survives serialization", async () => {
+		const { timeline } = await recordExchange("rt1");
+
+		expect(timeline.length).toBeGreaterThan(0);
+		expect(deserializeTimeline(serializeTimeline(timeline))).toEqual(timeline);
+	});
+
+	test("the timeline records the seams in causal order", async () => {
+		const { timeline } = await recordExchange("rt2");
+		const kinds = timeline.map((e) => e.kind);
+
+		expect(kinds).toContain("connection");
+		expect(kinds).toContain("localEdit");
+		expect(kinds).toContain("enroll");
+		// Ordering is by construction, so the recorded seq must be strictly
+		// increasing — the property the log `time` field could never give us.
+		const seqs = timeline.map((e) => e.seq);
+		expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+	});
+
+	test("replaying the recorded inputs converges a fresh registry to the same text", async () => {
+		const { timeline } = await recordExchange("rt3");
+		const hash = timeline.find((e) => e.kind === "localEdit")?.data.hash as string;
+		// The replayable INPUTS are the inbound frames, the connection landmarks,
+		// the room lifecycle, and the local edits. `send` and `flush` entries are
+		// OUTPUTS — assertions about what the system produced, not things to do.
+		const inputs = timeline.filter(
+			(e) => e.kind !== "send" && e.kind !== "flush" && e.kind !== "remoteUpdate",
+		);
+
+		const result = await replayTimeline(inputs, {
+			dbPrefix: "rt3-replay",
+			contentByHash: { [hash]: "hello world" },
+		});
+
+		expect(result.divergences).toEqual([]);
+		expect(result.finalText["note-1"]).toBe("hello world");
+	});
+
+	test("inbound frames alone cannot reconstruct locally-originated content", async () => {
+		// A real constraint worth pinning, not a bug. Content this device authored
+		// enters through localEdit and only ever leaves as an outbound frame, so a
+		// timeline filtered to `receive` carries no trace of it. A caller that
+		// forgets this gets an empty doc, and would otherwise read that as a
+		// convergence failure.
+		const { timeline } = await recordExchange("rt3b");
+		const inbound = timeline.filter((e) => e.kind === "receive" || e.kind === "connection");
+
+		const result = await replayTimeline(inbound, { dbPrefix: "rt3b-replay" });
+
+		expect(result.finalText["note-1"] ?? "").toBe("");
+	});
+
+	test("reports a divergence when replay does not reproduce a recorded flush", async () => {
+		// A flush the replay cannot produce — no inbound content preceded it — is
+		// exactly the shape of a real regression, and must be reported rather than
+		// passing silently.
+		const result = await replayTimeline(
+			[
+				{ seq: 0, kind: "connection", noteId: null, data: { connected: true } },
+				{ seq: 1, kind: "flush", noteId: "note-9", data: { length: 42 } },
+			],
+			{ dbPrefix: "rt4" },
+		);
+
+		expect(result.divergences).toHaveLength(1);
+		expect(result.divergences[0]).toMatchObject({ seq: 1, actual: "no flush" });
+	});
+
+	test("counts events it cannot act on instead of pretending they replayed", async () => {
+		const result = await replayTimeline(
+			[{ seq: 0, kind: "localEdit", noteId: "note-1", data: { hash: "unknown" } }],
+			{ dbPrefix: "rt5" },
+		);
+
+		// A localEdit whose content is not supplied must NOT become an empty write
+		// — that would silently rewrite the note to "" and invent a divergence.
+		expect(result.skipped.localEdit).toBe(1);
+		expect(result.divergences).toEqual([]);
+	});
+
+	test("replays a localEdit when its content is supplied by hash", async () => {
+		const { timeline } = await recordExchange("rt6");
+		const edit = timeline.find((e) => e.kind === "localEdit");
+		const hash = edit?.data.hash as string;
+
+		const result = await replayTimeline([edit as never], {
+			dbPrefix: "rt6-replay",
+			contentByHash: { [hash]: "hello world" },
+		});
+
+		expect(result.skipped.localEdit).toBeUndefined();
+		expect(result.finalText["note-1"]).toBe("hello world");
+	});
+});

--- a/tests/sync-ttl-windows.test.ts
+++ b/tests/sync-ttl-windows.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, mock, test } from "bun:test";
 import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { SyncEngine } from "../src/sync";
+import type { SyncedFileTable } from "../src/synced-file";
 import { ManualTimeProvider } from "../src/time-provider";
 import { DEFAULT_SETTINGS } from "../src/types";
 
@@ -46,9 +47,8 @@ function engineWithClock() {
 		markRecentlyDeleted(id: string): void;
 		recentlyDeleted: Map<string, number>;
 		markRecentlyFlushed(path: string): void;
-		recentlyFlushed: Map<string, number>;
 		markRecentlyPushed(path: string): void;
-		recentlyPushed: Map<string, number>;
+		files: SyncedFileTable;
 	};
 	return { engine, clock, probe };
 }
@@ -101,11 +101,11 @@ describe("recentlyFlushed echo window", () => {
 	test("expires on the same injected clock", () => {
 		const { clock, probe } = engineWithClock();
 		probe.markRecentlyFlushed("a.md");
-		expect(probe.recentlyFlushed.has("a.md")).toBe(true);
+		expect(probe.files.has("a.md", "flushed")).toBe(true);
 
 		clock.advance(RECENT_DELETE_COOLDOWN_MS);
 
-		expect(probe.recentlyFlushed.has("a.md")).toBe(false);
+		expect(probe.files.has("a.md", "flushed")).toBe(false);
 	});
 
 	test("leaves no timer pending after expiry", () => {

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -4,6 +4,7 @@ import type { EngramApi } from "../src/api";
 import { NoteIdMap } from "../src/crdt/note-id-map";
 import { LimitExceededError } from "../src/limit-error";
 import { fnv1a, SyncEngine } from "../src/sync";
+import type { SyncedFileTable } from "../src/synced-file";
 import { DEFAULT_SETTINGS } from "../src/types";
 import { __noticeCapture } from "./__mocks__/obsidian";
 
@@ -2826,10 +2827,9 @@ describe("Path sanitization on push", () => {
 		// path: the self-echo arrives as an upsert for RenameOld. Marking the live
 		// path instead would let the old-path echo recreate the renamed-away file
 		// and swallow a genuine remote update to RenameNew (Engram#944 class).
-		const recentlyPushed = (engine as unknown as { recentlyPushed: Map<string, number> })
-			.recentlyPushed;
-		expect(recentlyPushed.has("Notes/RenameOld.md")).toBe(true);
-		expect(recentlyPushed.has("Notes/RenameNew.md")).toBe(false);
+		const files = (engine as unknown as { files: SyncedFileTable }).files;
+		expect(files.has("Notes/RenameOld.md", "pushed")).toBe(true);
+		expect(files.has("Notes/RenameNew.md", "pushed")).toBe(false);
 	});
 
 	test("does not rename when server path matches original", async () => {

--- a/tests/synced-file.test.ts
+++ b/tests/synced-file.test.ts
@@ -22,6 +22,12 @@ function fakeTime() {
 		fireAll(): void {
 			for (const id of [...timers.keys()]) this.fire(id);
 		},
+		/** Fire only the earliest-armed timer. Needed where firing everything
+		 *  would also expire the marker under assertion. */
+		fireOldest(): void {
+			const [id] = timers.keys();
+			if (id !== undefined) this.fire(id);
+		},
 		get live(): number {
 			return timers.size;
 		},
@@ -136,6 +142,26 @@ describe("SyncedFileTable lifecycle", () => {
 
 		expect(time.live).toBe(0);
 		expect(t.size).toBe(0);
+	});
+
+	test("a stale timer from before a rename does not delete a newer entry at the old path", () => {
+		// The expiry closure captures the path it was created for, but rename()
+		// moves the object to a different key. Re-marking the old path creates a
+		// NEW entry there; when the stale timer fires it must not delete it.
+		// Losing that entry silently drops echo suppression for a real file.
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("old.md", "flushed", 100);
+		t.rename("old.md", "new.md");
+		t.mark("old.md", "pushed", 100);
+
+		// Only the PRE-rename timer. fireAll would also expire the marker under
+		// assertion and pass for the wrong reason.
+		time.fireOldest();
+
+		expect(t.has("old.md", "pushed")).toBe(true);
+		// ...and the renamed file keeps its own entry.
+		expect(t.has("new.md", "flushed")).toBe(false);
 	});
 
 	test("an expired marker leaves no empty entry behind", () => {

--- a/tests/synced-file.test.ts
+++ b/tests/synced-file.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { SyncedFileTable } from "../src/synced-file";
+
+/** Controllable clock so TTL expiry is asserted, not slept through. */
+function fakeTime() {
+	let next = 1;
+	const timers = new Map<number, () => void>();
+	return {
+		setTimeout(cb: () => void): number {
+			const id = next++;
+			timers.set(id, cb);
+			return id;
+		},
+		clearTimeout(id: number): void {
+			timers.delete(id);
+		},
+		fire(id: number): void {
+			const cb = timers.get(id);
+			timers.delete(id);
+			cb?.();
+		},
+		fireAll(): void {
+			for (const id of [...timers.keys()]) this.fire(id);
+		},
+		get live(): number {
+			return timers.size;
+		},
+	};
+}
+
+describe("SyncedFileTable markers", () => {
+	test("a marked path reads back as marked", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+
+		expect(t.has("a.md", "pushed")).toBe(true);
+	});
+
+	test("markers are independent of each other", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+
+		expect(t.has("a.md", "flushed")).toBe(false);
+	});
+
+	test("a marker clears when its timer fires", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+		time.fireAll();
+
+		expect(t.has("a.md", "pushed")).toBe(false);
+	});
+
+	test("re-marking replaces the pending timer rather than stacking one", () => {
+		// Two live timers for one marker means the FIRST expiry clears a window
+		// the second call had just extended.
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+		t.mark("a.md", "pushed", 100);
+
+		expect(time.live).toBe(1);
+	});
+
+	test("clearMarker drops it immediately and cancels the timer", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "remotelyDeleted", 100);
+		t.clearMarker("a.md", "remotelyDeleted");
+
+		expect(t.has("a.md", "remotelyDeleted")).toBe(false);
+		expect(time.live).toBe(0);
+	});
+
+	test("an unmarked path is not marked", () => {
+		const t = new SyncedFileTable(fakeTime());
+
+		expect(t.has("ghost.md", "pushed")).toBe(false);
+	});
+});
+
+describe("SyncedFileTable lifecycle", () => {
+	test("rename carries markers to the new path", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("old.md", "flushed", 100);
+		t.rename("old.md", "new.md");
+
+		expect(t.has("new.md", "flushed")).toBe(true);
+		expect(t.has("old.md", "flushed")).toBe(false);
+	});
+
+	test("rename onto an occupied path does not leak the displaced timers", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("old.md", "flushed", 100);
+		t.mark("new.md", "pushed", 100);
+		t.rename("old.md", "new.md");
+
+		// The displaced entry's timer must be cancelled, not orphaned.
+		expect(time.live).toBe(1);
+		expect(t.has("new.md", "flushed")).toBe(true);
+		expect(t.has("new.md", "pushed")).toBe(false);
+	});
+
+	test("renaming an untracked path is a no-op", () => {
+		const t = new SyncedFileTable(fakeTime());
+
+		expect(() => t.rename("nothing.md", "x.md")).not.toThrow();
+	});
+
+	test("forget drops the entry and cancels its timers", () => {
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+		t.mark("a.md", "flushed", 100);
+		t.forget("a.md");
+
+		expect(time.live).toBe(0);
+		expect(t.size).toBe(0);
+	});
+
+	test("destroy cancels every outstanding timer", () => {
+		// One call replaces the three near-identical clear-every-timer loops the
+		// maps needed in SyncEngine.destroy(), where adding a fourth marker meant
+		// remembering to add a fourth loop.
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+		t.mark("b.md", "flushed", 100);
+		t.mark("c.md", "remotelyDeleted", 100);
+		t.destroy();
+
+		expect(time.live).toBe(0);
+		expect(t.size).toBe(0);
+	});
+
+	test("an expired marker leaves no empty entry behind", () => {
+		// Otherwise a long session accumulates one entry per path ever touched.
+		const time = fakeTime();
+		const t = new SyncedFileTable(time);
+		t.mark("a.md", "pushed", 100);
+		time.fireAll();
+
+		expect(t.size).toBe(0);
+	});
+});

--- a/tests/track-promise.test.ts
+++ b/tests/track-promise.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+
+// DEV_MODE is a bare global that esbuild replaces at build time. Set it before
+// importing so the `trackPromise` gate takes its dev-build branch (mirrors
+// tests/dev-log.test.ts).
+(globalThis as unknown as { DEV_MODE: boolean }).DEV_MODE = true;
+
+const { PromiseTracker, setActiveTracker, trackPromise } = await import("../src/track-promise");
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+describe("PromiseTracker", () => {
+	test("passes the promise through untouched", async () => {
+		const tracker = new PromiseTracker();
+
+		await expect(tracker.track("a", Promise.resolve(42))).resolves.toBe(42);
+	});
+
+	test("lists a promise that has not settled", () => {
+		const tracker = new PromiseTracker();
+		tracker.track("slow-pull", new Promise(() => {}));
+
+		expect(tracker.pending().map((p) => p.label)).toEqual(["slow-pull"]);
+	});
+
+	test("drops a fulfilled promise from pending and records it as completed", async () => {
+		const tracker = new PromiseTracker();
+		tracker.track("push", Promise.resolve("ok"));
+		await settle();
+
+		expect(tracker.pending()).toHaveLength(0);
+		expect(tracker.recent().at(-1)).toMatchObject({ label: "push", state: "fulfilled" });
+	});
+
+	test("records a rejection without turning it into an unhandled rejection", async () => {
+		const tracker = new PromiseTracker();
+		const p = tracker.track("flush", Promise.reject(new Error("nope")));
+		// The caller still owns the rejection — tracking must not swallow it.
+		await expect(p).rejects.toThrow("nope");
+
+		expect(tracker.recent().at(-1)).toMatchObject({ label: "flush", state: "rejected" });
+	});
+
+	test("a rejected tracked promise nobody awaits does not crash the tracker", async () => {
+		const tracker = new PromiseTracker();
+		tracker.track("fire-and-forget", Promise.reject(new Error("boom")));
+		await settle();
+
+		expect(tracker.pending()).toHaveLength(0);
+	});
+
+	test("reports how long a pending promise has been outstanding", async () => {
+		let now = 1_000;
+		const tracker = new PromiseTracker({ now: () => now });
+		tracker.track("stuck", new Promise(() => {}));
+		now = 4_500;
+
+		expect(tracker.pending()[0].ageMs).toBe(3_500);
+	});
+
+	test("bounds the completion ring so a long session cannot grow it without limit", async () => {
+		const tracker = new PromiseTracker({ capacity: 3 });
+		for (let i = 0; i < 10; i++) tracker.track(`op-${i}`, Promise.resolve(i));
+		await settle();
+
+		const recent = tracker.recent();
+		expect(recent).toHaveLength(3);
+		expect(recent.map((r) => r.label)).toEqual(["op-7", "op-8", "op-9"]);
+	});
+
+	test("destroy clears pending entries", async () => {
+		const tracker = new PromiseTracker();
+		tracker.track("a", new Promise(() => {}));
+		tracker.destroy();
+
+		expect(tracker.pending()).toHaveLength(0);
+	});
+
+	test("a promise settling after destroy does not repopulate the tracker", async () => {
+		const tracker = new PromiseTracker();
+		let resolve!: (v: string) => void;
+		tracker.track("late", new Promise<string>((r) => (resolve = r)));
+		tracker.destroy();
+		resolve("done");
+		await settle();
+
+		expect(tracker.pending()).toHaveLength(0);
+		expect(tracker.recent()).toHaveLength(0);
+	});
+});
+
+describe("trackPromise", () => {
+	test("routes to the installed tracker", async () => {
+		const tracker = new PromiseTracker();
+		setActiveTracker(tracker);
+		try {
+			trackPromise("wired", new Promise(() => {}));
+
+			expect(tracker.pending().map((p) => p.label)).toEqual(["wired"]);
+		} finally {
+			setActiveTracker(null);
+		}
+	});
+
+	test("is a pass-through when no tracker is installed", async () => {
+		setActiveTracker(null);
+
+		await expect(trackPromise("orphan", Promise.resolve(7))).resolves.toBe(7);
+	});
+
+	test("does not swallow a rejection", async () => {
+		const tracker = new PromiseTracker();
+		setActiveTracker(tracker);
+		try {
+			await expect(trackPromise("bad", Promise.reject(new Error("x")))).rejects.toThrow("x");
+		} finally {
+			setActiveTracker(null);
+		}
+	});
+});


### PR DESCRIPTION
Implements the plugin-side work from the Relay audit (engram-app/engram-workspace#142,
`docs/context/relay-pattern-audit.md`). One commit per issue, ordered so each is
independently reviewable.

| Commit | Issue | What |
|---|---|---|
| 1 | #360 | ops-hygiene primitives: feature-flag schema, HasLogging, trackPromise |
| 2 | #355 | debug snapshot API — every copy of a note side by side |
| 3 | #356 | record + replay the CRDT sync seams |
| 4 | #359 | queue priority, synchronous cancel, queued-reason |
| 5 | #357 | merge disk edits against the LCA instead of current doc state |
| 6 | #358 | per-file sync state as an object (first slice) |

`2367 pass, 0 fail` · tsc, eslint, stylelint, biome all clean.

## Things worth a reviewer's attention

**The LCA store already existed.** `src/base-store.ts` persists the last-synced
content of each note and its own docstring calls it "the common ancestor for 3-way
merge conflict resolution", with LRU eviction and a 50MB cap. Nothing in the CRDT
path was reading it. So #357 turned out to be a merge problem, not a persistence
problem: `seedContentInto` ends in a TWO-way `diffIntoYText(text, diskBody)` that
forces the Y.Text to equal the disk snapshot, deleting any remote op that landed
between the file read and the diff. That is the stale-snapshot revert class, and
the reason `applyLocalEdit` carries a 3-attempt retry loop. With a base we apply
the disk's delta *relative to the base* instead, and remote work survives by
construction. `diff-match-patch` was already a dependency.

**The queue was not rewritten.** Relay's BackgroundSync is 2450 lines, but we
already had dedup, a persisted retry cap, oldest-first ordering, and IssueStore as
a terminal sink outside the retry loop. Only three things were missing and only
those were built.

**Three items from #360 were deliberately skipped**, with reasons in the commit:
the Patcher registry (we have 2 patch sites, both already returning unpatchers),
the local rotating log file (we have Loki + a dev ring buffer), and the error
taxonomy (deferred to where it has a caller).

## Flags

Both new flags are **off by default** and only visible with diagnostics enabled.
`crdtLcaMerge` is `danger` category — it changes how concurrent edits resolve and
wants a real soak before it becomes the default. The two-way path stays fully
reachable, and a test pins its lossy behaviour on purpose so it cannot rot while
it is still what ships.

## Not done here

Retiring the `applyLocalEdit` retry loop — it is still the path whenever
`crdtLcaMerge` is off, so deleting it now would leave the default configuration
unguarded. And 15 of the 19 side tables in #358; `debounceTimers` in particular
has rename re-arming logic that deserves its own change.

Backend decision engram-app/Engram#1146 (vault index as a CRDT) is independent of
all of this and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N62e5eq31DoffeCH2LJDFM
