### PR TITLE
fix(settings): isConnected guard on the progress-bar render

### DIFF
--- a/main.js
+++ b/main.js
@@ -18460,6 +18460,28 @@ function renderSyncCenterTab(ctx) {
 }
 
 // src/settings.ts
+function makeProgressBarRender(progressContainer, progressLabel, progressBarInner, getPlannedPhases) {
+  let prevTotals = /* @__PURE__ */ new Map();
+  return (progress) => {
+    var _a, _b, _c;
+    if (!progressContainer.isConnected) return;
+    if (progress.phase === "complete") {
+      progressContainer.removeClass("is-active"), prevTotals.clear();
+      return;
+    }
+    progressContainer.hasClass("is-active") || prevTotals.clear(), progressContainer.addClass("is-active");
+    let planned = (_a = getPlannedPhases()) == null ? void 0 : _a.find((p) => p.phase === progress.phase), { current, total, pct } = settingsBarCounts(
+      progress,
+      planned,
+      (_b = prevTotals.get(progress.phase)) != null ? _b : 0
+    );
+    prevTotals.set(progress.phase, total);
+    let phaseLabel = (_c = PHASE_FALLBACK_LABEL[progress.phase]) != null ? _c : progress.phase, failedSuffix = progress.failed > 0 ? ` (${progress.failed} failed)` : "";
+    progressLabel.setText(
+      total > 0 ? `${phaseLabel}... ${current}/${total}${failedSuffix}` : `${phaseLabel}... ${current}${failedSuffix}`
+    ), progressBarInner.style.width = `${pct}%`;
+  };
+}
 var EngramSyncSettingTab = class extends import_obsidian23.PluginSettingTab {
   constructor(app, plugin) {
     super(app, plugin);
@@ -18534,25 +18556,15 @@ var EngramSyncSettingTab = class extends import_obsidian23.PluginSettingTab {
     let progressContainer = containerEl.createDiv({ cls: "engram-sync-progress" }), progressLabel = progressContainer.createEl("p", {
       text: "Syncing...",
       cls: "engram-progress-label"
-    }), progressBarInner = progressContainer.createDiv({ cls: "engram-progress-bar-outer" }).createDiv({ cls: "engram-progress-bar-inner" }), prevTotals = /* @__PURE__ */ new Map();
-    this.installProgressBar((progress) => {
-      var _a, _b, _c;
-      if (progress.phase === "complete") {
-        progressContainer.removeClass("is-active"), prevTotals.clear();
-        return;
-      }
-      progressContainer.hasClass("is-active") || prevTotals.clear(), progressContainer.addClass("is-active");
-      let planned = (_a = this.plugin.activeSyncPhases) == null ? void 0 : _a.find((p) => p.phase === progress.phase), { current, total, pct } = settingsBarCounts(
-        progress,
-        planned,
-        (_b = prevTotals.get(progress.phase)) != null ? _b : 0
-      );
-      prevTotals.set(progress.phase, total);
-      let phaseLabel = (_c = PHASE_FALLBACK_LABEL[progress.phase]) != null ? _c : progress.phase, failedSuffix = progress.failed > 0 ? ` (${progress.failed} failed)` : "";
-      progressLabel.setText(
-        total > 0 ? `${phaseLabel}... ${current}/${total}${failedSuffix}` : `${phaseLabel}... ${current}${failedSuffix}`
-      ), progressBarInner.style.width = `${pct}%`;
-    });
+    }), progressBarInner = progressContainer.createDiv({ cls: "engram-progress-bar-outer" }).createDiv({ cls: "engram-progress-bar-inner" });
+    this.installProgressBar(
+      makeProgressBarRender(
+        progressContainer,
+        progressLabel,
+        progressBarInner,
+        () => this.plugin.activeSyncPhases
+      )
+    );
     let tabs = [
       { id: "about", label: "\u{1F44B} Welcome", render: renderAboutTab },
       { id: "account", label: "\u2601\uFE0F Cloud", render: renderAccountTab },

--- a/main.js
+++ b/main.js
@@ -35,9 +35,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 )), __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: !0 }), mod);
 var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key != "symbol" ? key + "" : key, value);
 
-// ../../node_modules/diff-match-patch/index.js
+// node_modules/diff-match-patch/index.js
 var require_diff_match_patch = __commonJS({
-  "../../node_modules/diff-match-patch/index.js"(exports, module2) {
+  "node_modules/diff-match-patch/index.js"(exports, module2) {
     var diff_match_patch5 = function() {
       this.Diff_Timeout = 1, this.Diff_EditCost = 4, this.Match_Threshold = 0.5, this.Match_Distance = 1e3, this.Patch_DeleteThreshold = 0.5, this.Patch_Margin = 4, this.Match_MaxBits = 32;
     }, DIFF_DELETE = -1, DIFF_INSERT = 1, DIFF_EQUAL = 0;
@@ -2297,7 +2297,7 @@ function textDiffToChangeSpec(before, after) {
 // src/crdt/live/live-binding-decisions.ts
 var import_diff_match_patch2 = __toESM(require_diff_match_patch(), 1);
 
-// ../../node_modules/yaml/browser/dist/nodes/identity.js
+// node_modules/yaml/browser/dist/nodes/identity.js
 var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias"), DOC = /* @__PURE__ */ Symbol.for("yaml.document"), MAP = /* @__PURE__ */ Symbol.for("yaml.map"), PAIR = /* @__PURE__ */ Symbol.for("yaml.pair"), SCALAR = /* @__PURE__ */ Symbol.for("yaml.scalar"), SEQ = /* @__PURE__ */ Symbol.for("yaml.seq"), NODE_TYPE = /* @__PURE__ */ Symbol.for("yaml.node.type"), isAlias = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === ALIAS, isDocument = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === DOC, isMap = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === MAP, isPair = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === PAIR, isScalar = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SCALAR, isSeq = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SEQ;
 function isCollection(node) {
   if (node && typeof node == "object")
@@ -2321,7 +2321,7 @@ function isNode(node) {
 }
 var hasAnchor = (node) => (isScalar(node) || isCollection(node)) && !!node.anchor;
 
-// ../../node_modules/yaml/browser/dist/visit.js
+// node_modules/yaml/browser/dist/visit.js
 var BREAK = /* @__PURE__ */ Symbol("break visit"), SKIP = /* @__PURE__ */ Symbol("skip children"), REMOVE = /* @__PURE__ */ Symbol("remove node");
 function visit(node, visitor) {
   let visitor_ = initVisitor(visitor);
@@ -2443,7 +2443,7 @@ function replaceNode(key, path, node) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/doc/directives.js
+// node_modules/yaml/browser/dist/doc/directives.js
 var escapeChars = {
   "!": "%21",
   ",": "%2C",
@@ -2561,7 +2561,7 @@ var escapeChars = {
 Directives.defaultYaml = { explicit: !1, version: "1.2" };
 Directives.defaultTags = { "!!": "tag:yaml.org,2002:" };
 
-// ../../node_modules/yaml/browser/dist/doc/anchors.js
+// node_modules/yaml/browser/dist/doc/anchors.js
 function anchorIsValid(anchor) {
   if (/[\x00-\x19\s,[\]{}]/.test(anchor)) {
     let msg = `Anchor must not contain whitespace or control characters: ${JSON.stringify(anchor)}`;
@@ -2612,7 +2612,7 @@ function createNodeAnchors(doc2, prefix) {
   };
 }
 
-// ../../node_modules/yaml/browser/dist/doc/applyReviver.js
+// node_modules/yaml/browser/dist/doc/applyReviver.js
 function applyReviver(reviver, obj, key, val) {
   if (val && typeof val == "object")
     if (Array.isArray(val))
@@ -2638,7 +2638,7 @@ function applyReviver(reviver, obj, key, val) {
   return reviver.call(obj, key, val);
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/toJS.js
+// node_modules/yaml/browser/dist/nodes/toJS.js
 function toJS(value, arg, ctx) {
   if (Array.isArray(value))
     return value.map((v, i) => toJS(v, String(i), ctx));
@@ -2655,7 +2655,7 @@ function toJS(value, arg, ctx) {
   return typeof value == "bigint" && !(ctx != null && ctx.keep) ? Number(value) : value;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Node.js
+// node_modules/yaml/browser/dist/nodes/Node.js
 var NodeBase = class {
   constructor(type) {
     Object.defineProperty(this, NODE_TYPE, { value: type });
@@ -2684,7 +2684,7 @@ var NodeBase = class {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/nodes/Alias.js
+// node_modules/yaml/browser/dist/nodes/Alias.js
 var Alias = class extends NodeBase {
   constructor(source) {
     super(ALIAS), this.source = source, Object.defineProperty(this, "tag", {
@@ -2764,7 +2764,7 @@ function getAliasCount(doc2, node, anchors) {
   return 1;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Scalar.js
+// node_modules/yaml/browser/dist/nodes/Scalar.js
 var isScalarValue = (value) => !value || typeof value != "function" && typeof value != "object", Scalar = class extends NodeBase {
   constructor(value) {
     super(SCALAR), this.value = value;
@@ -2782,7 +2782,7 @@ Scalar.PLAIN = "PLAIN";
 Scalar.QUOTE_DOUBLE = "QUOTE_DOUBLE";
 Scalar.QUOTE_SINGLE = "QUOTE_SINGLE";
 
-// ../../node_modules/yaml/browser/dist/doc/createNode.js
+// node_modules/yaml/browser/dist/doc/createNode.js
 var defaultTagPrefix = "tag:yaml.org,2002:";
 function findTagObject(value, tagName, tags) {
   var _a;
@@ -2826,7 +2826,7 @@ function createNode(value, tagName, ctx) {
   return tagName ? node.tag = tagName : tagObj.default || (node.tag = tagObj.tag), ref && (ref.node = node), node;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Collection.js
+// node_modules/yaml/browser/dist/nodes/Collection.js
 function collectionFromPath(schema4, path, value) {
   let v = value;
   for (let i = path.length - 1; i >= 0; --i) {
@@ -2943,7 +2943,7 @@ var isEmptyPath = (path) => path == null || typeof path == "object" && !!path[Sy
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyComment.js
+// node_modules/yaml/browser/dist/stringify/stringifyComment.js
 var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
 function indentComment(comment, indent) {
   return /^\n+$/.test(comment) ? comment.substring(1) : indent ? comment.replace(/^(?! *$)/gm, indent) : comment;
@@ -2953,7 +2953,7 @@ var lineComment = (str, indent, comment) => str.endsWith(`
 `) ? `
 ` + indentComment(comment, indent) : (str.endsWith(" ") ? "" : " ") + comment;
 
-// ../../node_modules/yaml/browser/dist/stringify/foldFlowLines.js
+// node_modules/yaml/browser/dist/stringify/foldFlowLines.js
 var FOLD_FLOW = "flow", FOLD_BLOCK = "block", FOLD_QUOTED = "quoted";
 function foldFlowLines(text2, indent, mode = "flow", { indentAtStart, lineWidth = 80, minContentWidth = 20, onFold, onOverflow } = {}) {
   if (!lineWidth || lineWidth < 0)
@@ -3035,7 +3035,7 @@ function consumeMoreIndentedLines(text2, i, indent) {
   return end;
 }
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyString.js
+// node_modules/yaml/browser/dist/stringify/stringifyString.js
 var getFoldOptions = (ctx, isBlock2) => ({
   indentAtStart: isBlock2 ? ctx.indent.length : ctx.indentAtStart,
   lineWidth: ctx.options.lineWidth,
@@ -3247,7 +3247,7 @@ function stringifyString(item, ctx, onComment, onChompKeep) {
   return res;
 }
 
-// ../../node_modules/yaml/browser/dist/stringify/stringify.js
+// node_modules/yaml/browser/dist/stringify/stringify.js
 function createStringifyContext(doc2, options) {
   let opt = Object.assign({
     blockQuote: !0,
@@ -3345,7 +3345,7 @@ function stringify(item, ctx, onComment, onChompKeep) {
 ${ctx.indent}${str}` : str;
 }
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyPair.js
+// node_modules/yaml/browser/dist/stringify/stringifyPair.js
 function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
   var _a, _b;
   let { allNullValues, doc: doc2, indent, indentStep, options: { commentString, indentSeq, simpleKeys } } = ctx, keyComment = isNode(key) && key.comment || null;
@@ -3408,12 +3408,12 @@ ${ctx.indent}`);
   return str += ws + valueStr, ctx.inFlow ? valueCommentDone && onComment && onComment() : valueComment && !valueCommentDone ? str += lineComment(str, ctx.indent, commentString(valueComment)) : chompKeep && onChompKeep && onChompKeep(), str;
 }
 
-// ../../node_modules/yaml/browser/dist/log.js
+// node_modules/yaml/browser/dist/log.js
 function warn(logLevel, warning) {
   (logLevel === "debug" || logLevel === "warn") && console.warn(warning);
 }
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/merge.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/merge.js
 var MERGE_KEY = "<<", merge = {
   identify: (value) => value === MERGE_KEY || typeof value == "symbol" && value.description === MERGE_KEY,
   default: "key",
@@ -3453,7 +3453,7 @@ function resolveAliasValue(ctx, value) {
   return ctx && isAlias(value) ? value.resolve(ctx.doc, ctx) : value;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/addPairToJSMap.js
+// node_modules/yaml/browser/dist/nodes/addPairToJSMap.js
 function addPairToJSMap(ctx, map3, { key, value }) {
   if (isNode(key) && key.addToJSMap)
     key.addToJSMap(ctx, map3, value);
@@ -3498,7 +3498,7 @@ function stringifyKey(key, jsKey, ctx) {
   return JSON.stringify(jsKey);
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Pair.js
+// node_modules/yaml/browser/dist/nodes/Pair.js
 function createPair(key, value, ctx) {
   let k = createNode(key, void 0, ctx), v = createNode(value, void 0, ctx);
   return new Pair(k, v);
@@ -3520,7 +3520,7 @@ var Pair = class _Pair {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyCollection.js
+// node_modules/yaml/browser/dist/stringify/stringifyCollection.js
 function stringifyCollection(collection, ctx, options) {
   var _a;
   return (((_a = ctx.inFlow) != null ? _a : collection.flow) ? stringifyFlowCollection : stringifyBlockCollection)(collection, ctx, options);
@@ -3602,7 +3602,7 @@ function addCommentBefore({ indent, options: { commentString } }, lines, comment
   }
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/YAMLMap.js
+// node_modules/yaml/browser/dist/nodes/YAMLMap.js
 function findPair(items, key) {
   let k = isScalar(key) ? key.value : key;
   for (let it of items)
@@ -3700,7 +3700,7 @@ var YAMLMap = class extends Collection {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/common/map.js
+// node_modules/yaml/browser/dist/schema/common/map.js
 var map = {
   collection: "map",
   default: !0,
@@ -3712,7 +3712,7 @@ var map = {
   createNode: (schema4, obj, ctx) => YAMLMap.from(schema4, obj, ctx)
 };
 
-// ../../node_modules/yaml/browser/dist/nodes/YAMLSeq.js
+// node_modules/yaml/browser/dist/nodes/YAMLSeq.js
 var YAMLSeq = class extends Collection {
   static get tagName() {
     return "tag:yaml.org,2002:seq";
@@ -3803,7 +3803,7 @@ function asItemIndex(key) {
   return idx && typeof idx == "string" && (idx = Number(idx)), typeof idx == "number" && Number.isInteger(idx) && idx >= 0 ? idx : null;
 }
 
-// ../../node_modules/yaml/browser/dist/schema/common/seq.js
+// node_modules/yaml/browser/dist/schema/common/seq.js
 var seq = {
   collection: "seq",
   default: !0,
@@ -3815,7 +3815,7 @@ var seq = {
   createNode: (schema4, obj, ctx) => YAMLSeq.from(schema4, obj, ctx)
 };
 
-// ../../node_modules/yaml/browser/dist/schema/common/string.js
+// node_modules/yaml/browser/dist/schema/common/string.js
 var string = {
   identify: (value) => typeof value == "string",
   default: !0,
@@ -3826,7 +3826,7 @@ var string = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/common/null.js
+// node_modules/yaml/browser/dist/schema/common/null.js
 var nullTag = {
   identify: (value) => value == null,
   createNode: () => new Scalar(null),
@@ -3837,7 +3837,7 @@ var nullTag = {
   stringify: ({ source }, ctx) => typeof source == "string" && nullTag.test.test(source) ? source : ctx.options.nullStr
 };
 
-// ../../node_modules/yaml/browser/dist/schema/core/bool.js
+// node_modules/yaml/browser/dist/schema/core/bool.js
 var boolTag = {
   identify: (value) => typeof value == "boolean",
   default: !0,
@@ -3854,7 +3854,7 @@ var boolTag = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyNumber.js
+// node_modules/yaml/browser/dist/stringify/stringifyNumber.js
 function stringifyNumber({ format, minFractionDigits, tag, value }) {
   if (typeof value == "bigint")
     return String(value);
@@ -3872,7 +3872,7 @@ function stringifyNumber({ format, minFractionDigits, tag, value }) {
   return n;
 }
 
-// ../../node_modules/yaml/browser/dist/schema/core/float.js
+// node_modules/yaml/browser/dist/schema/core/float.js
 var floatNaN = {
   identify: (value) => typeof value == "number",
   default: !0,
@@ -3903,7 +3903,7 @@ var floatNaN = {
   stringify: stringifyNumber
 };
 
-// ../../node_modules/yaml/browser/dist/schema/core/int.js
+// node_modules/yaml/browser/dist/schema/core/int.js
 var intIdentify = (value) => typeof value == "bigint" || Number.isInteger(value), intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
 function intStringify(node, radix, prefix) {
   let { value } = node;
@@ -3934,7 +3934,7 @@ var intOct = {
   stringify: (node) => intStringify(node, 16, "0x")
 };
 
-// ../../node_modules/yaml/browser/dist/schema/core/schema.js
+// node_modules/yaml/browser/dist/schema/core/schema.js
 var schema = [
   map,
   seq,
@@ -3949,7 +3949,7 @@ var schema = [
   float
 ];
 
-// ../../node_modules/yaml/browser/dist/schema/json/schema.js
+// node_modules/yaml/browser/dist/schema/json/schema.js
 function intIdentify2(value) {
   return typeof value == "bigint" || Number.isInteger(value);
 }
@@ -4003,7 +4003,7 @@ var stringifyJSON = ({ value }) => JSON.stringify(value), jsonScalars = [
   }
 }, schema2 = [map, seq].concat(jsonScalars, jsonError);
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/binary.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/binary.js
 var binary = {
   identify: (value) => value instanceof Uint8Array,
   // Buffer inherits from Uint8Array
@@ -4048,7 +4048,7 @@ var binary = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/pairs.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/pairs.js
 function resolvePairs(seq2, onError) {
   var _a;
   if (isSeq(seq2))
@@ -4106,7 +4106,7 @@ var pairs = {
   createNode: createPairs
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/omap.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/omap.js
 var YAMLOMap = class _YAMLOMap extends YAMLSeq {
   constructor() {
     super(), this.add = YAMLMap.prototype.add.bind(this), this.delete = YAMLMap.prototype.delete.bind(this), this.get = YAMLMap.prototype.get.bind(this), this.has = YAMLMap.prototype.has.bind(this), this.set = YAMLMap.prototype.set.bind(this), this.tag = _YAMLOMap.tag;
@@ -4149,7 +4149,7 @@ var omap = {
   createNode: (schema4, iterable, ctx) => YAMLOMap.from(schema4, iterable, ctx)
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/bool.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/bool.js
 function boolStringify({ value, source }, ctx) {
   return source && (value ? trueTag : falseTag).test.test(source) ? source : value ? ctx.options.trueStr : ctx.options.falseStr;
 }
@@ -4169,7 +4169,7 @@ var trueTag = {
   stringify: boolStringify
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/float.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/float.js
 var floatNaN2 = {
   identify: (value) => typeof value == "number",
   default: !0,
@@ -4204,7 +4204,7 @@ var floatNaN2 = {
   stringify: stringifyNumber
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/int.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/int.js
 var intIdentify3 = (value) => typeof value == "bigint" || Number.isInteger(value);
 function intResolve2(str, offset, radix, { intAsBigInt }) {
   let sign = str[0];
@@ -4267,7 +4267,7 @@ var intBin = {
   stringify: (node) => intStringify2(node, 16, "0x")
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/set.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/set.js
 var YAMLSet = class _YAMLSet extends YAMLMap {
   constructor(schema4) {
     super(schema4), this.tag = _YAMLSet.tag;
@@ -4327,7 +4327,7 @@ var set = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/timestamp.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/timestamp.js
 function parseSexagesimal(str, asBigInt) {
   let sign = str[0], parts = sign === "-" || sign === "+" ? str.substring(1) : str, num = (n) => asBigInt ? BigInt(n) : Number(n), res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
   return sign === "-" ? num(-1) * res : res;
@@ -4384,7 +4384,7 @@ var intTime = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/schema.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/schema.js
 var schema3 = [
   map,
   seq,
@@ -4409,7 +4409,7 @@ var schema3 = [
   timestamp
 ];
 
-// ../../node_modules/yaml/browser/dist/schema/tags.js
+// node_modules/yaml/browser/dist/schema/tags.js
 var schemas = /* @__PURE__ */ new Map([
   ["core", schema],
   ["failsafe", [map, seq, string]],
@@ -4469,7 +4469,7 @@ function getTags(customTags, schemaName, addMergeTag) {
   }, []);
 }
 
-// ../../node_modules/yaml/browser/dist/schema/Schema.js
+// node_modules/yaml/browser/dist/schema/Schema.js
 var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0, Schema = class _Schema {
   constructor({ compat, customTags, merge: merge2, resolveKnownTags, schema: schema4, sortMapEntries, toStringDefaults }) {
     this.compat = Array.isArray(compat) ? getTags(compat, "compat") : compat ? getTags(null, compat) : null, this.name = typeof schema4 == "string" && schema4 || "core", this.knownTags = resolveKnownTags ? coreKnownTags : {}, this.tags = getTags(customTags, this.name, merge2), this.toStringOptions = toStringDefaults != null ? toStringDefaults : null, Object.defineProperty(this, MAP, { value: map }), Object.defineProperty(this, SCALAR, { value: string }), Object.defineProperty(this, SEQ, { value: seq }), this.sortMapEntries = typeof sortMapEntries == "function" ? sortMapEntries : sortMapEntries === !0 ? sortMapEntriesByKey : null;
@@ -4480,7 +4480,7 @@ var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0, 
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyDocument.js
+// node_modules/yaml/browser/dist/stringify/stringifyDocument.js
 function stringifyDocument(doc2, options) {
   var _a;
   let lines = [], hasDirectives = options.directives === !0;
@@ -4524,7 +4524,7 @@ function stringifyDocument(doc2, options) {
 `;
 }
 
-// ../../node_modules/yaml/browser/dist/doc/Document.js
+// node_modules/yaml/browser/dist/doc/Document.js
 var Document = class _Document {
   constructor(value, replacer, options) {
     this.commentBefore = null, this.comment = null, this.errors = [], this.warnings = [], Object.defineProperty(this, NODE_TYPE, { value: DOC });
@@ -4741,7 +4741,7 @@ function assertCollection(contents) {
   throw new Error("Expected a YAML collection as document contents");
 }
 
-// ../../node_modules/yaml/browser/dist/errors.js
+// node_modules/yaml/browser/dist/errors.js
 var YAMLError = class extends Error {
   constructor(name, pos, code, message) {
     super(), this.name = name, this.code = code, this.message = message, this.pos = pos;
@@ -4782,7 +4782,7 @@ ${pointer}
   }
 };
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-props.js
+// node_modules/yaml/browser/dist/compose/resolve-props.js
 function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
   let spaceBefore = !1, atNewline = startOnNewline, hasSpace = startOnNewline, comment = "", commentSep = "", hasNewline = !1, reqSpace = !1, tab = null, anchor = null, tag = null, newlineAfterProp = null, comma = null, found = null, start = null;
   for (let token of tokens)
@@ -4833,7 +4833,7 @@ function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIn
   };
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-contains-newline.js
+// node_modules/yaml/browser/dist/compose/util-contains-newline.js
 function containsNewline(key) {
   if (!key)
     return null;
@@ -4870,7 +4870,7 @@ function containsNewline(key) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-flow-indent-check.js
+// node_modules/yaml/browser/dist/compose/util-flow-indent-check.js
 function flowIndentCheck(indent, fc, onError) {
   if ((fc == null ? void 0 : fc.type) === "flow-collection") {
     let end = fc.end[0];
@@ -4878,7 +4878,7 @@ function flowIndentCheck(indent, fc, onError) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-map-includes.js
+// node_modules/yaml/browser/dist/compose/util-map-includes.js
 function mapIncludes(ctx, items, search) {
   let { uniqueKeys } = ctx.options;
   if (uniqueKeys === !1)
@@ -4887,7 +4887,7 @@ function mapIncludes(ctx, items, search) {
   return items.some((pair) => isEqual(pair.key, search));
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-block-map.js
+// node_modules/yaml/browser/dist/compose/resolve-block-map.js
 var startColMsg = "All mapping items must start at the same column";
 function resolveBlockMap({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, bm, onError, tag) {
   var _a, _b;
@@ -4938,7 +4938,7 @@ function resolveBlockMap({ composeNode: composeNode2, composeEmptyNode: composeE
   return commentEnd && commentEnd < offset && onError(commentEnd, "IMPOSSIBLE", "Map comment with trailing content"), map3.range = [bm.offset, offset, commentEnd != null ? commentEnd : offset], map3;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-block-seq.js
+// node_modules/yaml/browser/dist/compose/resolve-block-seq.js
 function resolveBlockSeq({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, bs, onError, tag) {
   var _a;
   let NodeClass = (_a = tag == null ? void 0 : tag.nodeClass) != null ? _a : YAMLSeq, seq2 = new NodeClass(ctx.schema);
@@ -4966,7 +4966,7 @@ function resolveBlockSeq({ composeNode: composeNode2, composeEmptyNode: composeE
   return seq2.range = [bs.offset, offset, commentEnd != null ? commentEnd : offset], seq2;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-end.js
+// node_modules/yaml/browser/dist/compose/resolve-end.js
 function resolveEnd(end, offset, reqSpace, onError) {
   let comment = "";
   if (end) {
@@ -4995,7 +4995,7 @@ function resolveEnd(end, offset, reqSpace, onError) {
   return { comment, offset };
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-flow-collection.js
+// node_modules/yaml/browser/dist/compose/resolve-flow-collection.js
 var blockMsg = "Block collections are not allowed within flow collections", isBlock = (token) => token && (token.type === "block-map" || token.type === "block-seq");
 function resolveFlowCollection({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, fc, onError, tag) {
   var _a, _b, _c;
@@ -5110,7 +5110,7 @@ function resolveFlowCollection({ composeNode: composeNode2, composeEmptyNode: co
   return coll;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-collection.js
+// node_modules/yaml/browser/dist/compose/compose-collection.js
 function resolveCollection(CN2, ctx, token, onError, tagName, tag) {
   let coll = token.type === "block-map" ? resolveBlockMap(CN2, ctx, token, onError, tag) : token.type === "block-seq" ? resolveBlockSeq(CN2, ctx, token, onError, tag) : resolveFlowCollection(CN2, ctx, token, onError, tag), Coll = coll.constructor;
   return tagName === "!" || tagName === Coll.tagName ? (coll.tag = Coll.tagName, coll) : (tagName && (coll.tag = tagName), coll);
@@ -5137,7 +5137,7 @@ function composeCollection(CN2, ctx, token, props, onError) {
   return node.range = coll.range, node.tag = tagName, tag != null && tag.format && (node.format = tag.format), node;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-block-scalar.js
+// node_modules/yaml/browser/dist/compose/resolve-block-scalar.js
 function resolveBlockScalar(ctx, scalar, onError) {
   let start = scalar.offset, header = parseBlockScalarHeader(scalar, ctx.options.strict, onError);
   if (!header)
@@ -5257,7 +5257,7 @@ function splitLines(source) {
   return lines;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-flow-scalar.js
+// node_modules/yaml/browser/dist/compose/resolve-flow-scalar.js
 function resolveFlowScalar(scalar, strict, onError) {
   let { offset, type, source, end } = scalar, _type, value, _onError = (rel, code, msg) => onError(offset + rel, code, msg);
   switch (type) {
@@ -5432,7 +5432,7 @@ function parseCharCode(source, offset, length2, onError) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-scalar.js
+// node_modules/yaml/browser/dist/compose/compose-scalar.js
 function composeScalar(ctx, token, tagToken, onError) {
   let { value, type, comment, range } = token.type === "block-scalar" ? resolveBlockScalar(ctx, token, onError) : resolveFlowScalar(token, ctx.options.strict, onError), tagName = tagToken ? ctx.directives.tagName(tagToken.source, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg)) : null, tag;
   ctx.options.stringKeys && ctx.atKey ? tag = ctx.schema[SCALAR] : tagName ? tag = findScalarTagByName(ctx.schema, value, tagName, tagToken, onError) : token.type === "scalar" ? tag = findScalarTagByTest(ctx, value, token, onError) : tag = ctx.schema[SCALAR];
@@ -5482,7 +5482,7 @@ function findScalarTagByTest({ atKey, directives, schema: schema4 }, value, toke
   return tag;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-empty-scalar-position.js
+// node_modules/yaml/browser/dist/compose/util-empty-scalar-position.js
 function emptyScalarPosition(offset, before, pos) {
   if (before) {
     pos != null || (pos = before.length);
@@ -5503,7 +5503,7 @@ function emptyScalarPosition(offset, before, pos) {
   return offset;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-node.js
+// node_modules/yaml/browser/dist/compose/compose-node.js
 var CN = { composeNode, composeEmptyNode };
 function composeNode(ctx, token, props, onError) {
   let atKey = ctx.atKey, { spaceBefore, comment, anchor, tag } = props, node, isSrcToken = !0;
@@ -5550,7 +5550,7 @@ function composeAlias({ options }, { offset, source, end }, onError) {
   return alias.range = [offset, valueEnd, re.offset], re.comment && (alias.comment = re.comment), alias;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-doc.js
+// node_modules/yaml/browser/dist/compose/compose-doc.js
 function composeDoc(options, directives, { offset, start, value, end }, onError) {
   let opts = Object.assign({ _directives: directives }, options), doc2 = new Document(void 0, opts), ctx = {
     atKey: !1,
@@ -5571,7 +5571,7 @@ function composeDoc(options, directives, { offset, start, value, end }, onError)
   return re.comment && (doc2.comment = re.comment), doc2.range = [offset, contentEnd, re.offset], doc2;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/composer.js
+// node_modules/yaml/browser/dist/compose/composer.js
 function getErrorPos(src) {
   if (typeof src == "number")
     return [src, src + 1];
@@ -5724,7 +5724,7 @@ ${end.comment}` : end.comment;
   }
 };
 
-// ../../node_modules/yaml/browser/dist/parse/cst-visit.js
+// node_modules/yaml/browser/dist/parse/cst-visit.js
 var BREAK2 = /* @__PURE__ */ Symbol("break visit"), SKIP2 = /* @__PURE__ */ Symbol("skip children"), REMOVE2 = /* @__PURE__ */ Symbol("remove item");
 function visit2(cst, visitor) {
   "type" in cst && cst.type === "document" && (cst = { start: cst.start, value: cst.value }), _visit(Object.freeze([]), cst, visitor);
@@ -5772,7 +5772,7 @@ function _visit(path, item, visitor) {
   return typeof ctrl == "function" ? ctrl(item, path) : ctrl;
 }
 
-// ../../node_modules/yaml/browser/dist/parse/cst.js
+// node_modules/yaml/browser/dist/parse/cst.js
 var BOM = "\uFEFF", DOCUMENT = "", FLOW_END = "", SCALAR2 = "";
 function tokenType(source) {
   switch (source) {
@@ -5836,7 +5836,7 @@ function tokenType(source) {
   return null;
 }
 
-// ../../node_modules/yaml/browser/dist/parse/lexer.js
+// node_modules/yaml/browser/dist/parse/lexer.js
 function isEmpty(ch) {
   switch (ch) {
     case void 0:
@@ -6273,7 +6273,7 @@ var hexDigits = new Set("0123456789ABCDEFabcdef"), tagChars = new Set("012345678
   }
 };
 
-// ../../node_modules/yaml/browser/dist/parse/line-counter.js
+// node_modules/yaml/browser/dist/parse/line-counter.js
 var LineCounter = class {
   constructor() {
     this.lineStarts = [], this.addNewLine = (offset) => this.lineStarts.push(offset), this.linePos = (offset) => {
@@ -6292,7 +6292,7 @@ var LineCounter = class {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/parse/parser.js
+// node_modules/yaml/browser/dist/parse/parser.js
 function includesToken(list2, type) {
   for (let i = 0; i < list2.length; ++i)
     if (list2[i].type === type)
@@ -6949,7 +6949,7 @@ var Parser = class {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/public-api.js
+// node_modules/yaml/browser/dist/public-api.js
 function parseOptions(options) {
   let prettyErrors = options.prettyErrors !== !1;
   return { lineCounter: options.lineCounter || prettyErrors && new LineCounter() || null, prettyErrors };
@@ -7949,7 +7949,7 @@ var list = (items, max2 = 5) => {
   }
 };
 
-// ../../node_modules/lib0/map.js
+// node_modules/lib0/map.js
 var create = () => /* @__PURE__ */ new Map(), copy = (m) => {
   let r = create();
   return m.forEach((v, k) => {
@@ -7970,10 +7970,10 @@ var create = () => /* @__PURE__ */ new Map(), copy = (m) => {
   return !1;
 };
 
-// ../../node_modules/lib0/set.js
+// node_modules/lib0/set.js
 var create2 = () => /* @__PURE__ */ new Set();
 
-// ../../node_modules/lib0/array.js
+// node_modules/lib0/array.js
 var last = (arr) => arr[arr.length - 1];
 var appendTo = (dest, src) => {
   for (let i = 0; i < src.length; i++)
@@ -7997,7 +7997,7 @@ var unfold = (len, f) => {
 };
 var isArray = Array.isArray;
 
-// ../../node_modules/lib0/observable.js
+// node_modules/lib0/observable.js
 var ObservableV2 = class {
   constructor() {
     this._observers = create();
@@ -8105,17 +8105,17 @@ var ObservableV2 = class {
   }
 };
 
-// ../../node_modules/lib0/math.js
+// node_modules/lib0/math.js
 var floor = Math.floor;
 var abs = Math.abs;
 var min = (a, b) => a < b ? a : b, max = (a, b) => a > b ? a : b, isNaN2 = Number.isNaN;
 var isNegativeZero = (n) => n !== 0 ? n < 0 : 1 / n < 0;
 
-// ../../node_modules/lib0/number.js
+// node_modules/lib0/number.js
 var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER, MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER, LOWEST_INT32 = 1 << 31;
 var isInteger = Number.isInteger || ((num) => typeof num == "number" && isFinite(num) && floor(num) === num), isNaN3 = Number.isNaN, parseInt2 = Number.parseInt;
 
-// ../../node_modules/lib0/string.js
+// node_modules/lib0/string.js
 var fromCharCode = String.fromCharCode, fromCodePoint = String.fromCodePoint, MAX_UTF16_CHARACTER = fromCharCode(65535), toLowerCase = (s) => s.toLowerCase(), trimLeftRegex = /^\s*/g, trimLeft = (s) => s.replace(trimLeftRegex, ""), fromCamelCaseRegex = /([A-Z])/g, fromCamelCase = (s, separator) => trimLeft(s.replace(fromCamelCaseRegex, (match2) => `${separator}${toLowerCase(match2)}`));
 var _encodeUtf8Polyfill = (str) => {
   let encodedString = unescape(encodeURIComponent(str)), len = encodedString.length, buf = new Uint8Array(len);
@@ -8131,7 +8131,7 @@ var utf8TextDecoder = typeof TextDecoder == "undefined" ? null : new TextDecoder
 utf8TextDecoder && utf8TextDecoder.decode(new Uint8Array()).length === 1 && (utf8TextDecoder = null);
 var repeat = (source, n) => unfold(n, () => source).join("");
 
-// ../../node_modules/lib0/encoding.js
+// node_modules/lib0/encoding.js
 var Encoder = class {
   constructor() {
     this.cpos = 0, this.cbuf = new Uint8Array(100), this.bufs = [];
@@ -8308,14 +8308,14 @@ var flushIntDiffOptRleEncoder = (encoder) => {
   }
 };
 
-// ../../node_modules/lib0/error.js
+// node_modules/lib0/error.js
 var create3 = (s) => new Error(s), methodUnimplemented = () => {
   throw create3("Method unimplemented");
 }, unexpectedCase = () => {
   throw create3("Unexpected case");
 };
 
-// ../../node_modules/lib0/decoding.js
+// node_modules/lib0/decoding.js
 var errorUnexpectedEndOfArray = create3("Unexpected end of array"), errorIntegerOutOfRange = create3("Integer out of Range"), Decoder = class {
   /**
    * @param {Uint8Array<Buf>} uint8Array Binary data to decode
@@ -8482,10 +8482,10 @@ var IntDiffOptRleDecoder = class extends Decoder {
   }
 };
 
-// ../../node_modules/lib0/webcrypto.js
+// node_modules/lib0/webcrypto.js
 var subtle = crypto.subtle, getRandomValues = crypto.getRandomValues.bind(crypto);
 
-// ../../node_modules/lib0/random.js
+// node_modules/lib0/random.js
 var uint32 = () => getRandomValues(new Uint32Array(1))[0];
 var uuidv4Template = "10000000-1000-4000-8000" + -1e11, uuidv4 = () => uuidv4Template.replace(
   /[018]/g,
@@ -8493,20 +8493,20 @@ var uuidv4Template = "10000000-1000-4000-8000" + -1e11, uuidv4 = () => uuidv4Tem
   (c) => (c ^ uint32() & 15 >> c / 4).toString(16)
 );
 
-// ../../node_modules/lib0/time.js
+// node_modules/lib0/time.js
 var getUnixTime = Date.now;
 
-// ../../node_modules/lib0/promise.js
+// node_modules/lib0/promise.js
 var create4 = (f) => (
   /** @type {Promise<T>} */
   new Promise(f)
 );
 var all = Promise.all.bind(Promise);
 
-// ../../node_modules/lib0/conditions.js
+// node_modules/lib0/conditions.js
 var undefinedToNull = (v) => v === void 0 ? null : v;
 
-// ../../node_modules/lib0/storage.js
+// node_modules/lib0/storage.js
 var VarStoragePolyfill = class {
   constructor() {
     this.map = /* @__PURE__ */ new Map();
@@ -8531,13 +8531,13 @@ try {
 }
 var varStorage = _localStorage;
 
-// ../../node_modules/lib0/trait/equality.js
+// node_modules/lib0/trait/equality.js
 var EqualityTraitSymbol = /* @__PURE__ */ Symbol("Equality"), equals = (a, b) => {
   var _a;
   return a === b || !!((_a = a == null ? void 0 : a[EqualityTraitSymbol]) != null && _a.call(a, b)) || !1;
 };
 
-// ../../node_modules/lib0/object.js
+// node_modules/lib0/object.js
 var isObject = (o) => typeof o == "object", assign = Object.assign, keys = Object.keys;
 var forEach = (obj, f) => {
   for (let key in obj)
@@ -8561,7 +8561,7 @@ var isEmpty2 = (obj) => {
   return freeze(o);
 };
 
-// ../../node_modules/lib0/function.js
+// node_modules/lib0/function.js
 var callAll = (fs, args2, i = 0) => {
   try {
     for (; i < fs.length; i++)
@@ -8627,7 +8627,7 @@ var equalityDeep = (a, b) => {
   return !0;
 }, isOneOf = (value, options) => options.includes(value);
 
-// ../../node_modules/lib0/environment.js
+// node_modules/lib0/environment.js
 var isNode2 = typeof process != "undefined" && process.release && /node|io\.js/.test(process.release.name) && Object.prototype.toString.call(typeof process != "undefined" ? process : 0) === "[object process]";
 var isMac = typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : !1, params, args = [], computeParams = () => {
   if (params === void 0)
@@ -8651,14 +8651,14 @@ var getVariable = (name) => isNode2 ? undefinedToNull(process.env[name.toUpperCa
 var hasConf = (name) => hasParam("--" + name) || getVariable(name) !== null, production = hasConf("production"), forceColor = isNode2 && isOneOf(process.env.FORCE_COLOR, ["true", "1", "2"]), supportsColor = forceColor || !hasParam("--no-colors") && // @todo deprecate --no-colors
 !hasConf("no-color") && (!isNode2 || process.stdout.isTTY) && (!isNode2 || hasParam("--color") || getVariable("COLORTERM") !== null || (getVariable("TERM") || "").includes("color"));
 
-// ../../node_modules/lib0/buffer.js
+// node_modules/lib0/buffer.js
 var createUint8ArrayFromLen = (len) => new Uint8Array(len);
 var copyUint8Array = (uint8Array) => {
   let newBuf = createUint8ArrayFromLen(uint8Array.byteLength);
   return newBuf.set(uint8Array), newBuf;
 };
 
-// ../../node_modules/lib0/pair.js
+// node_modules/lib0/pair.js
 var Pair2 = class {
   /**
    * @param {L} left
@@ -8669,7 +8669,7 @@ var Pair2 = class {
   }
 }, create5 = (left, right) => new Pair2(left, right);
 
-// ../../node_modules/lib0/prng.js
+// node_modules/lib0/prng.js
 var bool = (gen) => gen.next() >= 0.5, int53 = (gen, min2, max2) => floor(gen.next() * (max2 + 1 - min2) + min2);
 var int32 = (gen, min2, max2) => floor(gen.next() * (max2 + 1 - min2) + min2);
 var int31 = (gen, min2, max2) => int32(gen, min2, max2);
@@ -8681,7 +8681,7 @@ var letter = (gen) => fromCharCode(int31(gen, 97, 122)), word = (gen, minLen = 0
 };
 var oneOf = (gen, array) => array[int31(gen, 0, array.length - 1)];
 
-// ../../node_modules/lib0/schema.js
+// node_modules/lib0/schema.js
 var schemaSymbol = /* @__PURE__ */ Symbol("0schema"), ValidationError = class {
   constructor() {
     this._rerrs = [];
@@ -9275,7 +9275,7 @@ ${err.toString()}`);
   _random($(schema4), gen)
 );
 
-// ../../node_modules/lib0/dom.js
+// node_modules/lib0/dom.js
 var doc = (
   /** @type {Document} */
   typeof document != "undefined" ? document : {}
@@ -9290,10 +9290,10 @@ var $text = $custom((el) => el.nodeType === TEXT_NODE);
 var mapToStyleString = (m) => map2(m, (value, key) => `${key}:${value};`).join("");
 var ELEMENT_NODE = doc.ELEMENT_NODE, TEXT_NODE = doc.TEXT_NODE, CDATA_SECTION_NODE = doc.CDATA_SECTION_NODE, COMMENT_NODE = doc.COMMENT_NODE, DOCUMENT_NODE = doc.DOCUMENT_NODE, DOCUMENT_TYPE_NODE = doc.DOCUMENT_TYPE_NODE, DOCUMENT_FRAGMENT_NODE = doc.DOCUMENT_FRAGMENT_NODE, $node = $custom((el) => el.nodeType === DOCUMENT_NODE);
 
-// ../../node_modules/lib0/symbol.js
+// node_modules/lib0/symbol.js
 var create6 = Symbol;
 
-// ../../node_modules/lib0/logging.common.js
+// node_modules/lib0/logging.common.js
 var BOLD = create6(), UNBOLD = create6(), BLUE = create6(), GREY = create6(), GREEN = create6(), RED = create6(), PURPLE = create6(), ORANGE = create6(), UNCOLOR = create6(), computeNoColorLoggingArgs = (args2) => {
   var _a;
   args2.length === 1 && ((_a = args2[0]) == null ? void 0 : _a.constructor) === Function && (args2 = /** @type {Array<string|Symbol|Object|number>} */
@@ -9317,7 +9317,7 @@ var BOLD = create6(), UNBOLD = create6(), BLUE = create6(), GREY = create6(), GR
 };
 var lastLoggingTime = getUnixTime();
 
-// ../../node_modules/lib0/logging.js
+// node_modules/lib0/logging.js
 var _browserStyleMap = {
   [BOLD]: create5("font-weight", "bold"),
   [UNBOLD]: create5("font-weight", "normal"),
@@ -9361,7 +9361,7 @@ var _browserStyleMap = {
 };
 var vconsoles = create2();
 
-// ../../node_modules/lib0/iterator.js
+// node_modules/lib0/iterator.js
 var createIterator = (next) => ({
   /**
    * @return {IterableIterator<T>}
@@ -9382,7 +9382,7 @@ var createIterator = (next) => ({
   return { done, value: done ? void 0 : fmap(value) };
 });
 
-// ../../node_modules/yjs/dist/yjs.mjs
+// node_modules/yjs/dist/yjs.mjs
 var DeleteItem = class {
   /**
    * @param {number} clock
@@ -14187,7 +14187,7 @@ var Item = class _Item extends AbstractStruct {
 glo[importIdentifier] === !0 && console.error("Yjs was already imported. This breaks constructor checks and will lead to issues! - https://github.com/yjs/yjs/issues/438");
 glo[importIdentifier] = !0;
 
-// ../../node_modules/lib0/indexeddb.js
+// node_modules/lib0/indexeddb.js
 var rtop = (request) => create4((resolve, reject) => {
   request.onerror = (event) => reject(new Error(event.target.error)), request.onsuccess = (event) => resolve(event.target.result);
 }), openDB = (name, initDB) => create4((resolve, reject) => {
@@ -14223,7 +14223,7 @@ var iterateOnRequest = (request, f) => create4((resolve, reject) => {
 var iterateKeys = (store, keyrange, f, direction = "next") => iterateOnRequest(store.openKeyCursor(keyrange, direction), (cursor) => f(cursor.key)), getStore = (t, store) => t.objectStore(store);
 var createIDBKeyRangeUpperBound = (upper, upperOpen) => IDBKeyRange.upperBound(upper, upperOpen), createIDBKeyRangeLowerBound = (lower, lowerOpen) => IDBKeyRange.lowerBound(lower, lowerOpen);
 
-// ../../node_modules/y-indexeddb/src/y-indexeddb.js
+// node_modules/y-indexeddb/src/y-indexeddb.js
 var customStoreName = "custom", updatesStoreName = "updates", PREFERRED_TRIM_SIZE = 500, fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {
 }, afterApplyUpdatesCallback = () => {
 }) => {
@@ -14466,7 +14466,7 @@ function mergeDiskOntoDoc(base, disk, current) {
   return { text: merged, clean: applied.every(Boolean) };
 }
 
-// ../../node_modules/y-protocols/sync.js
+// node_modules/y-protocols/sync.js
 var messageYjsSyncStep1 = 0, messageYjsSyncStep2 = 1, messageYjsUpdate = 2, writeSyncStep1 = (encoder, doc2) => {
   writeVarUint(encoder, messageYjsSyncStep1);
   let sv = encodeStateVector(doc2);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -5,7 +5,7 @@ import { type App, Notice, PluginSettingTab, type Setting } from "obsidian";
 import { DeviceFlowModal } from "./device-flow-modal";
 import { errMsg } from "./error-util";
 import type EngramSyncPlugin from "./main";
-import { PHASE_FALLBACK_LABEL, settingsBarCounts } from "./sync-progress-modal";
+import { PHASE_FALLBACK_LABEL, type PlannedPhase, settingsBarCounts } from "./sync-progress-modal";
 import { renderAboutTab } from "./tabs/about-tab";
 import { renderAccountTab } from "./tabs/account-tab";
 import { renderAdvancedTab } from "./tabs/advanced-tab";
@@ -14,6 +14,57 @@ import { pickInitialTab } from "./tabs/start-tab";
 import { renderSyncCenterTab } from "./tabs/sync-center-tab";
 import type { TabContext } from "./tabs/types";
 import type { SyncProgress } from "./types";
+
+/** Build the settings pane's progress-bar render callback. Extracted
+ *  DOM-agnostic (like renderCompletionSummary) so the teardown-without-hide
+ *  guard is testable: on 1.13+ Obsidian can tear down and recreate the
+ *  render-hatch row WITHOUT calling hide(), so uninstallProgressBar never
+ *  runs and this callback survives with a closure over detached DOM. Guard
+ *  with isConnected like renderStatus() does — go inert instead of rendering
+ *  into (and retaining) detached nodes; the installProgressBar wrapper still
+ *  forwards to `prev` regardless. */
+export function makeProgressBarRender(
+	progressContainer: HTMLElement,
+	progressLabel: HTMLElement,
+	progressBarInner: HTMLElement,
+	getPlannedPhases: () => PlannedPhase[] | null,
+): (progress: SyncProgress) => void {
+	// Per-phase previous denominator, so a fallback (plan-less) row keeps its
+	// total when the engine momentarily reports 0. Cleared on completion.
+	const prevTotals = new Map<string, number>();
+	return (progress) => {
+		if (!progressContainer.isConnected) return;
+		if (progress.phase === "complete") {
+			progressContainer.removeClass("is-active");
+			prevTotals.clear();
+			return;
+		}
+		// A new sync's first event (container was inactive): drop any denominators
+		// left over from a prior sync that ended without a "complete" (e.g. it
+		// errored), so a stale total can't leak into this run's fallback rows.
+		if (!progressContainer.hasClass("is-active")) prevTotals.clear();
+		progressContainer.addClass("is-active");
+		// Route through the same plan-aware, clamped logic as the modal so
+		// this bar can't sit stuck-low, pin at a fake 100%, or overshoot.
+		const planned = getPlannedPhases()?.find((p) => p.phase === progress.phase);
+		const { current, total, pct } = settingsBarCounts(
+			progress,
+			planned,
+			prevTotals.get(progress.phase) ?? 0,
+		);
+		prevTotals.set(progress.phase, total);
+		const phaseLabel = PHASE_FALLBACK_LABEL[progress.phase] ?? progress.phase;
+		const failedSuffix = progress.failed > 0 ? ` (${progress.failed} failed)` : "";
+		// total 0 = indeterminate (unknown-length incremental pull): show the
+		// running count as activity, no misleading "N / 0".
+		progressLabel.setText(
+			total > 0
+				? `${phaseLabel}... ${current}/${total}${failedSuffix}`
+				: `${phaseLabel}... ${current}${failedSuffix}`,
+		);
+		progressBarInner.style.width = `${pct}%`;
+	};
+}
 
 export class EngramSyncSettingTab extends PluginSettingTab {
 	plugin: EngramSyncPlugin;
@@ -123,40 +174,14 @@ export class EngramSyncSettingTab extends PluginSettingTab {
 		const progressBarOuter = progressContainer.createDiv({ cls: "engram-progress-bar-outer" });
 		const progressBarInner = progressBarOuter.createDiv({ cls: "engram-progress-bar-inner" });
 
-		// Per-phase previous denominator, so a fallback (plan-less) row keeps its
-		// total when the engine momentarily reports 0. Cleared on completion.
-		const prevTotals = new Map<string, number>();
-		this.installProgressBar((progress) => {
-			if (progress.phase === "complete") {
-				progressContainer.removeClass("is-active");
-				prevTotals.clear();
-				return;
-			}
-			// A new sync's first event (container was inactive): drop any denominators
-			// left over from a prior sync that ended without a "complete" (e.g. it
-			// errored), so a stale total can't leak into this run's fallback rows.
-			if (!progressContainer.hasClass("is-active")) prevTotals.clear();
-			progressContainer.addClass("is-active");
-			// Route through the same plan-aware, clamped logic as the modal so
-			// this bar can't sit stuck-low, pin at a fake 100%, or overshoot.
-			const planned = this.plugin.activeSyncPhases?.find((p) => p.phase === progress.phase);
-			const { current, total, pct } = settingsBarCounts(
-				progress,
-				planned,
-				prevTotals.get(progress.phase) ?? 0,
-			);
-			prevTotals.set(progress.phase, total);
-			const phaseLabel = PHASE_FALLBACK_LABEL[progress.phase] ?? progress.phase;
-			const failedSuffix = progress.failed > 0 ? ` (${progress.failed} failed)` : "";
-			// total 0 = indeterminate (unknown-length incremental pull): show the
-			// running count as activity, no misleading "N / 0".
-			progressLabel.setText(
-				total > 0
-					? `${phaseLabel}... ${current}/${total}${failedSuffix}`
-					: `${phaseLabel}... ${current}${failedSuffix}`,
-			);
-			progressBarInner.style.width = `${pct}%`;
-		});
+		this.installProgressBar(
+			makeProgressBarRender(
+				progressContainer,
+				progressLabel,
+				progressBarInner,
+				() => this.plugin.activeSyncPhases,
+			),
+		);
 
 		// ── Tab bar ──
 		const tabs = [

--- a/tests/settings-progress-render.test.ts
+++ b/tests/settings-progress-render.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for the settings pane's progress-bar render callback (#375).
+ *
+ * On Obsidian 1.13+ the settings row can be torn down and recreated WITHOUT
+ * the tab's hide() firing — so the installed render callback survives with a
+ * closure over detached DOM. It must go inert (no renders into, and no
+ * retention-visible writes on, detached nodes) exactly like renderStatus()'s
+ * isConnected guard, and come back to life if the container is reattached.
+ *
+ * Exercised through the extracted, DOM-agnostic `makeProgressBarRender`
+ * factory with a minimal fake-element adapter (same approach as
+ * sync-progress-modal.test.ts / renderCompletionSummary).
+ */
+import { describe, expect, test } from "bun:test";
+import { makeProgressBarRender } from "../src/settings";
+import type { PlannedPhase } from "../src/sync-progress-modal";
+import type { SyncProgress } from "../src/types";
+
+interface FakeProgressEls {
+	container: {
+		isConnected: boolean;
+		classes: Set<string>;
+		addClass: (c: string) => void;
+		removeClass: (c: string) => void;
+		hasClass: (c: string) => boolean;
+	};
+	label: { text: string; setText: (t: string) => void };
+	barInner: { style: { width: string } };
+}
+
+function makeEls(): FakeProgressEls {
+	const classes = new Set<string>();
+	return {
+		container: {
+			isConnected: true,
+			classes,
+			addClass: (c) => classes.add(c),
+			removeClass: (c) => classes.delete(c),
+			hasClass: (c) => classes.has(c),
+		},
+		label: {
+			text: "",
+			setText(t: string) {
+				this.text = t;
+			},
+		},
+		barInner: { style: { width: "" } },
+	};
+}
+
+function makeRender(els: FakeProgressEls, phases: PlannedPhase[] | null = null) {
+	return makeProgressBarRender(
+		els.container as unknown as HTMLElement,
+		els.label as unknown as HTMLElement,
+		els.barInner as unknown as HTMLElement,
+		() => phases,
+	);
+}
+
+const pushing = (current: number, total: number, failed = 0): SyncProgress => ({
+	phase: "pushing",
+	current,
+	total,
+	failed,
+});
+
+describe("settings progress-bar render (teardown-without-hide, #375)", () => {
+	test("renders label, bar width, and is-active while connected", () => {
+		const els = makeEls();
+		const render = makeRender(els);
+		render(pushing(5, 10));
+		expect(els.container.hasClass("is-active")).toBe(true);
+		expect(els.label.text).toBe("Uploading... 5/10");
+		expect(els.barInner.style.width).toBe("50%");
+	});
+
+	test("detached container: render is a no-op", () => {
+		const els = makeEls();
+		const render = makeRender(els);
+		els.container.isConnected = false;
+		render(pushing(5, 10));
+		expect(els.container.hasClass("is-active")).toBe(false);
+		expect(els.label.text).toBe("");
+		expect(els.barInner.style.width).toBe("");
+	});
+
+	test("detached container: 'complete' is also a no-op (no crash)", () => {
+		const els = makeEls();
+		const render = makeRender(els);
+		render(pushing(5, 10));
+		els.container.isConnected = false;
+		expect(() =>
+			render({ phase: "complete", current: 10, total: 10, failed: 0 }),
+		).not.toThrow();
+		// is-active is stale but the node is detached; next open re-renders fresh.
+		expect(els.label.text).toBe("Uploading... 5/10");
+	});
+
+	test("reattached container renders again on the next event", () => {
+		const els = makeEls();
+		const render = makeRender(els);
+		els.container.isConnected = false;
+		render(pushing(3, 10));
+		els.container.isConnected = true;
+		render(pushing(6, 10));
+		expect(els.container.hasClass("is-active")).toBe(true);
+		expect(els.label.text).toBe("Uploading... 6/10");
+		expect(els.barInner.style.width).toBe("60%");
+	});
+
+	test("complete hides the bar and a following sync starts with cleared totals", () => {
+		const els = makeEls();
+		const render = makeRender(els);
+		// Fallback (plan-less) row seeds prevTotals with its engine total…
+		render(pushing(5, 10));
+		render({ phase: "complete", current: 10, total: 10, failed: 0 });
+		expect(els.container.hasClass("is-active")).toBe(false);
+		// …and after complete, a plan-less 0-total event must NOT inherit the
+		// old denominator: indeterminate display, no "1/10".
+		render(pushing(1, 0));
+		expect(els.label.text).toBe("Uploading... 1");
+	});
+});


### PR DESCRIPTION
## Summary

On Obsidian 1.13+ the settings UI renders via `getSettingDefinitions()` into a row Obsidian can tear down and recreate WITHOUT calling the tab's `hide()`, so `uninstallProgressBar()` never runs and the installed `onSyncProgress` render closure keeps rendering into (and retaining) detached DOM nodes until the next settings open.

Fix: guard the render callback with `progressContainer.isConnected`, exactly like `renderStatus()` already does for the same teardown-without-hide path. The `installProgressBar` wrapper still forwards to `prev` regardless (chain behavior untouched, covered by the existing `settings-progress-chain` tests).

To make the guard testable, the render closure is extracted into a DOM-agnostic `makeProgressBarRender` factory (same pattern as `renderCompletionSummary`); body otherwise unchanged.

## Tests

- New `tests/settings-progress-render.test.ts`: detached no-op (including `complete`), reattach recovers, connected render, prevTotals cleared after complete.
- Full suite 2394 pass; build + biome/eslint/stylelint clean.

Fixes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjwVE1c1F691yNPKtkjkpJ