### PR TITLE
[parked] feat(crdt): Relay correctness primitives — invariants, Lifetime, TimeProvider

### DIFF
--- a/main.js
+++ b/main.js
@@ -12624,6 +12624,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  I/O and log messages — passing `path` to `crdt.projectedText` would open
    *  a stray path-keyed doc/IndexedDB store instead of the real note. */
   async materializeEmptyDiscovered(path, noteId) {
+    var _a;
     if (this.syncBlocked) {
       devLog().log(
         "sync-blocked",
@@ -12634,6 +12635,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     if (!this.isCrdtEligiblePath(path)) return;
     let normalized = (0, import_obsidian20.normalizePath)(path);
     if (this.app.vault.getAbstractFileByPath(normalized)) return;
+    if (this.recentlyDeleted.has(noteId)) {
+      rlog().info("crdt", `empty-materialize skip (recent local delete): ${normalized}`);
+      return;
+    }
+    if (this.queue.hasPendingDelete(normalized, (_a = this.settings.vaultId) != null ? _a : void 0)) {
+      rlog().info("crdt", `empty-materialize skip (delete queued): ${normalized}`);
+      return;
+    }
     let text2 = this.crdt ? await this.crdt.projectedText(noteId) : "";
     await this.flushFromCrdt(path, text2);
   }
@@ -16399,6 +16408,26 @@ async function ensureDocSchema(vaultId, storage, dbs) {
   for (let name of dbsToWipe)
     await dbs.drop(name);
   return storage.setItem(markerKey, "2"), !0;
+}
+
+// src/crdt/destroyed-error.ts
+var DestroyedError = class extends Error {
+  constructor(owner, detail) {
+    super(detail ? `${owner} was destroyed: ${detail}` : `${owner} was destroyed`);
+    this.owner = owner;
+    this.detail = detail;
+    this.name = "DestroyedError";
+  }
+}, NoteDestroyedError = class extends DestroyedError {
+  constructor(noteId, path) {
+    super("Note", path ? `${path} (${noteId})` : noteId);
+    this.noteId = noteId;
+    this.path = path;
+    this.name = "NoteDestroyedError";
+  }
+};
+function isDestroyedError(error) {
+  return error instanceof DestroyedError;
 }
 
 // node_modules/lib0/indexeddb.js
@@ -21577,6 +21606,12 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
     let { order, values } = frontmatterOf(e.doc);
     return projectNote(order, values, e.text.toJSON(), rawFrontmatterOf(e.doc));
   }
+  /** Relay parity (`Document.isDocumentAlive`): a tombstoned note is dead for
+   *  good — a note_id is minted once and never reused, so this never rejects a
+   *  legitimate access. Cleared only by destroyAll (stack teardown). */
+  assertAlive(noteId) {
+    if (this.removed.has(noteId)) throw new NoteDestroyedError(noteId);
+  }
   async entry(noteId) {
     let e = this.ensureEntrySync(noteId);
     return await e.ready, e;
@@ -21589,6 +21624,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
     var _a, _b, _c;
     let cached = this.entries.get(noteId);
     if (cached) return cached;
+    this.assertAlive(noteId);
     let doc2 = new Doc(), persistence = new IndexeddbPersistence(this.storeName(noteId), doc2), kind = (_c = (_b = (_a = this.opts).docKind) == null ? void 0 : _b.call(_a, noteId)) != null ? _c : "note", text2 = doc2.getText(CONTENT_KEY), provider = new NoteProvider(doc2, {
       // Start MUTED until IndexedDB replay finishes (activate() below): the
       // replayed persisted state must NOT be re-broadcast as a fresh local edit
@@ -21745,12 +21781,14 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
    *  cold SEND or fan-out RECEIVE stays room-free. (CrdtChannel.startSync +
    *  CrdtEnrollment.enroll collapse to this.) */
   async startSync(noteId) {
-    this.enrolledIds.add(noteId);
+    this.assertAlive(noteId), this.enrolledIds.add(noteId);
     let e = await this.entry(noteId);
     e.provider.setAdvertised(!0), this.connected && e.provider.setConnected(!0);
   }
   enroll(noteId) {
-    this.enrolledIds.add(noteId), this.startSync(noteId);
+    this.removed.has(noteId) || (this.enrolledIds.add(noteId), this.startSync(noteId).catch((e) => {
+      if (!isDestroyedError(e)) throw e;
+    }));
   }
   /** Close the room: stop advertising syncStep1 on reconnect. SEND/RECEIVE of
    *  ops still work (the note converges over the fan-out); the server room idles
@@ -21992,6 +22030,10 @@ function createCrdtWiring(deps) {
     }
   }), manager = registry, channel = registry, enrollment = registry, onCrdtMessage = (docId, b64) => {
     channel.receive(docId, b64).catch((e) => {
+      if (isDestroyedError(e)) {
+        rlog().info("crdt", `frame dropped for deleted note_id=${docId}`);
+        return;
+      }
       rlog().warn(
         "crdt",
         `handleFrame failed for note_id=${docId}: ${errMsg(e)} \u2014 frame dropped`

--- a/main.js
+++ b/main.js
@@ -12409,6 +12409,24 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let state = this.syncState.get((0, import_obsidian20.normalizePath)(path));
     return state !== void 0 && state.hash !== fnv1a(content);
   }
+  /** Should an inbound delete preserve `disk` as a keep-both conflict copy
+   *  before trashing the file and tearing the CRDT room down?
+   *
+   *  Only when the room actually holds work the server has not acknowledged.
+   *  `needsColdReconcile` alone is NOT sufficient: it is a baseline-vs-disk
+   *  hash proxy, and a note whose content reached the server through the LIVE
+   *  editor binding (rather than a push) trips it while being perfectly
+   *  converged — which made every delete of an opened note leave a spurious
+   *  "(conflict <stamp>)" copy. The undelivered-ops check is the positive
+   *  signal: it is true exactly when tearing the room down would destroy
+   *  something. Oversized notes are excluded (they never entered CRDT).
+   *
+   *  Registries without the probe (older fakes in tests) fall back to the
+   *  drift proxy alone — the pre-existing, copy-happy behavior. */
+  shouldKeepDriftCopy(normalized, disk, noteId) {
+    var _a;
+    return exceedsCrdtNoteLimit(disk, MAX_CRDT_NOTE_BYTES) || !this.needsColdReconcile(normalized, disk) ? !1 : !noteId || typeof ((_a = this.crdt) == null ? void 0 : _a.hasUndeliveredOps) != "function" ? !0 : this.crdt.hasUndeliveredOps(noteId);
+  }
   /** Write a remote-merged CRDT result to disk.
    *  Marks the path recentlyFlushed first so the resulting vault.modify/create
    *  event is suppressed by the recentlyFlushed guard in handleModify (the
@@ -12456,6 +12474,25 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   recordCrdtBaseline(normalized, content) {
     let prev = this.syncState.get(normalized);
     this.syncState.set(normalized, { ...prev, hash: fnv1a(content) });
+  }
+  /** Refresh a LIVE-BOUND note's baseline from the autosave that just landed.
+   *  Fire-and-forget from handleModify's editor-owns-the-file gate (which is
+   *  synchronous): the read is the same `cachedRead` the push path would have
+   *  done on the not-bound route, so this adds no disk work the gate saved.
+   *  Best-effort — a read failure only leaves the baseline as stale as it is
+   *  today, so it must never surface as an error to the vault event. */
+  async recordLiveBoundBaseline(file) {
+    try {
+      this.recordCrdtBaseline(
+        (0, import_obsidian20.normalizePath)(file.path),
+        await this.app.vault.cachedRead(file)
+      );
+    } catch (e) {
+      devLog().log(
+        "crdt",
+        `live-bound baseline refresh failed for ${file.path}: ${errMsg(e)}`
+      );
+    }
   }
   /** Capture an un-pushed on-disk edit into the Y.Doc BEFORE a fanned-out or
    *  cold-received remote update flushes to disk, so CRDT MERGES the local
@@ -12918,8 +12955,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       rlog().info("sync", `Modify echo skip (recently flushed from CRDT): ${file.path}`);
       return;
     }
-    if (crdtManaged && this.isLiveBound(file.path))
+    if (crdtManaged && this.isLiveBound(file.path)) {
+      file instanceof import_obsidian20.TFile && this.recordLiveBoundBaseline(file);
       return;
+    }
     let existing = this.debounceTimers.get(file.path);
     existing && window.clearTimeout(existing);
     let timer = window.setTimeout(() => {
@@ -14087,7 +14126,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       if (existing) {
         try {
           let disk = await this.app.vault.cachedRead(existing);
-          if (!exceedsCrdtNoteLimit(disk, MAX_CRDT_NOTE_BYTES) && this.needsColdReconcile(normalized, disk)) {
+          if (this.shouldKeepDriftCopy(normalized, disk, targetId != null ? targetId : currentId)) {
             let copy2 = await this.writeDriftConflictCopy(normalized, disk);
             rlog().info(
               "conflict",
@@ -14436,7 +14475,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             }
             return !1;
           }
-          if (this.needsColdReconcile(normalized, localContent))
+          if (this.shouldKeepDriftCopy(normalized, localContent, crdtNoteId))
             try {
               let copy2 = await this.writeDriftConflictCopy(
                 normalized,
@@ -21397,6 +21436,18 @@ var NoteProvider = class {
   isFullySynced() {
     return this.connected && this.synced && this.buffer.length === 0;
   }
+  /** True when this doc holds local work the server has NOT received: the
+   *  handshake never completed, or frames are sitting in the offline buffer.
+   *
+   *  Deliberately NOT gated on `connected`, unlike isFullySynced: a doc whose
+   *  frames were all handed to the transport before the socket dropped has
+   *  nothing undelivered, and treating a momentary disconnect as data-at-risk
+   *  would make every offline delete leave a keep-both copy behind. Eviction
+   *  safety needs the stricter question (is the server current RIGHT NOW);
+   *  a destructive path needs this one (would teardown lose anything). */
+  hasUndeliveredWork() {
+    return !this.synced || this.buffer.length > 0;
+  }
   /** Swap the transport (e.g. after a socket reconnect built a fresh channel).
    *  The doc + buffer are untouched. */
   setSend(send) {
@@ -21746,6 +21797,23 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
   async hasPendingGap(noteId) {
     let e = this.entries.get(noteId);
     return e ? e.doc.store.pendingStructs != null : !1;
+  }
+  /** True when this doc holds local work the server has NOT received — the
+   *  handshake never completed, or frames sit in the provider's offline
+   *  buffer. The positive signal a destructive path needs before deciding
+   *  whether tearing the room down would lose anything.
+   *
+   *  NOT `hasPendingGap`: that is a RECEIVE-side causal gap (a delta landed
+   *  before its base), which says nothing about undelivered local edits.
+   *  NOT `!isFullySynced` either — that also demands a CURRENTLY-connected
+   *  transport, so a plain offline window would read as data-at-risk.
+   *
+   *  No resident entry → false: nothing is held locally, so nothing is at risk.
+   *  Conservative by construction — a never-handshook doc reads as
+   *  undelivered, so a caller preserving data errs toward preserving it. */
+  hasUndeliveredOps(noteId) {
+    let e = this.entries.get(noteId);
+    return !e || e.destroyed ? !1 : e.provider.hasUndeliveredWork();
   }
   // --- Lifecycle no-ops the persistent doc doesn't need -----------------------
   /** Relay: the doc is NEVER closed on a transport reconnect (that was the

--- a/main.js
+++ b/main.js
@@ -3786,9 +3786,9 @@ var MERGE_CARD = {
         cls: "engram-sync-preview-picker-error"
       });
     else if (this.state.vaults && this.state.vaults.length > 0) {
-      let list = body.createDiv({ cls: "engram-sync-preview-picker-list" });
+      let list2 = body.createDiv({ cls: "engram-sync-preview-picker-list" });
       for (let v of this.state.vaults) {
-        let item = list.createEl("button", {
+        let item = list2.createEl("button", {
           cls: "engram-sync-preview-picker-item"
         });
         item.createSpan({
@@ -3988,7 +3988,7 @@ function makeActionButton(parent, text2, handler) {
   });
 }
 function renderPlanSkips(parent, plugin, refresh) {
-  let groups = groupedByCategory(plugin.syncEngine.issues.all(), ["informational"]), total = groups.reduce((n, [, list]) => n + list.length, 0);
+  let groups = groupedByCategory(plugin.syncEngine.issues.all(), ["informational"]), total = groups.reduce((n, [, list2]) => n + list2.length, 0);
   if (total === 0) return;
   let section = parent.createDiv({
     cls: "engram-sync-center-section engram-sync-center-plan-section"
@@ -3999,8 +3999,8 @@ function renderPlanSkips(parent, plugin, refresh) {
     cls: "engram-sync-center-card-hint",
     text: "These files are fine. They just need a paid plan to sync."
   });
-  for (let [category, list] of groups)
-    renderPlanCard(body, plugin, refresh, category, list);
+  for (let [category, list2] of groups)
+    renderPlanCard(body, plugin, refresh, category, list2);
 }
 function renderPlanCard(parent, plugin, refresh, category, issues) {
   var _a, _b, _c;
@@ -4024,13 +4024,13 @@ function renderPlanCard(parent, plugin, refresh, category, issues) {
     renderFileRow(fileList, plugin, refresh, issue);
 }
 function renderNeedsAttention(parent, plugin, refresh) {
-  let groups = groupedByCategory(plugin.syncEngine.issues.all(), ["actionable"]), total = groups.reduce((n, [, list]) => n + list.length, 0), section = parent.createDiv({
+  let groups = groupedByCategory(plugin.syncEngine.issues.all(), ["actionable"]), total = groups.reduce((n, [, list2]) => n + list2.length, 0), section = parent.createDiv({
     cls: "engram-sync-center-section engram-sync-center-attention-section"
   }), heading2 = sectionHeading(section, `Needs attention (${total})`);
   total > 0 && heading2.addButton(
     (btn) => btn.setButtonText("Clear all").onClick(() => {
-      for (let [, list] of groups)
-        for (let issue of list) plugin.syncEngine.issues.clear(issue.path);
+      for (let [, list2] of groups)
+        for (let issue of list2) plugin.syncEngine.issues.clear(issue.path);
       plugin.persistEngineState().then(refresh);
     })
   );
@@ -4042,8 +4042,8 @@ function renderNeedsAttention(parent, plugin, refresh) {
     });
     return;
   }
-  for (let [category, list] of groups)
-    renderAttentionCard(body, plugin, refresh, category, list);
+  for (let [category, list2] of groups)
+    renderAttentionCard(body, plugin, refresh, category, list2);
 }
 function renderAttentionCard(parent, plugin, refresh, category, issues) {
   var _a, _b;
@@ -4066,7 +4066,7 @@ function renderAttentionCard(parent, plugin, refresh, category, issues) {
     renderFileRow(fileList, plugin, refresh, issue);
 }
 function renderRetrying(parent, plugin, refresh) {
-  let groups = groupedByCategory(plugin.syncEngine.issues.all(), ["transient"]), total = groups.reduce((n, [, list2]) => n + list2.length, 0);
+  let groups = groupedByCategory(plugin.syncEngine.issues.all(), ["transient"]), total = groups.reduce((n, [, list3]) => n + list3.length, 0);
   if (total === 0) return;
   let section = parent.createDiv({ cls: "engram-sync-center-section" });
   sectionHeading(section, `Retrying automatically (${total})`).addButton(
@@ -4079,9 +4079,9 @@ function renderRetrying(parent, plugin, refresh) {
     cls: "engram-sync-center-card-hint",
     text: "Temporary errors. These clear themselves once the server recovers."
   });
-  let list = body.createDiv({ cls: "engram-sync-center-issue-list" });
+  let list2 = body.createDiv({ cls: "engram-sync-center-issue-list" });
   for (let [, issues] of groups)
-    for (let issue of issues) renderFileRow(list, plugin, refresh, issue);
+    for (let issue of issues) renderFileRow(list2, plugin, refresh, issue);
 }
 function renderFileRow(parent, plugin, refresh, issue) {
   var _a;
@@ -4110,9 +4110,9 @@ function renderIgnored(parent, plugin, refresh) {
     });
     return;
   }
-  let list = body.createDiv({ cls: "engram-sync-center-issue-list" });
+  let list2 = body.createDiv({ cls: "engram-sync-center-issue-list" });
   for (let path of ignored)
-    renderIgnoredRow(list, plugin, refresh, path);
+    renderIgnoredRow(list2, plugin, refresh, path);
 }
 function renderIgnoredRow(parent, plugin, refresh, path) {
   let row = parent.createDiv({ cls: "engram-sync-center-issue-row" });
@@ -4162,9 +4162,9 @@ function renderActivity(parent, plugin, refresh) {
     });
     return;
   }
-  let list = body.createDiv({ cls: "engram-sync-center-activity-list" }), recent = all2.slice(-ACTIVITY_LIMIT).reverse();
+  let list2 = body.createDiv({ cls: "engram-sync-center-activity-list" }), recent = all2.slice(-ACTIVITY_LIMIT).reverse();
   for (let entry of recent)
-    renderActivityRow(list, entry);
+    renderActivityRow(list2, entry);
 }
 function renderActivityRow(parent, entry) {
   var _a;
@@ -4577,8 +4577,8 @@ function renderAboutTab(ctx) {
   let plans = containerEl.createEl("ul", { cls: "engram-plans" }), plan = (name, features) => {
     let card = plans.createEl("li", { cls: "engram-plan" });
     card.createEl("h4", { text: name });
-    let list = card.createEl("ul", { cls: "engram-plan-features" });
-    for (let feature of features) list.createEl("li", { text: feature });
+    let list2 = card.createEl("ul", { cls: "engram-plan-features" });
+    for (let feature of features) list2.createEl("li", { text: feature });
   };
   plan("Free", [
     "1 vault, 1 device",
@@ -16224,6 +16224,12 @@ var SAVE_NUDGE_DEBOUNCE_MS = 300, ViewerRefcount = class {
   isBound(path) {
     return this.refcount.isBound(path);
   }
+  /** Every path an editor is currently bound to. Enumerable (not just the
+   *  isBound predicate) so the invariant checker can assert properties ACROSS
+   *  the whole binding set, e.g. every bound path resolves to a note_id. */
+  boundPaths() {
+    return this.refcount.boundPaths();
+  }
   /** Fix wave 6: nudge Obsidian's own save pipeline for the bound editor
    *  showing `path`, after a remote merge painted into it. `onFlushToDisk`
    *  skips the disk write for a bound path (the editor owns the file) — but
@@ -16430,6 +16436,96 @@ function isDestroyedError(error) {
   return error instanceof DestroyedError;
 }
 
+// src/crdt/invariants.ts
+var list = (items, max2 = 5) => {
+  let all2 = [...items], head = all2.slice(0, max2).join(", ");
+  return all2.length > max2 ? `${head} (+${all2.length - max2} more)` : head;
+}, STANDARD_INVARIANTS = [
+  {
+    id: "removed-implies-not-resident",
+    description: "A tombstoned note must have no resident Y.Doc",
+    check(ctx) {
+      let bad = [...ctx.removedNoteIds].filter((id2) => ctx.residentNoteIds.has(id2));
+      return bad.length ? `resident docs for removed note_ids: ${list(bad)}` : null;
+    }
+  },
+  {
+    id: "removed-implies-not-enrolled",
+    description: "A tombstoned note must not hold an open room",
+    check(ctx) {
+      let bad = [...ctx.removedNoteIds].filter((id2) => ctx.enrolledNoteIds.has(id2));
+      return bad.length ? `open rooms for removed note_ids: ${list(bad)}` : null;
+    }
+  },
+  {
+    id: "enrolled-implies-resident",
+    description: "An enrolled note must have a resident doc to advertise",
+    check(ctx) {
+      let bad = [...ctx.enrolledNoteIds].filter((id2) => !ctx.residentNoteIds.has(id2));
+      return bad.length ? `enrolled but not resident: ${list(bad)}` : null;
+    }
+  },
+  {
+    id: "live-bound-implies-mapped",
+    description: "A live-bound path must resolve to a note_id",
+    check(ctx) {
+      let bad = [...ctx.liveBoundPaths].filter((p) => ctx.idForPath(p) === null);
+      return bad.length ? `live-bound paths with no note_id: ${list(bad)}` : null;
+    }
+  },
+  {
+    id: "id-map-bijective",
+    description: "path\u2192id and id\u2192path must agree in both directions",
+    check(ctx) {
+      let bad = [];
+      for (let path of ctx.mappedPaths) {
+        let id2 = ctx.idForPath(path);
+        id2 !== null && ctx.pathForId(id2) !== path && bad.push(`${path}\u2192${id2}\u2192${ctx.pathForId(id2)}`);
+      }
+      return bad.length ? `id-map direction mismatch: ${list(bad)}` : null;
+    }
+  }
+], InvariantChecker = class {
+  constructor(opts) {
+    this.opts = opts;
+    this.timer = null;
+    var _a;
+    this.invariants = (_a = opts.invariants) != null ? _a : STANDARD_INVARIANTS;
+  }
+  /** Run every invariant once. Returns the violations found (also reported via
+   *  onViolation). A throwing invariant is itself a violation — a check that
+   *  cannot evaluate is never evidence that the property holds. */
+  async checkAll() {
+    let ctx = this.opts.getContext(), violations = [];
+    for (let inv of this.invariants) {
+      let detail;
+      try {
+        detail = await inv.check(ctx);
+      } catch (e) {
+        detail = `check threw: ${e instanceof Error ? e.message : String(e)}`;
+      }
+      if (detail !== null) {
+        let violation = { id: inv.id, description: inv.description, detail };
+        violations.push(violation), this.opts.onViolation(violation);
+      }
+    }
+    return violations;
+  }
+  startPeriodicChecks(ms) {
+    var _a;
+    if (this.timer !== null) return;
+    let schedule = (_a = this.opts.setInterval) != null ? _a : ((cb, delay) => window.setInterval(cb, delay));
+    this.timer = schedule(() => {
+      this.checkAll();
+    }, ms);
+  }
+  stop() {
+    var _a;
+    if (this.timer === null) return;
+    ((_a = this.opts.clearInterval) != null ? _a : ((id2) => window.clearInterval(id2)))(this.timer), this.timer = null;
+  }
+};
+
 // node_modules/lib0/indexeddb.js
 var rtop = (request) => create4((resolve, reject) => {
   request.onerror = (event) => reject(new Error(event.target.error)), request.onsuccess = (event) => resolve(event.target.result);
@@ -16564,6 +16660,68 @@ var IndexeddbPersistence = class extends Observable {
       let [custom] = transact2(db, [customStoreName]);
       return del(custom, key);
     });
+  }
+};
+
+// src/lifetime.ts
+var asError = (e) => e instanceof Error ? e : new Error(String(e)), Lifetime = class {
+  constructor() {
+    this.ended = !1;
+    this.controller = new AbortController();
+    this.endListeners = /* @__PURE__ */ new Set();
+  }
+  get signal() {
+    return this.controller.signal;
+  }
+  get active() {
+    return !this.ended;
+  }
+  get reason() {
+    return this.endReason;
+  }
+  /** The rejection value. A lifetime always ends WITH a reason in practice
+   *  (NoteDestroyedError); the fallback keeps the reject type honestly `Error`
+   *  rather than `unknown`, so callers can catch on type. */
+  get rejection() {
+    var _a;
+    return (_a = this.endReason) != null ? _a : new Error("Lifetime ended");
+  }
+  /** Subscribe to the end. Fires immediately if already ended. Returns an
+   *  unsubscribe. */
+  onEnded(listener) {
+    return this.ended ? (listener(this.rejection), () => {
+    }) : (this.endListeners.add(listener), () => {
+      this.endListeners.delete(listener);
+    });
+  }
+  /** Run `operation` under this lifetime. Rejects with the end reason if the
+   *  lifetime is already over, or the instant it ends — whichever comes first —
+   *  rather than waiting for the operation to settle into a dead owner. */
+  guard(operation) {
+    if (this.ended) return Promise.reject(this.rejection);
+    let promise;
+    try {
+      promise = typeof operation == "function" ? operation(this.signal) : operation;
+    } catch (error) {
+      return Promise.reject(asError(error));
+    }
+    return this.ended ? (promise.catch(() => {
+    }), Promise.reject(this.rejection)) : new Promise((resolve, reject) => {
+      let settled = !1, finish = (fn) => {
+        settled || (settled = !0, this.signal.removeEventListener("abort", onEnd), fn());
+      }, onEnd = () => finish(() => reject(this.rejection));
+      this.signal.addEventListener("abort", onEnd, { once: !0 }), promise.then(
+        (value) => finish(() => resolve(value)),
+        (error) => finish(() => reject(asError(error)))
+      );
+    });
+  }
+  end(reason) {
+    if (!this.ended) {
+      this.ended = !0, this.endReason = reason, this.controller.abort();
+      for (let listener of Array.from(this.endListeners)) listener(reason);
+      this.endListeners.clear();
+    }
   }
 };
 
@@ -20636,15 +20794,15 @@ var LineCounter = class {
 };
 
 // node_modules/yaml/browser/dist/parse/parser.js
-function includesToken(list, type) {
-  for (let i = 0; i < list.length; ++i)
-    if (list[i].type === type)
+function includesToken(list2, type) {
+  for (let i = 0; i < list2.length; ++i)
+    if (list2[i].type === type)
       return !0;
   return !1;
 }
-function findNonEmptyIndex(list) {
-  for (let i = 0; i < list.length; ++i)
-    switch (list[i].type) {
+function findNonEmptyIndex(list2) {
+  for (let i = 0; i < list2.length; ++i)
+    switch (list2[i].type) {
       case "space":
       case "comment":
       case "newline":
@@ -21594,6 +21752,11 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
   get docs() {
     return this.entries;
   }
+  /** note_ids tombstoned by removeDoc. Exposed for the invariant checker, which
+   *  asserts a removed note holds neither a resident doc nor an open room. */
+  get removedIds() {
+    return this.removed;
+  }
   /** Wire key == note_id (matches the backend's bare-UUID crdt_msg). */
   docId(noteId) {
     return noteId;
@@ -21614,7 +21777,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
   }
   async entry(noteId) {
     let e = this.ensureEntrySync(noteId);
-    return await e.ready, e;
+    return await e.lifetime.guard(e.ready), e;
   }
   /** Synchronously get-or-create the resident entry WITHOUT awaiting IndexedDB
    *  hydration. The Y.Doc + Y.Text exist immediately (empty until hydrated);
@@ -21655,10 +21818,10 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
       ready: Promise.resolve(),
       remoteSeq: 0,
       pendingFlush: null,
-      destroyed: !1
+      lifetime: new Lifetime()
     };
     return doc2.on("update", (_u, origin) => {
-      if (entry.destroyed || origin !== provider && origin !== REMOTE) return;
+      if (!entry.lifetime.active || origin !== provider && origin !== REMOTE) return;
       entry.remoteSeq += 1;
       let flush = Promise.resolve(
         this.opts.onFlushToDisk(noteId, this.project(entry))
@@ -21709,7 +21872,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
     var _a, _b;
     if (this.removed.has(noteId)) return null;
     let e = await this.entry(noteId);
-    if (e.destroyed) return null;
+    if (!e.lifetime.active) return null;
     let content = diskContent;
     if (reread) {
       let stable = !1;
@@ -21738,7 +21901,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
   async applyRemoteUpdate(noteId, update) {
     if (this.removed.has(noteId)) return;
     let e = await this.entry(noteId);
-    if (e.destroyed) return;
+    if (!e.lifetime.active) return;
     applyUpdate(e.doc, update, e.provider);
     let flush = e.pendingFlush;
     flush && (e.pendingFlush = null, await flush);
@@ -21851,7 +22014,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
    *  undelivered, so a caller preserving data errs toward preserving it. */
   hasUndeliveredOps(noteId) {
     let e = this.entries.get(noteId);
-    return !e || e.destroyed ? !1 : e.provider.hasUndeliveredWork();
+    return !e || !e.lifetime.active ? !1 : e.provider.hasUndeliveredWork();
   }
   // --- Lifecycle no-ops the persistent doc doesn't need -----------------------
   /** Relay: the doc is NEVER closed on a transport reconnect (that was the
@@ -21869,7 +22032,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
    *  data-loss class ("moving between files, only some make it"). */
   closeDoc(noteId) {
     let e = this.entries.get(noteId);
-    e && !e.destroyed && e.provider.isFullySynced() && this.destroy(noteId, !1);
+    e != null && e.lifetime.active && e.provider.isFullySynced() && this.destroy(noteId, !1);
   }
   /** No LRU eviction — the doc is persistent; protect/unprotect are no-ops. */
   protect(_noteId) {
@@ -21887,7 +22050,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
   }
   async destroy(noteId, clearData) {
     let e = this.entries.get(noteId);
-    if (e && (e.destroyed = !0), !e) {
+    if (e && e.lifetime.end(new NoteDestroyedError(noteId)), !e) {
       clearData && await new Promise((resolve) => {
         let req = indexedDB.deleteDatabase(this.storeName(noteId));
         req.onsuccess = req.onerror = req.onblocked = () => resolve();
@@ -21903,7 +22066,7 @@ var REMOTE = /* @__PURE__ */ Symbol("remote"), ProviderRegistry = class {
 };
 
 // src/crdt/wiring.ts
-var DEFAULT_STRAND_HEAL_DEBOUNCE_MS = 750, STRAND_HEAL_MAX_ATTEMPTS = 5, MAX_UNSENT_DOCS = 500;
+var INVARIANT_CHECK_INTERVAL_MS = 6e4, DEFAULT_STRAND_HEAL_DEBOUNCE_MS = 750, STRAND_HEAL_MAX_ATTEMPTS = 5, MAX_UNSENT_DOCS = 500;
 function partitionStrandedFlushes(pending, resolvePath, attempts, maxAttempts) {
   var _a;
   let toFlush = [], toRetry = [], toGiveUp = [];
@@ -22052,9 +22215,26 @@ function createCrdtWiring(deps) {
     path !== null && deps.isBound(path) && enrollment.enroll(docId);
   }, onCrdtNoteNotFound = (docId) => {
     syncEngine.isSyncBlocked() || syncEngine.ensureNoteIdMapped(docId);
-  };
+  }, invariants = new InvariantChecker({
+    getContext: () => {
+      var _a2, _b;
+      return {
+        removedNoteIds: registry.removedIds,
+        residentNoteIds: new Set(registry.docs.keys()),
+        enrolledNoteIds: registry.enrolled,
+        liveBoundPaths: new Set((_b = (_a2 = deps.boundPaths) == null ? void 0 : _a2.call(deps)) != null ? _b : []),
+        mappedPaths: new Set(Object.keys(noteIdMap.toJSON())),
+        pathForId: (id2) => noteIdMap.pathForId(id2),
+        idForPath: (path) => noteIdMap.get(path)
+      };
+    },
+    onViolation: (v) => {
+      rlog().warn("crdt", `invariant violated [${v.id}]: ${v.detail}`);
+    }
+  });
+  invariants.startPeriodicChecks(INVARIANT_CHECK_INTERVAL_MS);
   function dispose() {
-    strandHealTimer !== null && (window.clearTimeout(strandHealTimer), strandHealTimer = null);
+    invariants.stop(), strandHealTimer !== null && (window.clearTimeout(strandHealTimer), strandHealTimer = null);
   }
   return {
     manager,
@@ -22065,6 +22245,8 @@ function createCrdtWiring(deps) {
     onCrdtNoteNotFound,
     onNoteYjsUpdate,
     drainStrandedFlushes,
+    /** On-demand invariant sweep (Sync Center / e2e probe). */
+    checkInvariants: () => invariants.checkAll(),
     clearStrandHealAttempts: () => strandHealAttempts.clear(),
     reEnrollUnsent: () => {
       for (let id2 of [...unsentDocIds]) enrollment.enroll(id2);
@@ -22274,9 +22456,9 @@ var import_obsidian25 = require("obsidian"), ACTION_ICONS = {
     }).setText(
       entries.length === 0 ? "No sync activity this session." : `Showing ${entries.length} entries${errorCount > 0 ? ` (${errorCount} errors)` : ""}`
     ), entries.length === 0) return;
-    let list = contentEl.createDiv({ cls: "engram-sync-log-list" });
+    let list2 = contentEl.createDiv({ cls: "engram-sync-log-list" });
     for (let entry of entries) {
-      let row = list.createDiv({ cls: "engram-sync-log-entry" }), time = entry.timestamp.toLocaleTimeString([], {
+      let row = list2.createDiv({ cls: "engram-sync-log-entry" }), time = entry.timestamp.toLocaleTimeString([], {
         hour: "2-digit",
         minute: "2-digit",
         second: "2-digit"
@@ -23176,6 +23358,10 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
             isBound: (path) => {
               var _a3, _b2;
               return (_b2 = (_a3 = this.crdtLiveViews) == null ? void 0 : _a3.isBound(path)) != null ? _b2 : !1;
+            },
+            boundPaths: () => {
+              var _a3, _b2;
+              return (_b2 = (_a3 = this.crdtLiveViews) == null ? void 0 : _a3.boundPaths()) != null ? _b2 : [];
             },
             // Fix wave 6: nudge Obsidian's save pipeline after a remote merge
             // paints into an unfocused bound editor (CI doesn't flush it).

--- a/src/crdt/destroyed-error.ts
+++ b/src/crdt/destroyed-error.ts
@@ -1,0 +1,43 @@
+/**
+ * Liveness errors for torn-down CRDT docs.
+ *
+ * Ported from Relay (`src/DestroyedError.ts` + `src/DocumentDestroyedError.ts`),
+ * whose contract we adopt wholesale: touching a destroyed doc is an ERROR, not
+ * a get-or-create. Our registry previously answered "give me the doc for this
+ * note" by silently constructing a fresh one, so a late frame for a DELETED
+ * note rebuilt its room, completed an empty handshake, and materialized an
+ * empty file at the deleted path. Relay makes that state unrepresentable: the
+ * doc is dead, the access throws, and the caller decides explicitly.
+ *
+ * Callers that legitimately race a delete catch it (see `isDestroyedError`) —
+ * mirroring Relay's LiveViews/SharedFolder call sites, which swallow exactly
+ * this error and nothing else.
+ */
+
+export class DestroyedError extends Error {
+	constructor(
+		public readonly owner: string,
+		public readonly detail?: string,
+	) {
+		super(detail ? `${owner} was destroyed: ${detail}` : `${owner} was destroyed`);
+		this.name = "DestroyedError";
+	}
+}
+
+export class NoteDestroyedError extends DestroyedError {
+	constructor(
+		public readonly noteId: string,
+		public readonly path?: string,
+	) {
+		super("Note", path ? `${path} (${noteId})` : noteId);
+		this.name = "NoteDestroyedError";
+	}
+}
+
+export function isDestroyedError(error: unknown): error is DestroyedError {
+	return error instanceof DestroyedError;
+}
+
+export function isNoteDestroyedError(error: unknown): error is NoteDestroyedError {
+	return error instanceof NoteDestroyedError;
+}

--- a/src/crdt/invariants.ts
+++ b/src/crdt/invariants.ts
@@ -1,0 +1,150 @@
+/**
+ * Runtime invariant checking.
+ *
+ * Ported from Relay (`src/merge-hsm/invariants/`). The gap this closes: we
+ * already DETECT broken sync state — `drift on X (editor 7 vs doc 6)` is a log
+ * line we emit, silently repair, and move on from. That is an invariant
+ * violation we tolerate instead of a contract we enforce, which is why the
+ * live-bound baseline could rot for weeks before a delete turned it into a
+ * user-visible artifact.
+ *
+ * Each invariant is NAMED, so a violation is reportable and greppable rather
+ * than inferred from a symptom. All checks here are in-memory and cheap; the
+ * signature is async-capable so a disk-reading invariant
+ * (`synced-means-disk-matches-baseline`) can be added without redesign.
+ */
+
+export interface InvariantContext {
+	/** note_ids tombstoned by removeDoc. */
+	removedNoteIds: ReadonlySet<string>;
+	/** note_ids with a resident Y.Doc in the registry. */
+	residentNoteIds: ReadonlySet<string>;
+	/** note_ids advertising syncStep1 (an OPEN room). */
+	enrolledNoteIds: ReadonlySet<string>;
+	/** Vault paths the live editor is currently bound to. */
+	liveBoundPaths: ReadonlySet<string>;
+	/** Every path currently carrying an id mapping. */
+	mappedPaths: ReadonlySet<string>;
+	pathForId(noteId: string): string | null;
+	idForPath(path: string): string | null;
+}
+
+export interface InvariantViolation {
+	id: string;
+	description: string;
+	detail: string;
+}
+
+export interface InvariantDefinition {
+	id: string;
+	description: string;
+	/** Return a detail string when VIOLATED, or null when it holds. */
+	check(ctx: InvariantContext): string | null | Promise<string | null>;
+}
+
+const list = (items: Iterable<string>, max = 5): string => {
+	const all = [...items];
+	const head = all.slice(0, max).join(", ");
+	return all.length > max ? `${head} (+${all.length - max} more)` : head;
+};
+
+export const STANDARD_INVARIANTS: InvariantDefinition[] = [
+	{
+		id: "removed-implies-not-resident",
+		description: "A tombstoned note must have no resident Y.Doc",
+		check(ctx) {
+			const bad = [...ctx.removedNoteIds].filter((id) => ctx.residentNoteIds.has(id));
+			return bad.length ? `resident docs for removed note_ids: ${list(bad)}` : null;
+		},
+	},
+	{
+		id: "removed-implies-not-enrolled",
+		description: "A tombstoned note must not hold an open room",
+		check(ctx) {
+			const bad = [...ctx.removedNoteIds].filter((id) => ctx.enrolledNoteIds.has(id));
+			return bad.length ? `open rooms for removed note_ids: ${list(bad)}` : null;
+		},
+	},
+	{
+		id: "enrolled-implies-resident",
+		description: "An enrolled note must have a resident doc to advertise",
+		check(ctx) {
+			const bad = [...ctx.enrolledNoteIds].filter((id) => !ctx.residentNoteIds.has(id));
+			return bad.length ? `enrolled but not resident: ${list(bad)}` : null;
+		},
+	},
+	{
+		id: "live-bound-implies-mapped",
+		description: "A live-bound path must resolve to a note_id",
+		check(ctx) {
+			const bad = [...ctx.liveBoundPaths].filter((p) => ctx.idForPath(p) === null);
+			return bad.length ? `live-bound paths with no note_id: ${list(bad)}` : null;
+		},
+	},
+	{
+		id: "id-map-bijective",
+		description: "path→id and id→path must agree in both directions",
+		check(ctx) {
+			const bad: string[] = [];
+			for (const path of ctx.mappedPaths) {
+				const id = ctx.idForPath(path);
+				if (id === null) continue;
+				if (ctx.pathForId(id) !== path) bad.push(`${path}→${id}→${ctx.pathForId(id)}`);
+			}
+			return bad.length ? `id-map direction mismatch: ${list(bad)}` : null;
+		},
+	},
+];
+
+export interface InvariantCheckerOpts {
+	getContext: () => InvariantContext;
+	onViolation: (violation: InvariantViolation) => void;
+	invariants?: InvariantDefinition[];
+	/** Timer injection so periodic checking is testable (see TimeProvider). */
+	setInterval?: (cb: () => void, ms: number) => number;
+	clearInterval?: (id: number) => void;
+}
+
+export class InvariantChecker {
+	private timer: number | null = null;
+	private readonly invariants: InvariantDefinition[];
+
+	constructor(private readonly opts: InvariantCheckerOpts) {
+		this.invariants = opts.invariants ?? STANDARD_INVARIANTS;
+	}
+
+	/** Run every invariant once. Returns the violations found (also reported via
+	 *  onViolation). A throwing invariant is itself a violation — a check that
+	 *  cannot evaluate is never evidence that the property holds. */
+	async checkAll(): Promise<InvariantViolation[]> {
+		const ctx = this.opts.getContext();
+		const violations: InvariantViolation[] = [];
+		for (const inv of this.invariants) {
+			let detail: string | null;
+			try {
+				detail = await inv.check(ctx);
+			} catch (e) {
+				detail = `check threw: ${e instanceof Error ? e.message : String(e)}`;
+			}
+			if (detail !== null) {
+				const violation = { id: inv.id, description: inv.description, detail };
+				violations.push(violation);
+				this.opts.onViolation(violation);
+			}
+		}
+		return violations;
+	}
+
+	startPeriodicChecks(ms: number): void {
+		if (this.timer !== null) return;
+		const schedule = this.opts.setInterval ?? ((cb, delay) => window.setInterval(cb, delay));
+		this.timer = schedule(() => void this.checkAll(), ms);
+	}
+
+	stop(): void {
+		if (this.timer === null) return;
+		const cancel = this.opts.clearInterval ?? ((id: number) => window.clearInterval(id));
+		cancel(this.timer);
+		this.timer = null;
+	}
+}

--- a/src/crdt/live/live-views.ts
+++ b/src/crdt/live/live-views.ts
@@ -143,6 +143,13 @@ export class CrdtLiveViews implements LiveBindingCoordinator {
 		return this.refcount.isBound(path);
 	}
 
+	/** Every path an editor is currently bound to. Enumerable (not just the
+	 *  isBound predicate) so the invariant checker can assert properties ACROSS
+	 *  the whole binding set, e.g. every bound path resolves to a note_id. */
+	boundPaths(): string[] {
+		return this.refcount.boundPaths();
+	}
+
 	/** Fix wave 6: nudge Obsidian's own save pipeline for the bound editor
 	 *  showing `path`, after a remote merge painted into it. `onFlushToDisk`
 	 *  skips the disk write for a bound path (the editor owns the file) — but

--- a/src/crdt/note-provider.ts
+++ b/src/crdt/note-provider.ts
@@ -131,6 +131,19 @@ export class NoteProvider {
 		return this.connected && this.synced && this.buffer.length === 0;
 	}
 
+	/** True when this doc holds local work the server has NOT received: the
+	 *  handshake never completed, or frames are sitting in the offline buffer.
+	 *
+	 *  Deliberately NOT gated on `connected`, unlike isFullySynced: a doc whose
+	 *  frames were all handed to the transport before the socket dropped has
+	 *  nothing undelivered, and treating a momentary disconnect as data-at-risk
+	 *  would make every offline delete leave a keep-both copy behind. Eviction
+	 *  safety needs the stricter question (is the server current RIGHT NOW);
+	 *  a destructive path needs this one (would teardown lose anything). */
+	hasUndeliveredWork(): boolean {
+		return !this.synced || this.buffer.length > 0;
+	}
+
 	/** Swap the transport (e.g. after a socket reconnect built a fresh channel).
 	 *  The doc + buffer are untouched. */
 	setSend(send: ProviderSend): void {

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -12,6 +12,7 @@
 // re-handshake) become no-ops the persistent doc doesn't need.
 import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
+import { Lifetime } from "../lifetime";
 import { projectCanvas, seedCanvasInto } from "./canvas-codec";
 import { NoteDestroyedError, isDestroyedError } from "./destroyed-error";
 import { CONTENT_KEY, frontmatterOf, projectNote, rawFrontmatterOf } from "./frontmatter-codec";
@@ -39,10 +40,12 @@ interface Entry {
 	/** In-flight disk-flush from the last remote merge; applyRemoteUpdate awaits
 	 *  it so a write failure can leave crdtHead unadvanced (#235). */
 	pendingFlush: Promise<void> | null;
-	/** Set the instant removeDoc/destroy begins (before doc.destroy()), so an
-	 *  in-flight operation that captured this entry across an await bails instead
-	 *  of seeding/applying/flushing onto a dead doc (delete-note resurrection). */
-	destroyed: boolean;
+	/** Ownership window for this doc. Ended the instant removeDoc/destroy begins
+	 *  (before doc.destroy()), so an in-flight operation that captured this entry
+	 *  across an await is ABANDONED rather than resuming onto a dead doc
+	 *  (delete-note resurrection). `lifetime.guard(...)` races the await against
+	 *  the end; `lifetime.active` is the cheap synchronous check. */
+	lifetime: Lifetime;
 }
 
 export interface ProviderRegistryOpts {
@@ -101,6 +104,12 @@ export class ProviderRegistry {
 		return this.entries;
 	}
 
+	/** note_ids tombstoned by removeDoc. Exposed for the invariant checker, which
+	 *  asserts a removed note holds neither a resident doc nor an open room. */
+	get removedIds(): ReadonlySet<string> {
+		return this.removed;
+	}
+
 	/** Wire key == note_id (matches the backend's bare-UUID crdt_msg). */
 	docId(noteId: string): string {
 		return noteId;
@@ -125,7 +134,10 @@ export class ProviderRegistry {
 
 	private async entry(noteId: string): Promise<Entry> {
 		const e = this.ensureEntrySync(noteId);
-		await e.ready;
+		// Guarded, not a bare await: a removeDoc landing DURING IndexedDB
+		// hydration abandons this continuation immediately (rejects with
+		// NoteDestroyedError) instead of resuming to hand back a dead entry.
+		await e.lifetime.guard(e.ready);
 		return e;
 	}
 
@@ -175,13 +187,13 @@ export class ProviderRegistry {
 			ready: Promise.resolve(),
 			remoteSeq: 0,
 			pendingFlush: null,
-			destroyed: false,
+			lifetime: new Lifetime(),
 		};
 		// Disk-flush listener: a REMOTE merge (origin === provider from
 		// readSyncMessage, or REMOTE from applyRemoteUpdate) writes back to disk.
 		// Local edits (editor/default origin) and IndexedDB replay do NOT flush.
 		doc.on("update", (_u: Uint8Array, origin: unknown) => {
-			if (entry.destroyed) return; // deleted mid-flight — never flush a dead doc
+			if (!entry.lifetime.active) return; // deleted mid-flight — never flush a dead doc
 			if (origin !== provider && origin !== REMOTE) return;
 			entry.remoteSeq += 1;
 			const flush = Promise.resolve(
@@ -262,7 +274,7 @@ export class ProviderRegistry {
 	): Promise<string | null> {
 		if (this.removed.has(noteId)) return null; // deleted — don't resurrect
 		const e = await this.entry(noteId);
-		if (e.destroyed) return null; // destroyed while we awaited hydration
+		if (!e.lifetime.active) return null; // destroyed while we awaited hydration
 		let content = diskContent;
 
 		// Stale-snapshot revert guard (e2e test_83): diskContent was read before
@@ -309,7 +321,7 @@ export class ProviderRegistry {
 	async applyRemoteUpdate(noteId: string, update: Uint8Array): Promise<void> {
 		if (this.removed.has(noteId)) return; // deleted — a late fan-out must not resurrect
 		const e = await this.entry(noteId);
-		if (e.destroyed) return; // destroyed while we awaited hydration
+		if (!e.lifetime.active) return; // destroyed while we awaited hydration
 		// Apply with the PROVIDER as origin (NOT a distinct REMOTE symbol): the
 		// provider's update handler suppresses its own origin, so a fanned-out update
 		// is NOT re-broadcast to the server. Applying it as a foreign origin (the old
@@ -471,7 +483,7 @@ export class ProviderRegistry {
 	 *  undelivered, so a caller preserving data errs toward preserving it. */
 	hasUndeliveredOps(noteId: string): boolean {
 		const e = this.entries.get(noteId);
-		if (!e || e.destroyed) return false;
+		if (!e || !e.lifetime.active) return false;
 		return e.provider.hasUndeliveredWork();
 	}
 
@@ -492,7 +504,7 @@ export class ProviderRegistry {
 	 *  data-loss class ("moving between files, only some make it"). */
 	closeDoc(noteId: string): void {
 		const e = this.entries.get(noteId);
-		if (e && !e.destroyed && e.provider.isFullySynced()) void this.destroy(noteId, false);
+		if (e?.lifetime.active && e.provider.isFullySynced()) void this.destroy(noteId, false);
 	}
 
 	/** No LRU eviction — the doc is persistent; protect/unprotect are no-ops. */
@@ -514,7 +526,8 @@ export class ProviderRegistry {
 
 	private async destroy(noteId: string, clearData: boolean): Promise<void> {
 		const e = this.entries.get(noteId);
-		if (e) e.destroyed = true; // set BEFORE any await so in-flight ops bail
+		// End BEFORE any await so in-flight ops are abandoned, not merely checked.
+		if (e) e.lifetime.end(new NoteDestroyedError(noteId));
 		if (!e) {
 			if (clearData) {
 				await new Promise<void>((resolve) => {

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -433,6 +433,25 @@ export class ProviderRegistry {
 		return store.pendingStructs != null;
 	}
 
+	/** True when this doc holds local work the server has NOT received — the
+	 *  handshake never completed, or frames sit in the provider's offline
+	 *  buffer. The positive signal a destructive path needs before deciding
+	 *  whether tearing the room down would lose anything.
+	 *
+	 *  NOT `hasPendingGap`: that is a RECEIVE-side causal gap (a delta landed
+	 *  before its base), which says nothing about undelivered local edits.
+	 *  NOT `!isFullySynced` either — that also demands a CURRENTLY-connected
+	 *  transport, so a plain offline window would read as data-at-risk.
+	 *
+	 *  No resident entry → false: nothing is held locally, so nothing is at risk.
+	 *  Conservative by construction — a never-handshook doc reads as
+	 *  undelivered, so a caller preserving data errs toward preserving it. */
+	hasUndeliveredOps(noteId: string): boolean {
+		const e = this.entries.get(noteId);
+		if (!e || e.destroyed) return false;
+		return e.provider.hasUndeliveredWork();
+	}
+
 	// --- Lifecycle no-ops the persistent doc doesn't need -----------------------
 
 	/** Relay: the doc is NEVER closed on a transport reconnect (that was the

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -13,6 +13,7 @@
 import { IndexeddbPersistence } from "y-indexeddb";
 import * as Y from "yjs";
 import { projectCanvas, seedCanvasInto } from "./canvas-codec";
+import { NoteDestroyedError, isDestroyedError } from "./destroyed-error";
 import { CONTENT_KEY, frontmatterOf, projectNote, rawFrontmatterOf } from "./frontmatter-codec";
 import { type FrameKind, NoteProvider } from "./note-provider";
 import { docHasHistory, seedContentInto } from "./note-seed";
@@ -115,6 +116,13 @@ export class ProviderRegistry {
 		return projectNote(order, values, e.text.toJSON(), rawFrontmatterOf(e.doc));
 	}
 
+	/** Relay parity (`Document.isDocumentAlive`): a tombstoned note is dead for
+	 *  good — a note_id is minted once and never reused, so this never rejects a
+	 *  legitimate access. Cleared only by destroyAll (stack teardown). */
+	private assertAlive(noteId: string): void {
+		if (this.removed.has(noteId)) throw new NoteDestroyedError(noteId);
+	}
+
 	private async entry(noteId: string): Promise<Entry> {
 		const e = this.ensureEntrySync(noteId);
 		await e.ready;
@@ -128,6 +136,12 @@ export class ProviderRegistry {
 	private ensureEntrySync(noteId: string): Entry {
 		const cached = this.entries.get(noteId);
 		if (cached) return cached;
+		// Relay's contract (Document.commitDocumentState): a destroyed doc is not
+		// re-creatable — touching it throws. This is the ONE choke point where a
+		// doc comes into existence, so refusing here makes "a deleted note's room
+		// silently rebuilt by a late frame" unrepresentable, rather than something
+		// each inbound path has to remember to guard.
+		this.assertAlive(noteId);
 		const doc = new Y.Doc();
 		const persistence = new IndexeddbPersistence(this.storeName(noteId), doc);
 		const kind = this.opts.docKind?.(noteId) ?? "note";
@@ -358,6 +372,10 @@ export class ProviderRegistry {
 	 *  cold SEND or fan-out RECEIVE stays room-free. (CrdtChannel.startSync +
 	 *  CrdtEnrollment.enroll collapse to this.) */
 	async startSync(noteId: string): Promise<void> {
+		// Liveness FIRST, before any state mutation: a deleted note must not even
+		// appear enrolled. Throws NoteDestroyedError (Relay contract) — enroll()
+		// below is the fire-and-forget wrapper that absorbs it.
+		this.assertAlive(noteId);
 		this.enrolledIds.add(noteId);
 		const e = await this.entry(noteId);
 		e.provider.setAdvertised(true);
@@ -365,8 +383,13 @@ export class ProviderRegistry {
 	}
 
 	enroll(noteId: string): void {
+		if (this.removed.has(noteId)) return; // deleted — nothing to open
 		this.enrolledIds.add(noteId); // sync mark so the room shows immediately
-		void this.startSync(noteId);
+		// Fire-and-forget: absorb the destroyed-note rejection (a delete racing an
+		// enroll is expected), but let any OTHER failure surface as it did before.
+		void this.startSync(noteId).catch((e) => {
+			if (!isDestroyedError(e)) throw e;
+		});
 	}
 
 	/** Close the room: stop advertising syncStep1 on reconnect. SEND/RECEIVE of

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -2,6 +2,7 @@ import { errMsg } from "../error-util";
 import { rlog } from "../remote-log";
 import type { SyncEngine } from "../sync";
 import { isDestroyedError } from "./destroyed-error";
+import { InvariantChecker, type InvariantViolation } from "./invariants";
 import type { NoteIdMap } from "./note-id-map";
 import { ProviderRegistry } from "./provider-registry";
 import { fromB64 } from "./wire";
@@ -22,6 +23,10 @@ type WiringSyncEngine = Pick<
 	| "commitCrdtConvergence"
 >;
 
+/** How often the structural invariants are swept. Cheap (set arithmetic over
+ *  in-memory state), so this is about log volume, not CPU. */
+const INVARIANT_CHECK_INTERVAL_MS = 60_000;
+
 export interface CrdtWiringDeps {
 	/** Path <-> note_id sidecar. The wire is id-keyed; disk I/O is path-keyed,
 	 *  so every callback resolves id -> path through `pathForId`. */
@@ -34,6 +39,12 @@ export interface CrdtWiringDeps {
 	 *  the binding stays authoritative. Backed lazily by CrdtLiveViews (which is
 	 *  constructed after this wiring), so it must be a closure, not a value. */
 	isBound: (path: string) => boolean;
+	/** Every currently bound path. Enumerable counterpart to `isBound`, so the
+	 *  invariant checker can assert properties across the whole binding set
+	 *  rather than one path at a time. Same lazy-closure reason as `isBound`.
+	 *  Optional: a caller that omits it simply reports no bound paths, which
+	 *  makes the binding invariants vacuous rather than throwing. */
+	boundPaths?: () => string[];
 	/** Fix wave 6: called whenever a remote-merge flush is skipped BECAUSE
 	 *  `path` is bound (i.e. right where the editor binding painted the
 	 *  update instead of a disk write). Headless/unfocused Obsidian (CI)
@@ -83,6 +94,9 @@ export interface CrdtWiring {
 	 *  flush. Exposed for tests + teardown; production fires it via the debounce
 	 *  timer set in the manager's onFlushToDisk. */
 	drainStrandedFlushes: () => Promise<void>;
+	/** Run the structural invariant sweep once, on demand (Sync Center / e2e
+	 *  probe). The periodic sweep runs on its own timer from wiring setup. */
+	checkInvariants: () => Promise<InvariantViolation[]>;
 	/** Reset per-id strand-heal retry counters. Call when the noteIdMap was just
 	 *  reconciled wholesale (reconnect) — stranded ids deserve fresh attempts
 	 *  against the now-current map, not counters left over from before the drift
@@ -433,7 +447,27 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		syncEngine.ensureNoteIdMapped(docId);
 	};
 
+	// Runtime invariants (Relay parity). Violations report at WARN — the level
+	// that actually reaches Loki — so structural drift surfaces in prod instead
+	// of being inferred from a downstream symptom weeks later.
+	const invariants = new InvariantChecker({
+		getContext: () => ({
+			removedNoteIds: registry.removedIds,
+			residentNoteIds: new Set(registry.docs.keys()),
+			enrolledNoteIds: registry.enrolled,
+			liveBoundPaths: new Set(deps.boundPaths?.() ?? []),
+			mappedPaths: new Set(Object.keys(noteIdMap.toJSON())),
+			pathForId: (id) => noteIdMap.pathForId(id),
+			idForPath: (path) => noteIdMap.get(path),
+		}),
+		onViolation: (v) => {
+			rlog().warn("crdt", `invariant violated [${v.id}]: ${v.detail}`);
+		},
+	});
+	invariants.startPeriodicChecks(INVARIANT_CHECK_INTERVAL_MS);
+
 	function dispose(): void {
+		invariants.stop();
 		if (strandHealTimer !== null) {
 			window.clearTimeout(strandHealTimer);
 			strandHealTimer = null;
@@ -449,6 +483,8 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		onCrdtNoteNotFound,
 		onNoteYjsUpdate,
 		drainStrandedFlushes,
+		/** On-demand invariant sweep (Sync Center / e2e probe). */
+		checkInvariants: () => invariants.checkAll(),
 		clearStrandHealAttempts: () => strandHealAttempts.clear(),
 		reEnrollUnsent: () => {
 			// Snapshot: enroll() → startSync succeeds → clears the id from the set;

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -1,6 +1,7 @@
 import { errMsg } from "../error-util";
 import { rlog } from "../remote-log";
 import type { SyncEngine } from "../sync";
+import { isDestroyedError } from "./destroyed-error";
 import type { NoteIdMap } from "./note-id-map";
 import { ProviderRegistry } from "./provider-registry";
 import { fromB64 } from "./wire";
@@ -350,6 +351,15 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 	// docId is the bare note_id (Task 6) — forwarded to handleFrame directly.
 	const onCrdtMessage = (docId: string, b64: string): void => {
 		channel.receive(docId, b64).catch((e) => {
+			// A frame for a DELETED note is expected, not a fault: the server can
+			// fan out or reply for a note this device just tore down. Relay's
+			// call sites (LiveViews) swallow exactly this error and nothing else —
+			// dropping it here is the whole point of the tombstone, so it must not
+			// masquerade as a malformed-frame warning.
+			if (isDestroyedError(e)) {
+				rlog().info("crdt", `frame dropped for deleted note_id=${docId}`);
+				return;
+			}
 			// Malformed frame / doc-open failure: log + drop — never leak an
 			// unhandled rejection from the inbound hot path.
 			rlog().warn(

--- a/src/lifetime.ts
+++ b/src/lifetime.ts
@@ -1,0 +1,108 @@
+/**
+ * Lifetime — an ownership window you can end, and guard async work against.
+ *
+ * Ported from Relay (`src/promiseUtils.ts`). Our version of this is four
+ * hand-written `if (entry.destroyed) return;` checks in provider-registry,
+ * each re-derived at a different call site, each added after a bug taught us it
+ * was missing. Hand-written liveness is missed by construction — the
+ * entry-creation path had none, which is how a deleted note's room got rebuilt
+ * and materialized an empty file.
+ *
+ * The post-await check is also weaker than it looks: it only notices the owner
+ * died AFTER the awaited work resolves. `guard` races the operation against the
+ * end signal, so the continuation is abandoned the moment the lifetime ends —
+ * it never resumes into dead state at all.
+ */
+
+export type LifetimeOperation<T> = Promise<T> | ((signal: AbortSignal) => Promise<T>);
+
+/** Preserve a real Error unchanged; wrap anything else so a rejection is always
+ *  catchable by type. Identity is kept for Errors, so `rejects.toThrow(Foo)`
+ *  and `instanceof` checks at call sites still work. */
+const asError = (e: unknown): Error => (e instanceof Error ? e : new Error(String(e)));
+
+export class Lifetime {
+	private ended = false;
+	private endReason: Error | undefined;
+	private readonly controller = new AbortController();
+	private readonly endListeners = new Set<(reason: Error) => void>();
+
+	get signal(): AbortSignal {
+		return this.controller.signal;
+	}
+
+	get active(): boolean {
+		return !this.ended;
+	}
+
+	get reason(): Error | undefined {
+		return this.endReason;
+	}
+
+	/** The rejection value. A lifetime always ends WITH a reason in practice
+	 *  (NoteDestroyedError); the fallback keeps the reject type honestly `Error`
+	 *  rather than `unknown`, so callers can catch on type. */
+	private get rejection(): Error {
+		return this.endReason ?? new Error("Lifetime ended");
+	}
+
+	/** Subscribe to the end. Fires immediately if already ended. Returns an
+	 *  unsubscribe. */
+	onEnded(listener: (reason: Error) => void): () => void {
+		if (this.ended) {
+			listener(this.rejection);
+			return () => {};
+		}
+		this.endListeners.add(listener);
+		return () => {
+			this.endListeners.delete(listener);
+		};
+	}
+
+	/** Run `operation` under this lifetime. Rejects with the end reason if the
+	 *  lifetime is already over, or the instant it ends — whichever comes first —
+	 *  rather than waiting for the operation to settle into a dead owner. */
+	guard<T>(operation: LifetimeOperation<T>): Promise<T> {
+		if (this.ended) return Promise.reject(this.rejection);
+
+		let promise: Promise<T>;
+		try {
+			promise = typeof operation === "function" ? operation(this.signal) : operation;
+		} catch (error) {
+			return Promise.reject(asError(error));
+		}
+
+		if (this.ended) {
+			// Ended while the operation was starting. Observe its settlement so a
+			// later rejection isn't an unhandled rejection; discard the result.
+			void promise.catch(() => {});
+			return Promise.reject(this.rejection);
+		}
+
+		return new Promise<T>((resolve, reject) => {
+			let settled = false;
+			const finish = (fn: () => void) => {
+				if (settled) return;
+				settled = true;
+				this.signal.removeEventListener("abort", onEnd);
+				fn();
+			};
+			const onEnd = () => finish(() => reject(this.rejection));
+
+			this.signal.addEventListener("abort", onEnd, { once: true });
+			promise.then(
+				(value) => finish(() => resolve(value)),
+				(error: unknown) => finish(() => reject(asError(error))),
+			);
+		});
+	}
+
+	end(reason: Error): void {
+		if (this.ended) return;
+		this.ended = true;
+		this.endReason = reason;
+		this.controller.abort();
+		for (const listener of Array.from(this.endListeners)) listener(reason);
+		this.endListeners.clear();
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1980,6 +1980,7 @@ export default class EngramSyncPlugin extends Plugin {
 							// crdtLiveViews is constructed just below; read the field at call
 							// time, never capture a value.
 							isBound: (path) => this.crdtLiveViews?.isBound(path) ?? false,
+							boundPaths: () => this.crdtLiveViews?.boundPaths() ?? [],
 							// Fix wave 6: nudge Obsidian's save pipeline after a remote merge
 							// paints into an unfocused bound editor (CI doesn't flush it).
 							onBoundUpdate: (path) =>

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1481,6 +1481,21 @@ export class SyncEngine {
 		const normalized = normalizePath(path);
 		// Already on disk — a content STEP2 created it, or the user already has it.
 		if (this.app.vault.getAbstractFileByPath(normalized)) return;
+		// A note THIS device is deleting must NOT be materialized: "not on disk"
+		// is the expected state mid-delete, and an empty STEP2 racing the
+		// tombstone would otherwise CREATE an empty file at the deleted path that
+		// nothing ever removes (observed 2026-07-28). Same pair, keyed the same
+		// way, as discoverAnnouncedNote: recentlyDeleted (by note_id, ~60s TTL)
+		// covers a delete already sent; hasPendingDelete (by path) covers one
+		// still sitting unsent in the offline queue.
+		if (this.recentlyDeleted.has(noteId)) {
+			rlog().info("crdt", `empty-materialize skip (recent local delete): ${normalized}`);
+			return;
+		}
+		if (this.queue.hasPendingDelete(normalized, this.settings.vaultId ?? undefined)) {
+			rlog().info("crdt", `empty-materialize skip (delete queued): ${normalized}`);
+			return;
+		}
 
 		// An empty STEP2 is the server's authoritative "genuinely empty" reply.
 		// The transient-empty race (an author's REST-pushed body whose Y.Doc

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1120,6 +1120,27 @@ export class SyncEngine {
 		return state !== undefined && state.hash !== fnv1a(content);
 	}
 
+	/** Should an inbound delete preserve `disk` as a keep-both conflict copy
+	 *  before trashing the file and tearing the CRDT room down?
+	 *
+	 *  Only when the room actually holds work the server has not acknowledged.
+	 *  `needsColdReconcile` alone is NOT sufficient: it is a baseline-vs-disk
+	 *  hash proxy, and a note whose content reached the server through the LIVE
+	 *  editor binding (rather than a push) trips it while being perfectly
+	 *  converged — which made every delete of an opened note leave a spurious
+	 *  "(conflict <stamp>)" copy. The undelivered-ops check is the positive
+	 *  signal: it is true exactly when tearing the room down would destroy
+	 *  something. Oversized notes are excluded (they never entered CRDT).
+	 *
+	 *  Registries without the probe (older fakes in tests) fall back to the
+	 *  drift proxy alone — the pre-existing, copy-happy behavior. */
+	private shouldKeepDriftCopy(normalized: string, disk: string, noteId: string | null): boolean {
+		if (exceedsCrdtNoteLimit(disk, MAX_CRDT_NOTE_BYTES)) return false;
+		if (!this.needsColdReconcile(normalized, disk)) return false;
+		if (!noteId || typeof this.crdt?.hasUndeliveredOps !== "function") return true;
+		return this.crdt.hasUndeliveredOps(noteId);
+	}
+
 	/** Write a remote-merged CRDT result to disk.
 	 *  Marks the path recentlyFlushed first so the resulting vault.modify/create
 	 *  event is suppressed by the recentlyFlushed guard in handleModify (the
@@ -1217,6 +1238,26 @@ export class SyncEngine {
 	private recordCrdtBaseline(normalized: string, content: string): void {
 		const prev = this.syncState.get(normalized);
 		this.syncState.set(normalized, { ...prev, hash: fnv1a(content) });
+	}
+
+	/** Refresh a LIVE-BOUND note's baseline from the autosave that just landed.
+	 *  Fire-and-forget from handleModify's editor-owns-the-file gate (which is
+	 *  synchronous): the read is the same `cachedRead` the push path would have
+	 *  done on the not-bound route, so this adds no disk work the gate saved.
+	 *  Best-effort — a read failure only leaves the baseline as stale as it is
+	 *  today, so it must never surface as an error to the vault event. */
+	private async recordLiveBoundBaseline(file: TFile): Promise<void> {
+		try {
+			this.recordCrdtBaseline(
+				normalizePath(file.path),
+				await this.app.vault.cachedRead(file),
+			);
+		} catch (e) {
+			devLog().log(
+				"crdt",
+				`live-bound baseline refresh failed for ${file.path}: ${errMsg(e)}`,
+			);
+		}
 	}
 
 	/** Capture an un-pushed on-disk edit into the Y.Doc BEFORE a fanned-out or
@@ -2026,6 +2067,16 @@ export class SyncEngine {
 		// disk path still serves closed notes, reading-view-only notes, and
 		// external edits (none of which are live-bound).
 		if (crdtManaged && this.isLiveBound(file.path)) {
+			// ...but the baseline must still track disk. Skipping the push path also
+			// skips every syncState write, so the recorded hash would freeze at
+			// whatever the last REMOTE flush wrote and drift further with every
+			// autosave. Downstream that stale baseline is read as "un-synced local
+			// drift" by needsColdReconcile, which makes a delete of an opened note
+			// leave a spurious "(conflict <stamp>)" copy, and makes a later
+			// cold-start adopt keep-both a copy of content that was never in
+			// conflict. The editor's content IS in the Y.Doc, so recording it here
+			// is the truthful baseline, not an optimistic one.
+			if (file instanceof TFile) void this.recordLiveBoundBaseline(file);
 			return;
 		}
 
@@ -4465,16 +4516,13 @@ export class SyncEngine {
 				// old path (delete-first is the common order), so a note renamed on
 				// another device while THIS device has un-synced edits would lose that
 				// drift. Preserve it FIRST as a keep-both conflict copy (mirrors
-				// adoptHistoryLessNote's no-LCA keep-both), then trash. needsColdReconcile
-				// == a recorded baseline disagreeing with disk == real local drift; no
-				// baseline / no drift → trash directly. Best-effort: a copy failure must
-				// not block the delete.
+				// adoptHistoryLessNote's no-LCA keep-both), then trash. The copy is
+				// gated on the room actually holding undelivered work — see
+				// shouldKeepDriftCopy for why the drift proxy alone is not enough.
+				// Best-effort: a copy failure must not block the delete.
 				try {
 					const disk = await this.app.vault.cachedRead(existing);
-					if (
-						!exceedsCrdtNoteLimit(disk, MAX_CRDT_NOTE_BYTES) &&
-						this.needsColdReconcile(normalized, disk)
-					) {
+					if (this.shouldKeepDriftCopy(normalized, disk, targetId ?? currentId)) {
 						const copy = await this.writeDriftConflictCopy(normalized, disk);
 						rlog().info(
 							"conflict",
@@ -5280,7 +5328,7 @@ export class SyncEngine {
 						}
 						return false;
 					}
-					if (this.needsColdReconcile(normalized, localContent)) {
+					if (this.shouldKeepDriftCopy(normalized, localContent, crdtNoteId)) {
 						// Best-effort: a copy failure must not block the delete
 						// (mirrors the WS foreign-delete drift-capture on this branch).
 						try {

--- a/src/time-provider.ts
+++ b/src/time-provider.ts
@@ -1,0 +1,134 @@
+/**
+ * Injectable clock + timers.
+ *
+ * Ported from Relay (`src/TimeProvider.ts`). Our correctness depends on
+ * wall-clock windows — the ~60s recentlyDeleted cooldown, the echo-suppression
+ * window, heal cooldowns — and every one of them is driven by a raw
+ * `window.setTimeout`. That makes them untestable except by waiting, which is
+ * how timing-shaped flake gets into the e2e suite: the only way to assert "the
+ * window expired" is to sleep through it.
+ *
+ * With the clock injected, a test advances time instead of spending it.
+ */
+
+export interface TimeProvider {
+	now(): number;
+	setTimeout(callback: () => void, ms: number): number;
+	clearTimeout(id: number): void;
+	setInterval(callback: () => void, ms: number): number;
+	clearInterval(id: number): void;
+	/** Cancel every timer this provider handed out (plugin unload). */
+	destroy(): void;
+}
+
+export class DefaultTimeProvider implements TimeProvider {
+	private readonly timeouts = new Set<number>();
+	private readonly intervals = new Set<number>();
+
+	now(): number {
+		return Date.now();
+	}
+
+	setTimeout(callback: () => void, ms: number): number {
+		const id = window.setTimeout(() => {
+			this.timeouts.delete(id);
+			callback();
+		}, ms);
+		this.timeouts.add(id);
+		return id;
+	}
+
+	clearTimeout(id: number): void {
+		this.timeouts.delete(id);
+		window.clearTimeout(id);
+	}
+
+	setInterval(callback: () => void, ms: number): number {
+		const id = window.setInterval(callback, ms);
+		this.intervals.add(id);
+		return id;
+	}
+
+	clearInterval(id: number): void {
+		this.intervals.delete(id);
+		window.clearInterval(id);
+	}
+
+	destroy(): void {
+		for (const id of this.timeouts) window.clearTimeout(id);
+		for (const id of this.intervals) window.clearInterval(id);
+		this.timeouts.clear();
+		this.intervals.clear();
+	}
+}
+
+/** Test double: time only moves when you move it. Exported from src (not tests)
+ *  so the e2e harness can drive plugin-side windows deterministically too. */
+export class ManualTimeProvider implements TimeProvider {
+	private current: number;
+	private nextId = 1;
+	private readonly pending = new Map<
+		number,
+		{ due: number; callback: () => void; every: number | null }
+	>();
+
+	constructor(start = 0) {
+		this.current = start;
+	}
+
+	now(): number {
+		return this.current;
+	}
+
+	setTimeout(callback: () => void, ms: number): number {
+		const id = this.nextId++;
+		this.pending.set(id, { due: this.current + ms, callback, every: null });
+		return id;
+	}
+
+	clearTimeout(id: number): void {
+		this.pending.delete(id);
+	}
+
+	setInterval(callback: () => void, ms: number): number {
+		const id = this.nextId++;
+		this.pending.set(id, { due: this.current + ms, callback, every: ms });
+		return id;
+	}
+
+	clearInterval(id: number): void {
+		this.pending.delete(id);
+	}
+
+	/** Advance the clock, firing everything that comes due in timestamp order.
+	 *  Callbacks scheduling further work inside the advanced window still fire. */
+	advance(ms: number): void {
+		const target = this.current + ms;
+		for (;;) {
+			let nextId: number | null = null;
+			let nextDue = Number.POSITIVE_INFINITY;
+			for (const [id, t] of this.pending) {
+				if (t.due <= target && t.due < nextDue) {
+					nextDue = t.due;
+					nextId = id;
+				}
+			}
+			if (nextId === null) break;
+			const timer = this.pending.get(nextId);
+			if (!timer) break;
+			this.current = timer.due;
+			if (timer.every === null) this.pending.delete(nextId);
+			else timer.due = this.current + timer.every;
+			timer.callback();
+		}
+		this.current = target;
+	}
+
+	get pendingCount(): number {
+		return this.pending.size;
+	}
+
+	destroy(): void {
+		this.pending.clear();
+	}
+}

--- a/tests/crdt-invariants.test.ts
+++ b/tests/crdt-invariants.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Each invariant here corresponds to a bug class we have actually shipped, so
+ * the tests are written as "the broken state we saw in prod is detected".
+ */
+import { describe, expect, test } from "bun:test";
+import {
+	InvariantChecker,
+	type InvariantContext,
+	STANDARD_INVARIANTS,
+} from "../src/crdt/invariants";
+import { ManualTimeProvider } from "../src/time-provider";
+
+function ctx(overrides: Partial<InvariantContext> = {}): InvariantContext {
+	const idByPath = new Map<string, string>();
+	const base: InvariantContext = {
+		removedNoteIds: new Set(),
+		residentNoteIds: new Set(),
+		enrolledNoteIds: new Set(),
+		liveBoundPaths: new Set(),
+		mappedPaths: new Set(),
+		idForPath: (p) => idByPath.get(p) ?? null,
+		pathForId: (id) => {
+			for (const [p, v] of idByPath) if (v === id) return p;
+			return null;
+		},
+	};
+	return { ...base, ...overrides };
+}
+
+const check = async (c: InvariantContext) => {
+	const seen: string[] = [];
+	const checker = new InvariantChecker({
+		getContext: () => c,
+		onViolation: (v) => seen.push(v.id),
+	});
+	await checker.checkAll();
+	return seen;
+};
+
+describe("standard invariants", () => {
+	test("a healthy vault reports nothing", async () => {
+		const idByPath = new Map([["a.md", "id-a"]]);
+		const healthy = ctx({
+			residentNoteIds: new Set(["id-a"]),
+			enrolledNoteIds: new Set(["id-a"]),
+			liveBoundPaths: new Set(["a.md"]),
+			mappedPaths: new Set(["a.md"]),
+			idForPath: (p) => idByPath.get(p) ?? null,
+			pathForId: (id) => (id === "id-a" ? "a.md" : null),
+		});
+
+		expect(await check(healthy)).toEqual([]);
+	});
+
+	test("detects a deleted note whose room was rebuilt (2026-07-28 resurrection)", async () => {
+		const violations = await check(
+			ctx({ removedNoteIds: new Set(["id-gone"]), residentNoteIds: new Set(["id-gone"]) }),
+		);
+
+		expect(violations).toContain("removed-implies-not-resident");
+	});
+
+	test("detects a deleted note still holding an open room", async () => {
+		const violations = await check(
+			ctx({ removedNoteIds: new Set(["id-gone"]), enrolledNoteIds: new Set(["id-gone"]) }),
+		);
+
+		expect(violations).toContain("removed-implies-not-enrolled");
+	});
+
+	test("detects a phantom room with no doc behind it", async () => {
+		const violations = await check(ctx({ enrolledNoteIds: new Set(["id-ghost"]) }));
+
+		expect(violations).toContain("enrolled-implies-resident");
+	});
+
+	test("detects a live-bound path with no note_id (onEmptyStep2 'no known path')", async () => {
+		const violations = await check(ctx({ liveBoundPaths: new Set(["orphan.md"]) }));
+
+		expect(violations).toContain("live-bound-implies-mapped");
+	});
+
+	test("detects a NoteIdMap whose two directions disagree", async () => {
+		const violations = await check(
+			ctx({
+				mappedPaths: new Set(["a.md"]),
+				idForPath: (p) => (p === "a.md" ? "id-a" : null),
+				// Reverse map drifted to a different path — the stale-NoteIdMap class.
+				pathForId: () => "b.md",
+			}),
+		);
+
+		expect(violations).toContain("id-map-bijective");
+	});
+
+	test("a throwing invariant is reported, never treated as passing", async () => {
+		const seen: string[] = [];
+		const checker = new InvariantChecker({
+			getContext: () => ctx(),
+			onViolation: (v) => seen.push(`${v.id}:${v.detail}`),
+			invariants: [
+				{
+					id: "explodes",
+					description: "throws",
+					check() {
+						throw new Error("boom");
+					},
+				},
+			],
+		});
+
+		await checker.checkAll();
+
+		expect(seen).toEqual(["explodes:check threw: boom"]);
+	});
+});
+
+describe("periodic checking", () => {
+	test("runs on the injected interval and stops cleanly", async () => {
+		const clock = new ManualTimeProvider();
+		let runs = 0;
+		const checker = new InvariantChecker({
+			getContext: () => {
+				runs++;
+				return ctx();
+			},
+			onViolation: () => {},
+			setInterval: (cb, ms) => clock.setInterval(cb, ms),
+			clearInterval: (id) => clock.clearInterval(id),
+		});
+
+		checker.startPeriodicChecks(30_000);
+		clock.advance(90_000);
+		expect(runs).toBe(3);
+
+		checker.stop();
+		clock.advance(90_000);
+		expect(runs).toBe(3);
+	});
+});
+
+describe("invariant catalogue", () => {
+	test("every invariant has a unique id", () => {
+		const ids = STANDARD_INVARIANTS.map((i) => i.id);
+
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});

--- a/tests/lifetime.test.ts
+++ b/tests/lifetime.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { NoteDestroyedError } from "../src/crdt/destroyed-error";
+import { Lifetime } from "../src/lifetime";
+
+describe("Lifetime", () => {
+	test("passes a resolved value through while active", async () => {
+		const lifetime = new Lifetime();
+
+		await expect(lifetime.guard(Promise.resolve("ok"))).resolves.toBe("ok");
+	});
+
+	test("rejects immediately when already ended", async () => {
+		const lifetime = new Lifetime();
+		lifetime.end(new NoteDestroyedError("id-a"));
+
+		await expect(lifetime.guard(Promise.resolve("ok"))).rejects.toThrow(NoteDestroyedError);
+	});
+
+	test("abandons an in-flight operation the moment the lifetime ends", async () => {
+		const lifetime = new Lifetime();
+		// Never settles — a post-await `if (destroyed) return` would hang here
+		// forever, which is the whole weakness of that pattern.
+		const guarded = lifetime.guard(new Promise<string>(() => {}));
+
+		lifetime.end(new NoteDestroyedError("id-a"));
+
+		await expect(guarded).rejects.toThrow(NoteDestroyedError);
+	});
+
+	test("does not resume into dead state when work resolves after the end", async () => {
+		const lifetime = new Lifetime();
+		let resolveLate: (v: string) => void = () => {};
+		const late = new Promise<string>((r) => {
+			resolveLate = r;
+		});
+		const guarded = lifetime.guard(late);
+
+		lifetime.end(new NoteDestroyedError("id-a"));
+		resolveLate("too late");
+
+		await expect(guarded).rejects.toThrow(NoteDestroyedError);
+	});
+
+	test("aborts the signal handed to the operation", async () => {
+		const lifetime = new Lifetime();
+		let aborted = false;
+		const guarded = lifetime.guard((signal) => {
+			signal.addEventListener("abort", () => {
+				aborted = true;
+			});
+			return new Promise<string>(() => {});
+		});
+
+		lifetime.end(new NoteDestroyedError("id-a"));
+		await guarded.catch(() => {});
+
+		expect(aborted).toBe(true);
+	});
+
+	test("propagates a genuine operation failure unchanged", async () => {
+		const lifetime = new Lifetime();
+
+		await expect(lifetime.guard(Promise.reject(new Error("disk full")))).rejects.toThrow(
+			"disk full",
+		);
+	});
+
+	test("end is idempotent and keeps the first reason", () => {
+		const lifetime = new Lifetime();
+		const first = new NoteDestroyedError("id-a");
+		lifetime.end(first);
+		lifetime.end(new Error("second"));
+
+		expect(lifetime.active).toBe(false);
+		expect(lifetime.reason).toBe(first);
+	});
+
+	test("onEnded fires immediately for an already-ended lifetime", () => {
+		const lifetime = new Lifetime();
+		lifetime.end(new NoteDestroyedError("id-a"));
+		let seen: unknown = null;
+
+		lifetime.onEnded((reason) => {
+			seen = reason;
+		});
+
+		expect(seen).toBeInstanceOf(NoteDestroyedError);
+	});
+});

--- a/tests/sync-deleted-note-empty-materialize.test.ts
+++ b/tests/sync-deleted-note-empty-materialize.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Deleting a note must not leave an EMPTY file behind at the same path.
+ *
+ * Observed 2026-07-28 on 1.18.2-pr.348: delete a note in Obsidian, the file
+ * goes away, then an identically-named EMPTY file appears and stays. The
+ * emptiness is the fingerprint — a resurrected buffer or conflict copy would
+ * carry the note's text, so only a freshly-constructed Y.Doc projects "".
+ *
+ * Chain: a stray inbound frame for the deleted note rebuilds its registry
+ * entry from scratch (`removed` is read by applyLocalEdit/applyRemoteUpdate
+ * but NOT by the entry-creation path) → the new empty doc completes a
+ * syncStep2 → `onSynced` sees text.length === 0 → `onEmptyStep2` →
+ * `materializeEmptyDiscovered` → `flushFromCrdt("")` → the Discovery branch
+ * CREATES the file.
+ *
+ * Two guards close it, mirroring `discoverAnnouncedNote`, which already
+ * refuses to materialize a note this device is deleting.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import "fake-indexeddb/auto";
+import * as encoding from "lib0/encoding";
+import { TFile } from "obsidian";
+import * as syncProtocol from "y-protocols/sync";
+import * as Y from "yjs";
+import type { EngramApi } from "../src/api";
+import { NoteDestroyedError } from "../src/crdt/destroyed-error";
+import { NoteIdMap } from "../src/crdt/note-id-map";
+import { ProviderRegistry } from "../src/crdt/provider-registry";
+import { MESSAGE_SYNC, toB64 } from "../src/crdt/wire";
+import { SyncEngine } from "../src/sync";
+import { DEFAULT_SETTINGS } from "../src/types";
+
+/** An empty-doc syncStep2 — the server's "genuinely empty note" reply, which
+ *  is what fires onEmptyStep2. */
+function emptyStep2(): string {
+	const enc = encoding.createEncoder();
+	encoding.writeVarUint(enc, MESSAGE_SYNC);
+	syncProtocol.writeSyncStep2(enc, new Y.Doc());
+	return toB64(encoding.toUint8Array(enc));
+}
+
+function scenario(dbPrefix: string) {
+	const disk = new Map<string, string>();
+	const created: string[] = [];
+
+	const mgr = new ProviderRegistry({
+		dbPrefix,
+		send: () => true,
+		onFlushToDisk: async () => undefined,
+	});
+
+	const mockApp = {
+		vault: {
+			configDir: ".obsidian",
+			getAbstractFileByPath: mock((p: string) => (disk.has(p) ? new TFile(p) : null)),
+			getFileByPath: mock((p: string) => (disk.has(p) ? new TFile(p) : null)),
+			cachedRead: mock(async (f: TFile) => disk.get(f.path) ?? ""),
+			read: mock(async (f: TFile) => disk.get(f.path) ?? ""),
+			modify: mock(async (f: TFile, c: string) => {
+				disk.set(f.path, c);
+			}),
+			create: mock(async (p: string, c: string) => {
+				created.push(p);
+				disk.set(p, c);
+			}),
+			createFolder: mock().mockResolvedValue(undefined),
+			getName: mock().mockReturnValue("Test Vault"),
+		},
+		fileManager: { trashFile: mock().mockResolvedValue(undefined) },
+		workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
+	} as any;
+
+	const e = new SyncEngine(
+		mockApp,
+		{} as unknown as EngramApi,
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
+		mock().mockResolvedValue(undefined),
+	);
+	e.setCrdtManager(mgr);
+	e.setReady();
+	const map = new NoteIdMap();
+	map.set("gone.md", "id-gone");
+	e.setNoteIdMap(map);
+
+	return { e, mgr, created, disk };
+}
+
+describe("deleted note must not re-materialize empty", () => {
+	test("materializeEmptyDiscovered skips a note this device just deleted", async () => {
+		const { e, created } = scenario("mat-recent-delete");
+
+		// The delete has been issued: handleDelete tombstones the id before the
+		// send, which is the state a racing empty-STEP2 arrives in.
+		(e as unknown as { markRecentlyDeleted(id: string): void }).markRecentlyDeleted("id-gone");
+
+		await e.materializeEmptyDiscovered("gone.md", "id-gone");
+
+		expect(created).toEqual([]);
+	});
+
+	test("materializeEmptyDiscovered skips a note with a delete still queued", async () => {
+		const { e, created } = scenario("mat-pending-delete");
+
+		// Offline: the delete is durably queued but unsent, so the id-keyed
+		// cooldown may already have lapsed — the path-keyed queue is the guard.
+		await (
+			e as unknown as {
+				queue: {
+					enqueue(c: Record<string, unknown>): Promise<void>;
+				};
+			}
+		).queue.enqueue({
+			path: "gone.md",
+			action: "delete",
+			kind: "note",
+			timestamp: Date.now(),
+		});
+
+		await e.materializeEmptyDiscovered("gone.md", "id-gone");
+
+		expect(created).toEqual([]);
+	});
+
+	test("an inbound frame does not rebuild a removed note's doc", async () => {
+		const { mgr } = scenario("recv-after-remove");
+
+		await mgr.applyRemoteUpdate("id-gone", Y.encodeStateAsUpdate(new Y.Doc()));
+		await mgr.removeDoc("id-gone");
+		expect(mgr.docs.has("id-gone")).toBe(false);
+
+		// A late fan-out / handshake reply for the deleted note. Relay's contract:
+		// touching a destroyed doc THROWS rather than get-or-creating it, so the
+		// caller decides explicitly instead of silently resurrecting the room.
+		await expect(mgr.receive("id-gone", emptyStep2())).rejects.toThrow(NoteDestroyedError);
+
+		// Rebuilding the entry is what lets an empty syncStep2 complete and fire
+		// onEmptyStep2 → materialize an empty file at the deleted path.
+		expect(mgr.docs.has("id-gone")).toBe(false);
+	});
+});

--- a/tests/sync-live-bound-delete-drift.test.ts
+++ b/tests/sync-live-bound-delete-drift.test.ts
@@ -1,0 +1,178 @@
+/**
+ * A note you OPEN in Obsidian and then delete must not leave a
+ * "(conflict <stamp>)" copy behind.
+ *
+ * Two seams conspire:
+ *  1. `handleModify`'s editor-owns-the-file gate returns before anything
+ *     refreshes `syncState`, so a live-bound note's recorded baseline freezes
+ *     at whatever the last REMOTE flush wrote. Every subsequent autosave
+ *     widens the gap between disk and baseline.
+ *  2. Both inbound-delete drift sites gate the keep-both copy on
+ *     `needsColdReconcile` — a baseline-vs-disk hash proxy that now reads
+ *     "converged content" as "un-synced local drift" and writes the copy.
+ *
+ * The copy exists to protect edits that would die with the CRDT room, so the
+ * fix is NOT to delete it: it must fire on a positive signal (the doc holds
+ * frames the server has not acknowledged), not on the hash proxy.
+ *
+ * Uses the REAL ProviderRegistry so sync state is genuine, not mocked.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import "fake-indexeddb/auto";
+import * as encoding from "lib0/encoding";
+import { TFile } from "obsidian";
+import * as syncProtocol from "y-protocols/sync";
+import * as Y from "yjs";
+import type { EngramApi } from "../src/api";
+import { NoteIdMap } from "../src/crdt/note-id-map";
+import { ProviderRegistry } from "../src/crdt/provider-registry";
+import { MESSAGE_SYNC, toB64 } from "../src/crdt/wire";
+import { SyncEngine, fnv1a } from "../src/sync";
+import { DEFAULT_SETTINGS, type NoteChange } from "../src/types";
+
+/** Build an engine whose note `a.md` is CRDT-managed, live-bound, and whose
+ *  disk content has drifted from the recorded baseline (the exact state an
+ *  opened-and-typed-in note reaches).
+ *
+ *  `deliverable` controls whether the provider's transport accepts frames:
+ *  true  → the doc reaches isFullySynced (nothing buffered, server has it all)
+ *  false → frames buffer locally (offline edits the server has NOT seen) */
+async function liveBoundScenario(opts: { dbPrefix: string; deliverable: boolean }) {
+	const disk = new Map<string, string>([["a.md", "BASE typed-in-obsidian"]]);
+	const created: string[] = [];
+
+	const mgr = new ProviderRegistry({
+		dbPrefix: opts.dbPrefix,
+		send: () => opts.deliverable,
+		onFlushToDisk: async (_id, content) => {
+			disk.set("a.md", content);
+		},
+	});
+
+	const tfile = (p: string) => new TFile(p);
+	const mockApp = {
+		vault: {
+			configDir: ".obsidian",
+			getAbstractFileByPath: mock((p: string) => (disk.has(p) ? tfile(p) : null)),
+			getFileByPath: mock((p: string) => (disk.has(p) ? tfile(p) : null)),
+			cachedRead: mock(async (f: TFile) => disk.get(f.path) ?? ""),
+			read: mock(async (f: TFile) => disk.get(f.path) ?? ""),
+			modify: mock(async (f: TFile, c: string) => {
+				disk.set(f.path, c);
+			}),
+			create: mock(async (p: string, c: string) => {
+				created.push(p);
+				disk.set(p, c);
+			}),
+			createFolder: mock().mockResolvedValue(undefined),
+			getName: mock().mockReturnValue("Test Vault"),
+		},
+		fileManager: {
+			trashFile: mock(async (f: TFile) => {
+				disk.delete(f.path);
+			}),
+		},
+		workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
+	} as any;
+
+	const e = new SyncEngine(
+		mockApp,
+		{} as unknown as EngramApi,
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
+		mock().mockResolvedValue(undefined),
+	);
+	e.setCrdtManager(mgr);
+	e.setReady();
+	const map = new NoteIdMap();
+	map.set("a.md", "id-a");
+	e.setNoteIdMap(map);
+	// CRDT-sole oracle: a recorded head under the path marks the note
+	// server-known, which is what routes the delete through the CRDT branch.
+	(e as unknown as { setCrdtHead(p: string, h: string): void }).setCrdtHead(
+		"a.md",
+		"server-head",
+	);
+	(e as unknown as { confirmedNoteIds: Set<string> }).confirmedNoteIds.add("id-a");
+	e.setLiveBoundCheck((p) => p === "a.md");
+
+	// Seed the doc so the note has a real room.
+	const server = new Y.Doc();
+	server.getText("content").insert(0, "BASE");
+	await mgr.applyRemoteUpdate("id-a", Y.encodeStateAsUpdate(server));
+
+	if (opts.deliverable) {
+		// Complete a REAL handshake: a syncStep2 carrying the server's state is
+		// what flips the provider's `synced` flag, so the doc genuinely reports
+		// "the server has everything" rather than a poked test flag.
+		mgr.setConnected(true);
+		const enc = encoding.createEncoder();
+		encoding.writeVarUint(enc, MESSAGE_SYNC);
+		syncProtocol.writeSyncStep2(enc, server);
+		await mgr.receive("id-a", toB64(encoding.toUint8Array(enc)));
+	}
+
+	// The baseline records what that remote flush wrote — NOT what the user has
+	// since typed into the open editor.
+	e.importSyncState({ "a.md": { hash: fnv1a("BASE") } });
+	disk.set("a.md", "BASE typed-in-obsidian");
+
+	return {
+		e,
+		mgr,
+		disk,
+		conflictCopies: () => created.filter((p) => p.includes("(conflict ")),
+	};
+}
+
+const tombstone = (path: string): NoteChange => ({
+	path,
+	title: "a",
+	folder: "",
+	tags: [],
+	mtime: Date.now(),
+	updated_at: new Date().toISOString(),
+	deleted: true,
+});
+
+describe("live-bound note delete drift", () => {
+	test("live-bound modify refreshes the synced baseline", async () => {
+		const { e, disk } = await liveBoundScenario({
+			dbPrefix: "lb-baseline",
+			deliverable: true,
+		});
+
+		// Precondition: the frozen baseline reads the open note as drifted.
+		expect(e.needsColdReconcile("a.md", disk.get("a.md") as string)).toBe(true);
+
+		e.handleModify(new TFile("a.md"));
+		await new Promise((r) => setTimeout(r, 10));
+
+		// The editor owns this content and it is already in the Y.Doc — the
+		// baseline must track it, not lag behind it.
+		expect(e.needsColdReconcile("a.md", disk.get("a.md") as string)).toBe(false);
+	});
+
+	test("delete of a delivered live-bound note writes no conflict copy", async () => {
+		const { e, conflictCopies } = await liveBoundScenario({
+			dbPrefix: "lb-delivered",
+			deliverable: true,
+		});
+
+		await e.applyChange(tombstone("a.md"));
+
+		expect(conflictCopies()).toEqual([]);
+	});
+
+	test("delete of a live-bound note with undelivered ops keeps a conflict copy", async () => {
+		const { e, conflictCopies } = await liveBoundScenario({
+			dbPrefix: "lb-undelivered",
+			deliverable: false,
+		});
+
+		await e.applyChange(tombstone("a.md"));
+
+		// The server never acknowledged this doc's frames — deleting the room
+		// would destroy them, so the keep-both copy is correct here.
+		expect(conflictCopies()).toHaveLength(1);
+	});
+});

--- a/tests/time-provider.test.ts
+++ b/tests/time-provider.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { ManualTimeProvider } from "../src/time-provider";
+
+describe("ManualTimeProvider", () => {
+	test("does not fire a timeout before it is due", () => {
+		const clock = new ManualTimeProvider();
+		let fired = false;
+		clock.setTimeout(() => {
+			fired = true;
+		}, 60_000);
+
+		clock.advance(59_999);
+
+		expect(fired).toBe(false);
+	});
+
+	test("fires a timeout once its window elapses", () => {
+		const clock = new ManualTimeProvider();
+		let fired = false;
+		clock.setTimeout(() => {
+			fired = true;
+		}, 60_000);
+
+		clock.advance(60_000);
+
+		expect(fired).toBe(true);
+	});
+
+	test("clearTimeout cancels a pending timer", () => {
+		const clock = new ManualTimeProvider();
+		let fired = false;
+		const id = clock.setTimeout(() => {
+			fired = true;
+		}, 100);
+
+		clock.clearTimeout(id);
+		clock.advance(1000);
+
+		expect(fired).toBe(false);
+	});
+
+	test("fires timers in due order, not insertion order", () => {
+		const clock = new ManualTimeProvider();
+		const order: string[] = [];
+		clock.setTimeout(() => order.push("late"), 200);
+		clock.setTimeout(() => order.push("early"), 100);
+
+		clock.advance(500);
+
+		expect(order).toEqual(["early", "late"]);
+	});
+
+	test("now() reflects the time a callback actually ran at", () => {
+		const clock = new ManualTimeProvider(1000);
+		let observed = -1;
+		clock.setTimeout(() => {
+			observed = clock.now();
+		}, 250);
+
+		clock.advance(900);
+
+		// Not 1900 (the end of the advanced window) — the callback ran at its due
+		// instant, which is what a TTL check inside it would observe.
+		expect(observed).toBe(1250);
+	});
+
+	test("an interval repeats across a long advance", () => {
+		const clock = new ManualTimeProvider();
+		let ticks = 0;
+		clock.setInterval(() => {
+			ticks++;
+		}, 100);
+
+		clock.advance(350);
+
+		expect(ticks).toBe(3);
+	});
+});


### PR DESCRIPTION
**Parked, not proposed.** Opened during a worktree cleanup so this work stays discoverable. Do not merge as-is; it is months of `main` behind by now and CI will be red.

## Why it was parked rather than deleted

This branch existed only in a local worktree — no remote branch, no PR, nothing on origin. Deleting the worktree would have destroyed it permanently. The audit (`engram-workspace/docs/context/worktree-hygiene.md`) says park in that case, so here it is.

## What it holds

3 commits, ~1612 insertions, and it is genuinely absent from `main` — not a duplicate of something already shipped:

- `feat(crdt): port Relay's correctness primitives — invariants, Lifetime, TimeProvider`
- `fix(crdt): adopt Relay's destroyed-doc contract; stop empty resurrection`
- `fix(sync): stop deleting an opened note leaving a conflict copy`

New modules: `src/lifetime.ts`, `src/time-provider.ts`. New suites: `tests/crdt-invariants.test.ts`, `tests/lifetime.test.ts`, `tests/time-provider.test.ts`, `tests/sync-deleted-note-empty-materialize.test.ts`, `tests/sync-live-bound-delete-drift.test.ts`.

## Whether it is still worth anything

Plausibly yes. `TimeProvider` and `Lifetime` are the injectable-clock and scoped-teardown primitives that make CRDT teardown ordering testable without wall-clock sleeps, and the two `fix(sync)`/`fix(crdt)` commits describe real bug classes (empty resurrection, conflict copy on deleting an open note).

It also overlaps the index-CRDT epic (engram-app/Engram#1146 and #1150-#1154). Worth reading before that work starts — either to lift the primitives or to consciously decide against them.