### PR TITLE
chore: correct stale batch-order comment

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -6351,9 +6351,12 @@ export class SyncEngine {
 				const { results } = await this.crdtCreateBatch!(
 					sent.map((e) => ({ doc_id: e.noteId, path: e.pushedPath, b64: e.b64 })),
 				);
-				// Match by INDEX, not id: the backend preserves the `creates` order
-				// (Enum.map_reduce), and an id_conflict result echoes the EXISTING
-				// note's id, not the one we sent — so an id lookup would miss it.
+				// Match by INDEX, not id: the backend guarantees `results` is
+				// index-aligned with `creates` (ordered Task.async_stream phases
+				// since engram#1194, pinned by a backend channel test with a
+				// mid-batch conflict), and an id_conflict result echoes the
+				// EXISTING note's id, not the one we sent — an id lookup would
+				// miss it.
 				for (let i = 0; i < sent.length; i++) {
 					const e = sent[i]!;
 					const r = results[i];


### PR DESCRIPTION
## Summary
Comment-only change. The batch-create result-matching comment in `src/sync.ts` still claimed ordering came from a server-side `Enum.map_reduce`; since engram#1194 the backend runs parallel `Task.async_stream` phases and guarantees `results` is index-aligned with `creates` (pinned by a backend channel test with a mid-batch conflict). Updated the comment to state the actual contract, including why an id lookup would miss `id_conflict` echoes.

## Test plan
- `bun test` (2373 pass), `biome ci`, `lint:obsidian`, `lint:css` all green
- No code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015buSiNhFQTvQ8ELdkTuLpz