### PR TITLE
fix(sync): sweep per-note CRDT maps in destroy()

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -7579,6 +7579,16 @@ export class SyncEngine {
 			window.clearTimeout(timer);
 		}
 		this.crdtHealTrailingTimers.clear();
+		// Per-note CRDT bookkeeping that holds no timers, so nothing leaks if it
+		// survives — but it is per-engine-lifetime state and every sibling map
+		// above is swept here. Left behind, a reused engine would carry a stale
+		// heal cooldown (suppressing a handshake the new session needs), a stale
+		// re-handshake attempt count, and a staged convergence for a note whose
+		// room is gone. `syncState` is deliberately NOT in this list: it is the
+		// persisted sync baseline, not transient state.
+		this.pendingConvergence.clear();
+		this.crdtRehandshakeAttempts.clear();
+		this.crdtHealCooldown.clear();
 		this.pendingQueueDeliveries.clear();
 		if (this.degradedNoticeTimer) window.clearTimeout(this.degradedNoticeTimer);
 		this.degradedNoticeTimer = null;

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -1015,6 +1015,44 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(reset).toHaveBeenCalledTimes(1);
 	});
 
+	// #290 (item 2). These three hold no timers, so nothing leaks either way —
+	// this pins teardown DISCIPLINE: every per-note CRDT map is swept, so a
+	// reused engine cannot inherit a stale heal cooldown (which would suppress
+	// a handshake the new session needs) or a staged convergence for a room
+	// that no longer exists.
+	test("destroy() sweeps the per-note CRDT bookkeeping maps", async () => {
+		const { engine } = crdtEngine();
+		engine.healCooldownMs = 30;
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		engine.setLiveBoundCheck((p: string) => p === "owned.md");
+		engine.importSyncState({ "owned.md": { hash: 1, version: 1, serverHash: "h0" } });
+
+		const change = {
+			path: "owned.md",
+			action: "upsert",
+			content: "a",
+			content_hash: "h1",
+			version: 2,
+			mtime: 1,
+		} as any;
+		await engine.applyChange(change); // fires: stages convergence + cooldown
+		await engine.applyChange(change); // suppressed: bumps attempt bookkeeping
+
+		const e = engine as any;
+		// Guard the guard: if the setup stopped arming these, the assertions
+		// below would pass on empty maps and prove nothing.
+		expect(e.crdtHealCooldown.size).toBeGreaterThan(0);
+		expect(e.pendingConvergence.size + e.crdtRehandshakeAttempts.size).toBeGreaterThan(0);
+
+		engine.destroy();
+
+		expect(e.pendingConvergence.size).toBe(0);
+		expect(e.crdtRehandshakeAttempts.size).toBe(0);
+		expect(e.crdtHealCooldown.size).toBe(0);
+	});
+
 	test("fix wave 3 (a): seq decides the staleRow fence — a newer seq with equal version RUNS the diverged leg (D3 gate forensics, issue #282)", async () => {
 		const { engine, reset } = crdtEngine();
 		const localFile = new TFile("owned.md");


### PR DESCRIPTION
Closes the `pendingConvergence` item (2) of #290.

## What

`destroy()` cleared every timer-bearing map but left three per-note bookkeeping maps populated:

- `pendingConvergence`
- `crdtRehandshakeAttempts`
- `crdtHealCooldown`

None holds a timer, so **nothing leaks either way** — this is teardown discipline, not a leak fix, exactly as #290 describes it.

## Why it matters anyway

Left populated, a reused engine inherits:

- a stale **heal cooldown**, which suppresses a `socketConverge` re-handshake the new session legitimately needs
- a stale **re-handshake attempt count**
- a **staged convergence** for a room that no longer exists

## Scope note

#290 names `pendingConvergence` only. The other two are the same class, sit in the same teardown path, and are three lines away — sweeping them together beats leaving two-thirds of the bug for the next person to rediscover.

`syncState` is deliberately **not** swept: it is the persisted sync baseline, not transient state.

## Test

`destroy() sweeps the per-note CRDT bookkeeping maps` arms all three through the real `applyChange` path, then asserts they are empty after `destroy()`.

It carries a guard-the-guard assertion first (`expect(...size).toBeGreaterThan(0)`) — without it, a future change that stopped arming these maps would leave the test passing against empty maps, proving nothing.

Verified it fails without the fix:

```
(fail) destroy() sweeps the per-note CRDT bookkeeping maps
  expect(received).toBe(expected)  Expected: 0  Received: 1
 43 pass, 1 fail
```

## Gate

| check | result |
|---|---|
| `biome ci src tests` | pass (248 files) |
| `lint:obsidian` (eslint) | pass |
| `lint:css` (stylelint) | pass |
| `build` (tsc + esbuild) | pass |
| `bun test` | **2370 pass, 1 skip, 0 fail** (145 files) |

## Deliberately NOT in this PR

**#290 item 1 (tracked `main.js` drift) stays open.** Running `bun run build` here regenerated `main.js` with ~700 lines of churn unrelated to this 10-line source change, confirming the drift the issue reports. I reverted it rather than commit it: a regenerated minified artifact is version-sensitive output, and it deserves its own change and its own revert point rather than riding along in a teardown fix.

Item 3 (manifest-null phantom-binding slice) is also untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CvUvadaneVBQXax8NfeNJU