### PR TITLE
fix(crdt): stop dropping inserts at the frontmatter boundary (first-line typing corruption)

### DIFF
--- a/docs/context/frontmatter-boundary-insert-drop.md
+++ b/docs/context/frontmatter-boundary-insert-drop.md
@@ -1,0 +1,26 @@
+# Context Doc: first-line typing mangled/lost — boundary insert dropped by the FM guard
+
+_Last verified: 2026-08-05_
+
+## Status
+Fixed (branch `fix/first-line-boundary-insert-drop`)
+
+## Symptom
+Typing at the very beginning of a note mangles and loses characters — only at the start of the first line. Example: doc `Hello`, type `AB` at the start → ends up `HBello` after ~3s.
+
+## Mechanism
+`live-binding.ts` forwards local CM edits to the body-only Y.Text, dropping changes inside the frontmatter block (`[0, prefix)`) because the FM hook owns them. The guard was `if (toA <= prefix) return;`. A **pure insert at the boundary** (`fromA === toA === prefix`) — typing at the start of the first body line — satisfies it and is silently dropped. With **no frontmatter at all**, `prefix` is 0 and an insert at position 0 has `toA = 0 <= 0`: same drop.
+
+Cascade: the dropped insert never reaches the Y.Text → every following keystroke forwards with offsets shifted by the dropped length → characters interleave wrongly in the doc → the 3s drift check declares the doc authoritative and snaps the editor to the mangled text.
+
+## Fix
+`classifyEditSpan(fromA, toA, prefix)` in `live-binding-decisions.ts` (pure, unit-tested): `body` when `fromA >= prefix`, `frontmatter` when `toA <= prefix`, `spans` otherwise — **checked in that order**, so the boundary insert classifies as body. Frontmatter is the half-open range `[0, prefix)`; position `prefix` is body offset 0.
+
+## General Lesson
+Any "is this edit inside region X" guard on half-open ranges must decide which side owns the boundary for **zero-width (insert) edits** — `<=`/`>=` comparisons silently claim the boundary for the wrong side. Deletions at the same spot span past the boundary and mask the bug, so it only bites pure inserts (i.e. typing).
+
+## References
+- `src/crdt/live/live-binding.ts` — `update()` forward path
+- `src/crdt/live/live-binding-decisions.ts` — `classifyEditSpan`
+- `tests/crdt-live-binding-decisions.test.ts` — boundary cases
+- Sibling doc: `crdt-editor-bind-race-pollution.md` (different first-line-adjacent class: bind race, not offsets)

--- a/docs/context/frontmatter-boundary-insert-drop.md
+++ b/docs/context/frontmatter-boundary-insert-drop.md
@@ -16,6 +16,10 @@ Cascade: the dropped insert never reaches the Y.Text → every following keystro
 ## Fix
 `classifyEditSpan(fromA, toA, prefix)` in `live-binding-decisions.ts` (pure, unit-tested): `body` when `fromA >= prefix`, `frontmatter` when `toA <= prefix`, `spans` otherwise — **checked in that order**, so the boundary insert classifies as body. Frontmatter is the half-open range `[0, prefix)`; position `prefix` is body offset 0.
 
+## Review findings (same bug class, fixed in the same branch)
+- **FM creation in one transaction** (paste a complete `---` block at position 0, select-all paste of a full note, typed fence completion): per-change classification against the PRE-change prefix of 0 is meaningless — the same chars flip from body to FM mid-transaction, and the boundary fix would have forwarded the block into the body-only Y.Text (duplicated after drift re-adopt). `fmCreationBodyDiff` forwards a body(before)→body(after) diff instead (empty for a pure FM paste).
+- **`CrdtFrontmatterHook` diffed `view.text` (FULL file text) into the body-only CONTENT Y.Text** — every patchable `saveFrontmatter` (properties edit) would prepend the whole FM block to the body and broadcast it. Its old tests encoded the wrong full-doc contract. Now diffs `splitFrontmatter(newText).body`; usually a no-op — FM itself syncs via the disk-save path (`routeModify` → `seedContentInto`). Follow-up candidate: the hook may now be pure dead weight (deletable) since it never wrote the FM Y.Maps.
+
 ## General Lesson
 Any "is this edit inside region X" guard on half-open ranges must decide which side owns the boundary for **zero-width (insert) edits** — `<=`/`>=` comparisons silently claim the boundary for the wrong side. Deletions at the same spot span past the boundary and mask the bug, so it only bites pure inserts (i.e. typing).
 

--- a/main.js
+++ b/main.js
@@ -7098,6 +7098,14 @@ function frontmatterPrefixLen(editorText) {
   let { fmBlock, body } = splitFrontmatter(editorText);
   return fmBlock === null ? 0 : editorText.length - body.length;
 }
+function classifyEditSpan(fromA, toA, prefix) {
+  return fromA >= prefix ? "body" : toA <= prefix ? "frontmatter" : "spans";
+}
+function fmCreationBodyDiff(prefixBefore, beforeDoc, afterDoc) {
+  if (prefixBefore !== 0) return null;
+  let prefixAfter = frontmatterPrefixLen(afterDoc);
+  return prefixAfter === 0 ? null : textDiffToChangeSpec(beforeDoc, afterDoc.slice(prefixAfter));
+}
 function needsReattach(bound, path, noteId, coordinator2) {
   return path !== bound.path || noteId !== bound.noteId || coordinator2 !== bound.coordinator;
 }
@@ -7193,19 +7201,38 @@ var LiveBindingValue = class {
     let ytext = this.ytext;
     for (let tr of u.transactions) {
       if (!tr.docChanged || tr.annotation(ySyncAnnotation) === this.editor) continue;
-      let prefix = frontmatterPrefixLen(tr.startState.doc.toString()), changes = [], spansFrontmatter = !1;
+      let beforeDoc = tr.startState.doc.toString(), prefix = frontmatterPrefixLen(beforeDoc), creation = fmCreationBodyDiff(prefix, beforeDoc, tr.state.doc.toString());
+      if (creation !== null) {
+        try {
+          this.writeYText(ytext, creation);
+        } catch (err) {
+          rlog().error(
+            "crdt-live-binding",
+            `fm-creation forward failed for ${this.path}: ${String(err)}`
+          ), this.scheduleDriftCheck();
+        }
+        continue;
+      }
+      let changes = [], spansFrontmatter = !1;
       if (tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
-        if (!(toA <= prefix)) {
-          if (fromA < prefix) {
+        let span = classifyEditSpan(fromA, toA, prefix);
+        switch (span) {
+          case "frontmatter":
+            return;
+          // entirely inside frontmatter — the FM hook owns it
+          case "spans":
             spansFrontmatter = !0;
             return;
-          }
-          changes.push({
-            fromA: fromA - prefix,
-            toA: toA - prefix,
-            insert: inserted.sliceString(0, inserted.length, `
+          case "body":
+            changes.push({
+              fromA: fromA - prefix,
+              toA: toA - prefix,
+              insert: inserted.sliceString(0, inserted.length, `
 `)
-          });
+            });
+            return;
+          default:
+            return span;
         }
       }), spansFrontmatter && this.scheduleDriftCheck(), changes.length !== 0)
         try {
@@ -7482,7 +7509,7 @@ var CrdtFrontmatterHook = class {
     if (!path) return;
     let uninstall = patchFrontmatterSave(view, (newText) => {
       this.deps.getYText(path).then((ytext) => {
-        diffIntoYText(ytext, newText);
+        diffIntoYText(ytext, splitFrontmatter(newText).body);
       }).catch(
         (err) => rlog().error("crdt-frontmatter", `getYText failed for ${path}: ${String(err)}`)
       );

--- a/src/crdt/live/frontmatter-hook.ts
+++ b/src/crdt/live/frontmatter-hook.ts
@@ -3,6 +3,7 @@
 import type * as Y from "yjs";
 import { rlog } from "../../remote-log"; // Correction 1: rlog is exported from src/remote-log.ts
 import { diffIntoYText } from "../bridge";
+import { splitFrontmatter } from "../frontmatter-codec";
 import { patchFrontmatterSave } from "./obsidian-internals";
 
 export interface FrontmatterHookDeps {
@@ -30,9 +31,14 @@ export class CrdtFrontmatterHook {
 			void this.deps
 				.getYText(path)
 				.then((ytext) => {
-					// diffIntoYText is a no-op when content is unchanged, and patches only
-					// the frontmatter range, leaving body Y.Text ops untouched.
-					diffIntoYText(ytext, newText);
+					// The CONTENT Y.Text is BODY-ONLY (note-seed strips the FM block into
+					// the frontmatter Y.Maps), but view.text at saveFrontmatter time is the
+					// FULL file text. Diff only the body slice in — diffing the full text
+					// prepends the whole FM block to the body Y.Text and broadcasts it.
+					// The FM block itself syncs via the disk-save path (routeModify ->
+					// seedContentInto), same as the unpatchable fallback below. Usually a
+					// no-op (a properties save doesn't touch the body).
+					diffIntoYText(ytext, splitFrontmatter(newText).body);
 				})
 				.catch((err: unknown) =>
 					rlog().error("crdt-frontmatter", `getYText failed for ${path}: ${String(err)}`),

--- a/src/crdt/live/live-binding-decisions.ts
+++ b/src/crdt/live/live-binding-decisions.ts
@@ -32,6 +32,27 @@ export function frontmatterPrefixLen(editorText: string): number {
 	return fmBlock === null ? 0 : editorText.length - body.length;
 }
 
+/** Classify a CM edit (PRE-change offsets) against the frontmatter block that
+ *  occupies [0, prefix) of the editor document.
+ *   - "body": forward to the Y.Text, mapped by -prefix.
+ *   - "frontmatter": drop — the FM hook owns frontmatter sync.
+ *   - "spans": straddles the boundary — repair via drift check, not a guess.
+ *  The boundary belongs to the BODY: a pure insert at fromA === toA === prefix
+ *  is typing at the start of the first body line (offset 0 of the Y.Text, and
+ *  with no frontmatter at all that is position 0 of the document). Classifying
+ *  it as frontmatter silently drops the keystroke, shifts every following edit
+ *  by the dropped length, and the drift check then "repairs" the editor to the
+ *  mangled doc — the type-at-start-of-note corruption bug. */
+export function classifyEditSpan(
+	fromA: number,
+	toA: number,
+	prefix: number,
+): "body" | "frontmatter" | "spans" {
+	if (fromA >= prefix) return "body";
+	if (toA <= prefix) return "frontmatter";
+	return "spans";
+}
+
 /** True when the editor must detach from its current doc and re-attach. Catches
  *  THREE cases:
  *   - path changed  -> Obsidian reused this editor for a different file.

--- a/src/crdt/live/live-binding-decisions.ts
+++ b/src/crdt/live/live-binding-decisions.ts
@@ -37,9 +37,11 @@ export function frontmatterPrefixLen(editorText: string): number {
  *   - "body": forward to the Y.Text, mapped by -prefix.
  *   - "frontmatter": drop — the FM hook owns frontmatter sync.
  *   - "spans": straddles the boundary — repair via drift check, not a guess.
- *  The boundary belongs to the BODY: a pure insert at fromA === toA === prefix
+ *  The END boundary belongs to the BODY: a pure insert at fromA === toA === prefix
  *  is typing at the start of the first body line (offset 0 of the Y.Text, and
- *  with no frontmatter at all that is position 0 of the document). Classifying
+ *  with no frontmatter at all that is position 0 of the document). The START
+ *  boundary belongs to FRONTMATTER: a pure insert at 0 before an existing
+ *  opening fence is frontmatter-owned. Classifying
  *  it as frontmatter silently drops the keystroke, shifts every following edit
  *  by the dropped length, and the drift check then "repairs" the editor to the
  *  mangled doc — the type-at-start-of-note corruption bug. */
@@ -51,6 +53,28 @@ export function classifyEditSpan(
 	if (fromA >= prefix) return "body";
 	if (toA <= prefix) return "frontmatter";
 	return "spans";
+}
+
+/** Handle a transaction that CREATES a frontmatter block (prefix 0 -> N in one
+ *  transaction: a pasted `---` block at position 0, a select-all paste of a
+ *  full note, a typed fence completion). Per-change classification against the
+ *  PRE-change prefix of 0 is meaningless here — the same characters flip from
+ *  body to frontmatter mid-transaction, and classifyEditSpan would forward the
+ *  FM block into the body-only Y.Text (duplicated after the next drift
+ *  re-adopt). Returns the body(before) -> body(after) diff to forward instead
+ *  (empty when the body is unchanged, e.g. a pure FM paste), or null when the
+ *  transaction did not create frontmatter and the normal per-change path owns
+ *  it. */
+export function fmCreationBodyDiff(
+	prefixBefore: number,
+	beforeDoc: string,
+	afterDoc: string,
+): CmChangeSpec[] | null {
+	if (prefixBefore !== 0) return null;
+	const prefixAfter = frontmatterPrefixLen(afterDoc);
+	if (prefixAfter === 0) return null;
+	// prefixBefore === 0 -> the whole pre-change doc IS the body.
+	return textDiffToChangeSpec(beforeDoc, afterDoc.slice(prefixAfter));
 }
 
 /** True when the editor must detach from its current doc and re-attach. Catches

--- a/src/crdt/live/live-binding.ts
+++ b/src/crdt/live/live-binding.ts
@@ -32,7 +32,12 @@ import {
 	type YDeltaEntry,
 	yDeltaToChangeSpec,
 } from "./cm-yjs-bridge";
-import { decideReconcile, frontmatterPrefixLen, needsReattach } from "./live-binding-decisions";
+import {
+	classifyEditSpan,
+	decideReconcile,
+	frontmatterPrefixLen,
+	needsReattach,
+} from "./live-binding-decisions";
 
 /** Interval for the drift backstop (Relay's DRIFT_CHECK_DELAY is 3000ms). */
 const DRIFT_CHECK_MS = 3000;
@@ -184,16 +189,19 @@ class LiveBindingValue implements PluginValue {
 			const changes: Array<{ fromA: number; toA: number; insert: string }> = [];
 			let spansFrontmatter = false;
 			tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
-				if (toA <= prefix) return; // entirely inside frontmatter — the FM hook owns it
-				if (fromA < prefix) {
-					spansFrontmatter = true; // straddles the boundary — repair via drift, not a guess
-					return;
+				switch (classifyEditSpan(fromA, toA, prefix)) {
+					case "frontmatter":
+						return; // entirely inside frontmatter — the FM hook owns it
+					case "spans":
+						spansFrontmatter = true; // straddles the boundary — repair via drift, not a guess
+						return;
+					case "body":
+						changes.push({
+							fromA: fromA - prefix,
+							toA: toA - prefix,
+							insert: inserted.sliceString(0, inserted.length, "\n"),
+						});
 				}
-				changes.push({
-					fromA: fromA - prefix,
-					toA: toA - prefix,
-					insert: inserted.sliceString(0, inserted.length, "\n"),
-				});
 			});
 			if (spansFrontmatter) this.scheduleDriftCheck();
 			if (changes.length === 0) continue;

--- a/src/crdt/live/live-binding.ts
+++ b/src/crdt/live/live-binding.ts
@@ -35,6 +35,7 @@ import {
 import {
 	classifyEditSpan,
 	decideReconcile,
+	fmCreationBodyDiff,
 	frontmatterPrefixLen,
 	needsReattach,
 } from "./live-binding-decisions";
@@ -185,11 +186,29 @@ class LiveBindingValue implements PluginValue {
 			// frontmatter block occupies the first `prefix` chars of the CM document,
 			// which the body-only Y.Text does not have. Offsets are against the
 			// PRE-change doc, so compute the prefix from the transaction's start state.
-			const prefix = frontmatterPrefixLen(tr.startState.doc.toString());
+			const beforeDoc = tr.startState.doc.toString();
+			const prefix = frontmatterPrefixLen(beforeDoc);
+			// A transaction that CREATES frontmatter (prefix 0 -> N) invalidates
+			// per-change classification (the same chars flip from body to FM);
+			// forward the body->body diff instead — empty for a pure FM paste.
+			const creation = fmCreationBodyDiff(prefix, beforeDoc, tr.state.doc.toString());
+			if (creation !== null) {
+				try {
+					this.writeYText(ytext, creation);
+				} catch (err) {
+					rlog().error(
+						"crdt-live-binding",
+						`fm-creation forward failed for ${this.path}: ${String(err)}`,
+					);
+					this.scheduleDriftCheck();
+				}
+				continue;
+			}
 			const changes: Array<{ fromA: number; toA: number; insert: string }> = [];
 			let spansFrontmatter = false;
 			tr.changes.iterChanges((fromA, toA, _fromB, _toB, inserted) => {
-				switch (classifyEditSpan(fromA, toA, prefix)) {
+				const span = classifyEditSpan(fromA, toA, prefix);
+				switch (span) {
 					case "frontmatter":
 						return; // entirely inside frontmatter — the FM hook owns it
 					case "spans":
@@ -201,6 +220,13 @@ class LiveBindingValue implements PluginValue {
 							toA: toA - prefix,
 							insert: inserted.sliceString(0, inserted.length, "\n"),
 						});
+						return;
+					default: {
+						// Compile-time exhaustiveness: a new variant must not silently
+						// drop edits (the bug class this file exists to kill).
+						const exhaustive: never = span;
+						return exhaustive;
+					}
 				}
 			});
 			if (spansFrontmatter) this.scheduleDriftCheck();

--- a/tests/crdt-frontmatter-hook.test.ts
+++ b/tests/crdt-frontmatter-hook.test.ts
@@ -1,11 +1,17 @@
 // tests/crdt-frontmatter-hook.test.ts
+//
+// CONTRACT: the CONTENT Y.Text the hook writes into is BODY-ONLY (note-seed
+// seeds it with splitFrontmatter(content).body; the live binding maps editor
+// offsets past the FM block). view.text at saveFrontmatter time is the FULL
+// file text including the `---` block, so the hook must strip the block before
+// diffing — diffing the full text in prepends the whole FM block to the body
+// Y.Text and broadcasts it (the FM-in-body corruption class).
 import { describe, expect, it } from "bun:test";
 import * as Y from "yjs";
 import { CrdtFrontmatterHook } from "../src/crdt/live/frontmatter-hook";
 
 function fakeView(initialData: string) {
-	// Correction 2: patchFrontmatterSave reads view.text (not view.data).
-	// Use `text` field and set `this.text = next` in saveFrontmatter.
+	// patchFrontmatterSave reads view.text (not view.data).
 	return {
 		file: { path: "n.md" },
 		text: initialData,
@@ -15,37 +21,56 @@ function fakeView(initialData: string) {
 	};
 }
 
+function bodyOnlyYText(body: string): Y.Text {
+	const ytext = new Y.Doc().getText("content");
+	ytext.insert(0, body);
+	return ytext;
+}
+
+function hookFor(ytext: Y.Text): CrdtFrontmatterHook {
+	return new CrdtFrontmatterHook({
+		getPath: (v: any) => v.file.path,
+		getYText: async () => ytext,
+	});
+}
+
 describe("CrdtFrontmatterHook", () => {
-	it("routes a frontmatter save into the Y.Text", async () => {
-		const doc = new Y.Doc();
-		const ytext = doc.getText("content");
-		ytext.insert(0, "---\ntags: []\n---\nbody");
-		const hook = new CrdtFrontmatterHook({
-			getPath: (v: any) => v.file.path,
-			getYText: async () => ytext,
-		});
+	it("does NOT write the frontmatter block into the body-only Y.Text", async () => {
+		const ytext = bodyOnlyYText("body");
 		const view = fakeView("---\ntags: []\n---\nbody");
-		hook.attach(view);
-		// Simulate Obsidian saving new frontmatter.
+		hookFor(ytext).attach(view);
+		// Properties edit: only the FM block changes; the body is untouched.
 		view.saveFrontmatter("---\ntags: [x]\n---\nbody");
 		await Promise.resolve();
-		expect(ytext.toJSON()).toBe("---\ntags: [x]\n---\nbody");
+		expect(ytext.toJSON()).toBe("body");
+	});
+
+	it("forwards a body change present in the saved text", async () => {
+		const ytext = bodyOnlyYText("body");
+		const view = fakeView("---\ntags: []\n---\nbody");
+		hookFor(ytext).attach(view);
+		view.saveFrontmatter("---\ntags: []\n---\nbody edited");
+		await Promise.resolve();
+		expect(ytext.toJSON()).toBe("body edited");
+	});
+
+	it("handles a save with no frontmatter block at all", async () => {
+		const ytext = bodyOnlyYText("body");
+		const view = fakeView("body");
+		hookFor(ytext).attach(view);
+		view.saveFrontmatter("body");
+		await Promise.resolve();
+		expect(ytext.toJSON()).toBe("body");
 	});
 
 	it("is a safe no-op when the view is not patchable (fallback to disk path)", () => {
-		const hook = new CrdtFrontmatterHook({
-			getPath: () => "n.md",
-			getYText: async () => new Y.Doc().getText("content"),
-		});
+		const hook = hookFor(bodyOnlyYText(""));
 		// No saveFrontmatter -> patch returns null -> attach must not throw.
 		expect(() => hook.attach({ file: { path: "n.md" } })).not.toThrow();
 	});
 
 	it("attach() is idempotent: double-attach triggers onSave exactly once", async () => {
-		// FIX 1a: attach the same view twice; the second call must be a no-op.
-		const doc = new Y.Doc();
-		const ytext = doc.getText("content");
-		ytext.insert(0, "---\ntags: []\n---\nbody");
+		const ytext = bodyOnlyYText("body");
 		let onSaveCount = 0;
 		const hook = new CrdtFrontmatterHook({
 			getPath: (v: any) => v.file.path,
@@ -60,46 +85,35 @@ describe("CrdtFrontmatterHook", () => {
 		view.saveFrontmatter("---\ntags: [x]\n---\nbody");
 		await Promise.resolve();
 		// If attach was not idempotent, getYText would be called twice and the
-		// Y.Text would be patched twice (double-apply). onSaveCount captures how
-		// many times getYText was invoked via the onSave callback.
+		// Y.Text would be patched twice (double-apply).
 		expect(onSaveCount).toBe(1);
 	});
 
 	it("detachAll() uninstalls all attached views", async () => {
-		const doc = new Y.Doc();
-		const ytext = doc.getText("content");
-		ytext.insert(0, "---\ntags: []\n---\nbody");
-		const hook = new CrdtFrontmatterHook({
-			getPath: (v: any) => v.file.path,
-			getYText: async () => ytext,
-		});
-
-		// Attach two distinct views.
+		const ytext = bodyOnlyYText("body");
+		const hook = hookFor(ytext);
 		const view1 = fakeView("---\ntags: []\n---\nbody");
 		const view2 = fakeView("---\ntags: []\n---\nbody");
 		hook.attach(view1);
 		hook.attach(view2);
 
-		// Verify both are attached by patching frontmatter on each; both should update Y.Text.
-		view1.saveFrontmatter("---\ntags: [a]\n---\nbody");
+		// Both attached: a body change from either view updates the Y.Text.
+		view1.saveFrontmatter("---\ntags: [a]\n---\nbody a");
 		await Promise.resolve();
-		expect(ytext.toJSON()).toBe("---\ntags: [a]\n---\nbody");
+		expect(ytext.toJSON()).toBe("body a");
 
-		view2.saveFrontmatter("---\ntags: [b]\n---\nbody");
+		view2.saveFrontmatter("---\ntags: [b]\n---\nbody b");
 		await Promise.resolve();
-		expect(ytext.toJSON()).toBe("---\ntags: [b]\n---\nbody");
+		expect(ytext.toJSON()).toBe("body b");
 
-		// Now detachAll and verify neither view patches the Y.Text anymore.
 		hook.detachAll();
 
-		view1.saveFrontmatter("---\ntags: [view1-after]\n---\nbody");
+		view1.saveFrontmatter("---\ntags: [a]\n---\nafter detach 1");
 		await Promise.resolve();
-		// Y.Text should not have changed because view1's patch was uninstalled.
-		expect(ytext.toJSON()).toBe("---\ntags: [b]\n---\nbody");
+		expect(ytext.toJSON()).toBe("body b");
 
-		view2.saveFrontmatter("---\ntags: [view2-after]\n---\nbody");
+		view2.saveFrontmatter("---\ntags: [b]\n---\nafter detach 2");
 		await Promise.resolve();
-		// Y.Text should still not have changed because view2's patch was uninstalled.
-		expect(ytext.toJSON()).toBe("---\ntags: [b]\n---\nbody");
+		expect(ytext.toJSON()).toBe("body b");
 	});
 });

--- a/tests/crdt-live-binding-decisions.test.ts
+++ b/tests/crdt-live-binding-decisions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { splitFrontmatter } from "../src/crdt/frontmatter-codec";
 import {
+	classifyEditSpan,
 	decideReconcile,
 	frontmatterPrefixLen,
 	needsReattach,
@@ -63,6 +64,36 @@ describe("frontmatterPrefixLen", () => {
 		for (const text of inputs) {
 			expect(text.slice(frontmatterPrefixLen(text))).toBe(splitFrontmatter(text).body);
 		}
+	});
+});
+
+describe("classifyEditSpan", () => {
+	// THE first-line mangling bug: frontmatter occupies [0, prefix), so a pure
+	// insert AT the boundary (fromA === toA === prefix) is the first body char —
+	// classifying it as frontmatter silently drops the keystroke from the Y.Text,
+	// and the drift check then reverts/mangles what the user typed.
+	it("forwards a pure insert at position 0 with no frontmatter (prefix 0)", () => {
+		expect(classifyEditSpan(0, 0, 0)).toBe("body");
+	});
+
+	it("forwards a pure insert at the frontmatter boundary (start of first body line)", () => {
+		expect(classifyEditSpan(17, 17, 17)).toBe("body");
+	});
+
+	it("forwards ordinary body edits", () => {
+		expect(classifyEditSpan(3, 5, 0)).toBe("body"); // replace, no FM
+		expect(classifyEditSpan(20, 21, 17)).toBe("body"); // delete past the FM block
+		expect(classifyEditSpan(17, 18, 17)).toBe("body"); // delete the first body char
+	});
+
+	it("drops edits entirely inside frontmatter (the FM hook owns them)", () => {
+		expect(classifyEditSpan(2, 2, 17)).toBe("frontmatter"); // insert inside FM
+		expect(classifyEditSpan(2, 5, 17)).toBe("frontmatter"); // delete inside FM
+		expect(classifyEditSpan(10, 17, 17)).toBe("frontmatter"); // delete ending at boundary
+	});
+
+	it("flags edits straddling the frontmatter boundary", () => {
+		expect(classifyEditSpan(10, 20, 17)).toBe("spans");
 	});
 });
 

--- a/tests/crdt-live-binding-decisions.test.ts
+++ b/tests/crdt-live-binding-decisions.test.ts
@@ -3,6 +3,7 @@ import { splitFrontmatter } from "../src/crdt/frontmatter-codec";
 import {
 	classifyEditSpan,
 	decideReconcile,
+	fmCreationBodyDiff,
 	frontmatterPrefixLen,
 	needsReattach,
 } from "../src/crdt/live/live-binding-decisions";
@@ -94,6 +95,57 @@ describe("classifyEditSpan", () => {
 
 	it("flags edits straddling the frontmatter boundary", () => {
 		expect(classifyEditSpan(10, 20, 17)).toBe("spans");
+	});
+
+	it("drops a pure insert at position 0 BEFORE an existing opening fence", () => {
+		// The START boundary belongs to frontmatter — mirror image of the prefix
+		// boundary, deliberately unchanged behavior.
+		expect(classifyEditSpan(0, 0, 17)).toBe("frontmatter");
+	});
+});
+
+describe("fmCreationBodyDiff", () => {
+	// A transaction that CREATES frontmatter (prefix 0 -> N) makes per-change
+	// offset classification meaningless: the same characters flip from body to
+	// frontmatter mid-transaction. The helper returns a body->body diff to
+	// forward instead, or null when the transaction did not create frontmatter.
+	const fm = "---\nfoo: 1\n---\n";
+
+	/** Apply specs (offsets against the ORIGINAL text) with a running shift,
+	 *  mirroring applyCmChangesToYText. */
+	function applySpecs(text: string, specs: ReturnType<typeof fmCreationBodyDiff>): string {
+		let adj = 0;
+		for (const c of specs ?? []) {
+			text = text.slice(0, c.from + adj) + c.insert + text.slice(c.to + adj);
+			adj += c.insert.length - (c.to - c.from);
+		}
+		return text;
+	}
+
+	it("returns null when no frontmatter was created", () => {
+		expect(fmCreationBodyDiff(0, "body", "body edited")).toBeNull();
+		// Doc already had frontmatter (prefixBefore > 0): normal path owns it.
+		expect(fmCreationBodyDiff(fm.length, `${fm}body`, `${fm}body!`)).toBeNull();
+	});
+
+	it("returns an empty diff for a pure FM-block paste before an unchanged body", () => {
+		// Body is untouched -> nothing to forward; the FM path syncs the block.
+		expect(fmCreationBodyDiff(0, "body", `${fm}body`)).toEqual([]);
+	});
+
+	it("returns the body diff when one transaction replaces the whole doc (select-all paste)", () => {
+		const specs = fmCreationBodyDiff(0, "old body", `${fm}new body`);
+		expect(specs).not.toBeNull();
+		// Applying the specs to the old body must yield the new body.
+		expect(applySpecs("old body", specs)).toBe("new body");
+	});
+
+	it("empties the body when the whole doc became a frontmatter-only note", () => {
+		// Typed fence completion: the stray fence chars were forwarded as body
+		// while the block was unterminated; on completion they must be removed.
+		const specs = fmCreationBodyDiff(0, "---\nfoo: 1\n--", "---\nfoo: 1\n---");
+		expect(specs).not.toBeNull();
+		expect(applySpecs("---\nfoo: 1\n--", specs)).toBe("");
 	});
 });
 


### PR DESCRIPTION
## Symptom

Typing at the beginning of a note's first line mangles and loses characters (e.g. type `AB` at the start of `Hello` → `HBello` after ~3s).

## Root cause

The live-binding forward path dropped changes with `toA <= prefix` as "inside frontmatter". A **pure insert at the boundary** (`fromA === toA === prefix`) — typing at the start of the first body line, including position 0 when there is no frontmatter and `prefix === 0` — satisfied that guard and was silently dropped from the body Y.Text. Subsequent keystrokes forwarded with offsets shifted by the dropped length (interleaving characters wrongly in the doc), and the 3s drift check then re-adopted the mangled doc into the editor.

Frontmatter occupies the half-open range `[0, prefix)`, so the boundary belongs to the body.

## Fix

- `classifyEditSpan(fromA, toA, prefix)` (pure, unit-tested): `body` when `fromA >= prefix`, `frontmatter` when `toA <= prefix`, `spans` otherwise — checked in that order so the boundary insert forwards.
- `fmCreationBodyDiff()`: a transaction that CREATES frontmatter (prefix 0 → N: pasted `---` block, select-all paste of a full note, typed fence completion) invalidates per-change classification (the same chars flip from body to FM mid-transaction); forward a body(before)→body(after) diff instead. Also fixes the pre-existing select-all-paste corruption.
- `CrdtFrontmatterHook` diffed `view.text` (**full** file text) into the **body-only** CONTENT Y.Text — any patchable `saveFrontmatter` would prepend the FM block to the body and broadcast it. Now diffs `splitFrontmatter(newText).body`; its tests encoded the wrong full-doc contract and were rewritten to the body-only contract.
- Context doc: `docs/context/frontmatter-boundary-insert-drop.md`.

Relay reference checked: unaffected (its Y.Text is full-document — the prefix mapping exists only in our adaptation).

## Verification

- New boundary/creation/hook tests written red-first
- Full suite: 2435 pass / 0 fail (1 pre-existing skip)
- `bun run build`, biome ci, eslint, stylelint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK