### PR TITLE
fix(sync): id-keyed move must not discard content over an EMPTY target

### DIFF
--- a/main.js
+++ b/main.js
@@ -21719,9 +21719,18 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           await this.trashRemotelyDeleted(oldFile);
         } catch (e) {
         }
-        this.app.vault.getAbstractFileByPath((0, import_obsidian24.normalizePath)(newPath)) ? rlog().info(
+        let existingAtNew = this.app.vault.getAbstractFileByPath((0, import_obsidian24.normalizePath)(newPath)), existingBody = null;
+        if (existingAtNew instanceof import_obsidian24.TFile)
+          try {
+            existingBody = await this.app.vault.cachedRead(existingAtNew);
+          } catch (e) {
+          }
+        existingAtNew && !(existingAtNew instanceof import_obsidian24.TFile) ? rlog().info(
           "pull",
-          `Id-keyed move: skipping stale disk flush for ${newPath} \u2014 already exists (a concurrent flush won the race)`
+          `Id-keyed move: skipping disk flush for ${newPath} \u2014 a non-file already occupies the path`
+        ) : existingBody !== null && existingBody.trim() !== "" ? rlog().info(
+          "pull",
+          `Id-keyed move: skipping stale disk flush for ${newPath} \u2014 already holds content (a concurrent flush won the race)`
         ) : await this.flushFromCrdt(newPath, content), rlog().info("pull", `Id-keyed move: ${priorPath} -> ${newPath} (id=${id2})`);
       } catch (e) {
         rlog().warn(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -5102,10 +5102,42 @@ export class SyncEngine {
 				// doc-triggered flush already wrote to newPath during that window
 				// with these old-file bytes, which are never newer. Re-check right
 				// before flushing — mirrors materializeRelocated's own exists check.
-				if (this.app.vault.getAbstractFileByPath(normalizePath(newPath))) {
+				//
+				// NARROWED to "already holds CONTENT" (e2e test_34, 0-byte clobber).
+				// The guard's premise is that an existing newPath means a concurrent
+				// flush already wrote a BETTER body. That is false when the concurrent
+				// flush wrote an EMPTY one: CRDT discovery calls
+				// flushFromCrdt(newPath, content) for a note this device has never had
+				// on disk, and flushFromCrdt's own content-loss guard is gated on
+				// `file instanceof TFile` — so on its CREATE branch an empty body is
+				// written with no guard at all. A bare exists() check then made THIS
+				// path discard the only copy of the real body, leaving B with a 0-byte
+				// note forever (wait_for_delivery's non-empty guard never satisfies →
+				// 120s timeout, 5 of 7 red nights).
+				//
+				// "Exists" is not "has content". Yielding to a non-empty target keeps
+				// the original protection intact.
+				const existingAtNew = this.app.vault.getAbstractFileByPath(normalizePath(newPath));
+				let existingBody: string | null = null;
+				if (existingAtNew instanceof TFile) {
+					try {
+						existingBody = await this.app.vault.cachedRead(existingAtNew);
+					} catch {
+						// Unreadable — treat as "holds nothing worth keeping" so the
+						// flush proceeds. Losing the body is the worse failure.
+					}
+				}
+				if (existingAtNew && !(existingAtNew instanceof TFile)) {
+					// A folder squatting the note path: not ours to overwrite, and
+					// flushFromCrdt would fail on it. Same skip as before.
 					rlog().info(
 						"pull",
-						`Id-keyed move: skipping stale disk flush for ${newPath} — already exists (a concurrent flush won the race)`,
+						`Id-keyed move: skipping disk flush for ${newPath} — a non-file already occupies the path`,
+					);
+				} else if (existingBody !== null && existingBody.trim() !== "") {
+					rlog().info(
+						"pull",
+						`Id-keyed move: skipping stale disk flush for ${newPath} — already holds content (a concurrent flush won the race)`,
 					);
 				} else {
 					await this.flushFromCrdt(newPath, content);

--- a/tests/sync-note-id.test.ts
+++ b/tests/sync-note-id.test.ts
@@ -1289,3 +1289,128 @@ describe("eventToOp timestamp honesty (repo-review 2026-08)", () => {
 		expect(op.updated_at).toBe("2026-01-01T00:00:10Z");
 	});
 });
+
+describe("moveIfIdRelocated must not discard content when newPath exists but is EMPTY (e2e test_34, 0-byte clobber)", () => {
+	// The 5-of-7-red-nights folder-rename failure. Two code paths race for the
+	// new path and BOTH behave 'correctly' in isolation:
+	//
+	//   1. CRDT discovery (sync.ts) calls flushFromCrdt(newPath, content) for a
+	//      note this device has never had on disk. flushFromCrdt's content-loss
+	//      guard is gated on `file instanceof TFile`, so on the CREATE branch an
+	//      empty `content` is written with no guard at all -> 0-byte file.
+	//
+	//   2. moveIfIdRelocated reads the OLD file's real body, then hits its
+	//      CREATE-ONLY GUARD: `if (getAbstractFileByPath(newPath))` -> skip.
+	//
+	// The guard's own comment states its assumption -- that an existing newPath
+	// means "a CONCURRENT doc-triggered flush already wrote content" whose bytes
+	// are newer than ours. That assumption is FALSE when the concurrent flush
+	// wrote an EMPTY placeholder, and the skip then throws away the only copy of
+	// the body. B is left with a 0-byte note forever; wait_for_delivery's
+	// non-empty guard never satisfies and the test times out at 120s.
+	//
+	// "Exists" is not "has content".
+	test("an empty placeholder at newPath does NOT suppress the flush of real content", async () => {
+		const engine = createEngine();
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("E2E/RenameFolder34/Note1.md", "id-empty-target");
+		engine.setNoteIdMap(noteIdMap);
+		manifestWith([{ id: "id-empty-target", path: "E2E/RenamedFolder34/Note1.md" }]);
+
+		const oldFile = new TFile("E2E/RenameFolder34/Note1.md");
+		// The 0-byte placeholder CRDT discovery just created at the new path.
+		const emptyNewFile = new TFile("E2E/RenamedFolder34/Note1.md");
+
+		(mockApp.vault.getFileByPath as ReturnType<typeof mock>).mockImplementation((p: string) =>
+			p === "E2E/RenameFolder34/Note1.md"
+				? oldFile
+				: p === "E2E/RenamedFolder34/Note1.md"
+					? emptyNewFile
+					: null,
+		);
+		(mockApp.vault.getAbstractFileByPath as ReturnType<typeof mock>).mockImplementation(
+			(p: string) =>
+				p === "E2E/RenamedFolder34/Note1.md"
+					? emptyNewFile
+					: p === "E2E/RenameFolder34/Note1.md"
+						? oldFile
+						: null,
+		);
+		// Old path holds the real body; the new-path placeholder is empty.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockImplementation((f: TFile) =>
+			Promise.resolve(f === oldFile ? "# Note 1\nIn old folder" : ""),
+		);
+		(mockApp.vault.modify as ReturnType<typeof mock>).mockClear();
+		(mockApp.vault.create as ReturnType<typeof mock>).mockClear();
+
+		engine.setCrdtManager({
+			isSynced: mock().mockReturnValue(true),
+			projectedText: mock().mockResolvedValue(""),
+		} as any);
+		engine.setCrdtEnrollment({ enroll: mock(() => {}), reset: mock(() => {}) } as any);
+
+		await engine.handleStreamEvent({
+			event_type: "upsert",
+			kind: "note",
+			id: "id-empty-target",
+			path: "E2E/RenamedFolder34/Note1.md",
+			timestamp: 2,
+			title: "Note1",
+			folder: "E2E/RenamedFolder34",
+			tags: [],
+			mtime: 2,
+			updated_at: "2026-01-01T00:00:00Z",
+		} as any);
+
+		// The body must reach the new path. The file already exists, so
+		// flushFromCrdt takes its modify branch.
+		expect(mockApp.vault.modify).toHaveBeenCalledWith(emptyNewFile, "# Note 1\nIn old folder");
+	});
+
+	test("a NON-empty file at newPath still suppresses the flush (the guard's real purpose)", async () => {
+		// The guard exists for a reason: a concurrent doc-triggered flush that
+		// wrote REAL content must not be overwritten with the old file's bytes,
+		// which are never newer. Narrowing it to "empty only" must not weaken
+		// that -- this is the regression fence for the fix above.
+		const engine = createEngine();
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("Old.md", "id-nonempty-target");
+		engine.setNoteIdMap(noteIdMap);
+		manifestWith([{ id: "id-nonempty-target", path: "New.md" }]);
+
+		const oldFile = new TFile("Old.md");
+		const freshNewFile = new TFile("New.md");
+
+		(mockApp.vault.getFileByPath as ReturnType<typeof mock>).mockImplementation((p: string) =>
+			p === "Old.md" ? oldFile : p === "New.md" ? freshNewFile : null,
+		);
+		(mockApp.vault.getAbstractFileByPath as ReturnType<typeof mock>).mockImplementation(
+			(p: string) => (p === "New.md" ? freshNewFile : p === "Old.md" ? oldFile : null),
+		);
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockImplementation((f: TFile) =>
+			Promise.resolve(f === oldFile ? "stale old bytes" : "# winner from the CRDT doc"),
+		);
+		(mockApp.vault.modify as ReturnType<typeof mock>).mockClear();
+
+		engine.setCrdtManager({
+			isSynced: mock().mockReturnValue(true),
+			projectedText: mock().mockResolvedValue(""),
+		} as any);
+		engine.setCrdtEnrollment({ enroll: mock(() => {}), reset: mock(() => {}) } as any);
+
+		await engine.handleStreamEvent({
+			event_type: "upsert",
+			kind: "note",
+			id: "id-nonempty-target",
+			path: "New.md",
+			timestamp: 2,
+			title: "New",
+			folder: "",
+			tags: [],
+			mtime: 2,
+			updated_at: "2026-01-01T00:00:00Z",
+		} as any);
+
+		expect(mockApp.vault.modify).not.toHaveBeenCalledWith(freshNewFile, "stale old bytes");
+	});
+});


### PR DESCRIPTION
## The bug

`e2e test_34` (folder rename) failed **5 of the last 7 red nights**. B ends up holding a **0-byte note** at the new path, so `wait_for_delivery`'s non-empty guard never satisfies and it times out at 120s.

Two paths race for the new path, and each looks correct in isolation:

**1. CRDT discovery** calls `flushFromCrdt(newPath, content)` for a note this device has never had on disk. `flushFromCrdt`'s content-loss guard is gated on the file *already existing*:

```js
if (file instanceof TFile && content.trim() === "") {   // ← create branch never reaches this
```

So on the **create** branch an empty body is written with no guard at all → 0-byte file.

**2. `moveIfIdRelocated`** reads the OLD file's real body, then hits its CREATE-ONLY GUARD:

```js
if (this.app.vault.getAbstractFileByPath(normalizePath(newPath))) {
    // skip — "already exists (a concurrent flush won the race)"
} else {
    await this.flushFromCrdt(newPath, content);
}
```

## Why the guard is wrong

Its own comment states the premise — that an existing `newPath` means *"content a CONCURRENT doc-triggered flush already wrote"*, whose bytes are never older than ours.

**That premise is false when the concurrent flush wrote an empty one.** The skip then discards the only copy of the body — content this path had just read off disk *specifically to preserve it*.

**"Exists" is not "has content."**

## The fix

The guard now yields only to a target that actually **holds** content. An empty placeholder no longer suppresses the flush.

Two edges kept explicit:
- a **non-file** occupying the path keeps the old skip (`flushFromCrdt` would fail on a folder)
- an **unreadable** target is treated as holding nothing — losing the body is the worse failure

## Why here and not at discovery

This is where content is **destroyed**. Discovery writing an empty placeholder is defensible on its own — it makes the note visible pending the STEP2 backfill. Silently dropping a body you are already holding is not defensible from any caller, so the fix belongs at the point of loss.

## TDD

- **`an empty placeholder at newPath does NOT suppress the flush of real content`** — fails on main for the right reason (`vault.modify` never called, i.e. the body is discarded), passes with the fix.
- **`a NON-empty file at newPath still suppresses the flush`** — regression fence proving the narrowing did **not** weaken the guard's real purpose. It already passed before the change, and still does.

```
2420 pass / 1 skip / 0 fail   (151 files)
tsc + esbuild build clean
biome ci / eslint (lint:obsidian) / stylelint (lint:css) clean
```

## Confidence

The guard is provably wrong on its own merits — discarding held content on a bare `exists()` is a data-loss bug regardless of test_34. Whether it fully closes test_34 wants an e2e confirmation: the nightly evidence could not be attributed to a device before engram-app/Engram#1257, so the `bytes=22` / `bytes=0` log lines may have come from different instances.

Refs engram-app/Engram#1178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YN1Zy7YSQmq8aSVZwjY9nz