### PR TITLE
feat(crdt): make LCA three-way merge the default path

### DIFF
--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -81,9 +81,6 @@ export interface ProviderRegistryOpts {
 	 *  ancestor for 3-way merge". Null when none is recorded (a note that has
 	 *  never completed a sync), which falls back to the pre-LCA path. */
 	lcaFor?: (noteId: string) => string | null;
-	/** `crdtLcaMerge` flag. Read per call so a toggle takes effect without a
-	 *  stack rebuild. */
-	lcaMergeEnabled?: () => boolean;
 	/** Called when a merge could not apply every hunk. The content is still
 	 *  written, but the caller may want to record an issue — a dirty merge is the
 	 *  honest conflict signal that the two-way diff never produced. */
@@ -324,10 +321,7 @@ export class ProviderRegistry {
 		// projection, which for a fresh doc is empty — and the caller records
 		// fnv1a(returned) as the last-synced baseline, so an empty return poisons
 		// isUnchangedSynced for a note that actually has content (#846 doubling).
-		const base =
-			this.opts.lcaMergeEnabled?.() && (hasLca ?? docHasHistory(e.doc, e.kind))
-				? this.opts.lcaFor?.(noteId)
-				: null;
+		const base = (hasLca ?? docHasHistory(e.doc, e.kind)) ? this.opts.lcaFor?.(noteId) : null;
 		if (base !== null && base !== undefined && e.kind === "note") {
 			const merged = mergeDiskOntoDoc(base, diskContent, this.project(e));
 			if (merged.clean) {
@@ -350,8 +344,8 @@ export class ProviderRegistry {
 		// Stale-snapshot revert guard (e2e test_83): diskContent was read before
 		// this resolved; a remote merge in that window is absent from it, and
 		// diffing would DELETE the remote ops. Re-read across a doc-stable window.
-		// Still the path when the LCA flag is off, no base is recorded yet, the doc
-		// is a canvas, or the merge came back dirty.
+		// Still the path when no base is recorded yet, the doc is a canvas, or the
+		// merge came back dirty.
 		if (reread) {
 			let stable = false;
 			for (let attempt = 0; attempt < 3 && !stable; attempt++) {

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -75,8 +75,6 @@ export interface CrdtWiringDeps {
 	/** Merge base for a note_id (#357), resolved through the id map to the path
 	 *  BaseStore is keyed by. Omitted = the pre-LCA path. */
 	lcaFor?: (noteId: string) => string | null;
-	/** `crdtLcaMerge` flag, read per call. */
-	lcaMergeEnabled?: () => boolean;
 	/** A merge that could not apply every hunk. */
 	onDirtyMerge?: (noteId: string) => void;
 }
@@ -288,7 +286,6 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		dbPrefix: deps.dbPrefix,
 		recorder: deps.recorder,
 		lcaFor: deps.lcaFor,
-		lcaMergeEnabled: deps.lcaMergeEnabled,
 		onDirtyMerge: deps.onDirtyMerge,
 		send: (docId, frame, kind) => {
 			// Create-before-edit: hold OPS until the note's server row exists. Never

--- a/src/feature-flags.ts
+++ b/src/feature-flags.ts
@@ -36,9 +36,6 @@ export interface FlagSchemaEntry {
 export interface FeatureFlags {
 	/** Capture an ordered timeline of CRDT sync events for replay (#356). */
 	crdtRecording: boolean;
-	/** Merge disk changes against the persisted LCA instead of diffing against
-	 *  current doc state (#357). */
-	crdtLcaMerge: boolean;
 }
 
 export const FLAG_SCHEMA: { [K in keyof FeatureFlags]: FlagSchemaEntry } = {
@@ -48,13 +45,6 @@ export const FLAG_SCHEMA: { [K in keyof FeatureFlags]: FlagSchemaEntry } = {
 		title: "Record CRDT sync timeline",
 		description:
 			"Capture an ordered event timeline for each synced note so a sync failure can be replayed offline. Metadata and note content stay local.",
-	},
-	crdtLcaMerge: {
-		default: false,
-		category: "danger",
-		title: "Three-way merge against the last common ancestor",
-		description:
-			"Merge disk edits against the last synced content instead of the current document state. Changes how concurrent edits are resolved.",
 	},
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2080,7 +2080,6 @@ export default class EngramSyncPlugin extends Plugin {
 								const path = this.noteIdMap.pathForId(noteId);
 								return path ? (this.baseStore?.get(path)?.content ?? null) : null;
 							},
-							lcaMergeEnabled: () => this.flags.crdtLcaMerge,
 							onDirtyMerge: (noteId) =>
 								rlog().warn(
 									"crdt",

--- a/tests/crdt/lca-apply-local-edit.test.ts
+++ b/tests/crdt/lca-apply-local-edit.test.ts
@@ -6,18 +6,16 @@ const settle = () => new Promise<void>((r) => setTimeout(r, 20));
 
 interface Opts {
 	lca: string | null;
-	enabled?: boolean;
 	dbPrefix: string;
 }
 
-function registryWith({ lca, enabled = true, dbPrefix }: Opts) {
+function registryWith({ lca, dbPrefix }: Opts) {
 	const dirty: string[] = [];
 	const registry = new ProviderRegistry({
 		dbPrefix,
 		send: () => true,
 		onFlushToDisk: () => true,
 		lcaFor: () => lca,
-		lcaMergeEnabled: () => enabled,
 		onDirtyMerge: (id) => dirty.push(id),
 	});
 	return { registry, dirty };
@@ -51,18 +49,15 @@ describe("applyLocalEdit with an LCA", () => {
 		await registry.destroyAll();
 	});
 
-	test("falls back to the pre-LCA path when the flag is off", async () => {
-		const { registry } = registryWith({
-			lca: "line one\n",
-			enabled: false,
-			dbPrefix: "lca3",
-		});
+	test("falls back to the lossy two-way path when there is no base", async () => {
+		const { registry } = registryWith({ lca: null, dbPrefix: "lca3" });
 		await registry.applyLocalEdit("n3", "line one\nremote\n");
 		await settle();
 
-		// Flag off: the two-way diff forces the doc to equal the disk snapshot, so
-		// the remote line is lost. Pinned deliberately — this is the behaviour the
-		// flag exists to replace, and it must stay reachable while the flag is off.
+		// No base: the two-way diff forces the doc to equal the disk snapshot, so
+		// the remote line is lost. Pinned deliberately — LCA is the default path
+		// now, but this one stays reachable for never-synced notes, canvases and
+		// dirty merges, and its lossiness is why those cases still carry guards.
 		await registry.applyLocalEdit("n3", "line one\nlocal\n");
 
 		expect(await registry.projectedText("n3")).not.toContain("remote");
@@ -90,7 +85,6 @@ describe("applyLocalEdit with an LCA", () => {
 			send: () => true,
 			onFlushToDisk: () => true,
 			lcaFor: () => "same content\n",
-			lcaMergeEnabled: () => true,
 			isUnchangedSynced: () => true,
 		});
 


### PR DESCRIPTION
`crdtLcaMerge` shipped OFF in #361 so the new merge could soak behind a flag. A flag on the sync path is a fork in behaviour we then have to reason about twice, and this is the path we want long-term — so it becomes the default and the flag is deleted rather than carried.

## What changed

- `crdtLcaMerge` removed from `FeatureFlags` / `FLAG_SCHEMA` (`crdtRecording` stays — it is a debugging instrument, not a behaviour fork).
- `lcaMergeEnabled` removed from `ProviderRegistryOpts`, `CrdtWiringDeps`, and the `main.ts` wiring.
- The gate in `applyLocalEdit` is now just "does a base exist for a doc that has history".

## What did NOT change

The two-way diff is still the path when:

- no base is recorded yet (a note that has never completed a sync),
- the doc is a canvas (structural, not text), or
- the merge came back dirty (overlapping edits in one region).

Those cases keep the stale-snapshot retry loop that guards them. Retiring that loop is what remains of #364, and it now depends on closing those three cases rather than on a soak.

The `docHasHistory` gate stays: routing a history-less doc through the merge would bypass the adopt-first gate and return an empty projection that the caller records as the last-synced baseline — the #846 doubling trigger. That regression test is unchanged.

## Coverage

The "flag off is lossy" test is re-pointed at the no-base fallback. That is the same two-way code and is still reachable, so the pinned lossy behaviour survives the flag's removal rather than being deleted with it.

## Gates (real exit codes)

| gate | result |
|---|---|
| `bun run build` (tsc + esbuild) | 0 |
| `bun run lint` (biome check) | 0 |
| `bun run lint:obsidian` | 0 |
| `bun run lint:css` | 0 |
| `bun test` | 0 — 2372 pass, 1 skip, 0 fail |

Refs #364