### PR TITLE
fix(ci): reconcile orphaned preview releases instead of trusting one event

### DIFF
--- a/.github/scripts/prereleases.sh
+++ b/.github/scripts/prereleases.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+#
+# Shared inventory/selection/removal for preview prereleases. Every workflow
+# that removes one routes through here so the error handling lives in ONE place.
+#
+# This exists because three workflows each carried their own copy of the same
+# paginate-then-delete loop, and every copy ended its DELETEs with `|| true`.
+# A failed delete was indistinguishable from a successful one, so the jobs
+# reported success while 33 orphaned prereleases accumulated over three months.
+# Deletes here fail the job instead.
+#
+#   prereleases.sh list      -> "<id>\t<tag>" for every prerelease
+#   prereleases.sh orphans   -> "<id>\t<tag>" for the ones nothing needs any
+#                               more (decisions logged to stderr)
+#   prereleases.sh for-pr N [keep]
+#                            -> "<id>\t<tag>" for PR N's previews, minus [keep]
+#   prereleases.sh delete    -> reads "<id>\t<tag>" on stdin, removes the
+#                               release and its tag
+#   prereleases.sh selftest  -> asserts the version rule; needs no network
+#
+# env: GH_TOKEN (contents: write for delete), GH_REPO (owner/name),
+#      DRY_RUN=1 (delete lists what it would remove and exits)
+set -euo pipefail
+
+# --- pure helpers (covered by selftest) --------------------------------------
+
+# True when $1 (a bare x.y.z) is at or below $2, the current stable. Compares
+# numerically per component: a lexical compare puts 1.9.26 and 1.2.0 ABOVE
+# 1.20.1 and would keep spent RCs forever.
+version_superseded() {
+	local base="$1" stable="$2" newest
+	newest=$(printf '%s\n%s\n' "$base" "$stable" | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
+	[ "$newest" = "$stable" ]
+}
+
+# The PR number embedded in a preview tag (<version>-pr.<N>[.<sha>]).
+preview_pr_number() {
+	sed -E 's/.*-pr\.([0-9]+).*/\1/' <<<"$1"
+}
+
+# Keep only "<id>\t<tag>" lines whose tag is a preview of PR $1, dropping tag $2
+# if given. Compares the PR field EXACTLY rather than regex-matching a prefix:
+# a `-pr.35` prefix match also hits `-pr.354`, and passing an escaped regex
+# through `awk -v` silently loses the backslashes (awk unescapes the assignment,
+# so `\.` degrades to "any character" and the boundary guard evaporates).
+filter_pr() {
+	awk -F'\t' -v pr="$1" -v keep="${2:-}" '
+		$2 ~ /-pr\./ {
+			n = $2
+			sub(/.*-pr\./, "", n)   # drop everything up to the PR number
+			sub(/\..*/, "", n)      # drop the .<sha> suffix if present
+			if (n == pr && $2 != keep) print
+		}'
+}
+
+# --- subcommands -------------------------------------------------------------
+
+require_env() {
+	: "${GH_TOKEN:?GH_TOKEN required}"
+	: "${GH_REPO:?GH_REPO required}"
+	API="https://api.github.com/repos/${GH_REPO}"
+	AUTH=(-H "Authorization: Bearer ${GH_TOKEN}" -H "Accept: application/vnd.github+json")
+}
+
+cmd_list() {
+	require_env
+	local page=1 batch n
+	while :; do
+		batch=$(curl --fail -sS "${AUTH[@]}" "${API}/releases?per_page=100&page=${page}")
+		n=$(jq 'length' <<<"$batch")
+		if [ "$n" -eq 0 ]; then break; fi
+		jq -r '.[] | select(.prerelease==true) | "\(.id)\t\(.tag_name)"' <<<"$batch"
+		if [ "$n" -lt 100 ]; then break; fi
+		page=$((page + 1))
+	done
+}
+
+cmd_for_pr() {
+	local pr="${1:?PR number required}" keep="${2:-}"
+	cmd_list | filter_pr "$pr" "$keep"
+}
+
+cmd_orphans() {
+	require_env
+	local stable id tag pr state base
+	# Highest stable release, by numeric version rather than publish order.
+	stable=$(gh release list --limit 100 --json tagName,isPrerelease \
+		--jq '[.[] | select(.isPrerelease==false) | .tagName | ltrimstr("v")]
+		      | sort_by(split(".") | map(tonumber? // 0)) | last')
+	stable="${stable:-0.0.0}"
+	echo "current stable: ${stable}" >&2
+
+	while IFS=$'\t' read -r id tag; do
+		if [ -z "$id" ]; then continue; fi
+		case "$tag" in
+			# PR preview: the PR's own state is authoritative, so a preview
+			# outlives exactly as long as its PR is open. State-based, so a
+			# missed close event self-heals on the next run.
+			*-pr.*)
+				pr=$(preview_pr_number "$tag")
+				state=$(gh api "repos/${GH_REPO}/pulls/${pr}" --jq .state 2>/dev/null || echo "missing")
+				if [ "$state" = "open" ]; then
+					echo "keep    ${tag} (PR #${pr} open)" >&2
+				else
+					echo "orphan  ${tag} (PR #${pr} ${state})" >&2
+					printf '%s\t%s\n' "$id" "$tag"
+				fi
+				;;
+			# Legacy hand-cut RC from the retired pre-1.13 scheme. Spent once
+			# stable reaches its base version; an RC for an unreleased version
+			# is left alone so reviving the scheme does not self-destruct.
+			*-rc.*)
+				base=${tag%%-rc.*}
+				base=${base#v}
+				if version_superseded "$base" "$stable"; then
+					echo "orphan  ${tag} (superseded by stable ${stable})" >&2
+					printf '%s\t%s\n' "$id" "$tag"
+				else
+					echo "keep    ${tag} (ahead of stable ${stable})" >&2
+				fi
+				;;
+			*)
+				echo "keep    ${tag} (unrecognised prerelease shape)" >&2
+				;;
+		esac
+	done < <(cmd_list)
+}
+
+cmd_delete() {
+	require_env
+	# Buffer stdin: callers pipe from `list`/`orphans`, and deleting while that
+	# paginated read is still in flight shifts later pages out from under it.
+	local pending count id tag code
+	pending=$(mktemp)
+	cat > "$pending"
+	count=$(grep -c . "$pending" || true)
+
+	if [ "$count" -eq 0 ]; then
+		echo "nothing to delete"
+		return 0
+	fi
+	if [ "${DRY_RUN:-0}" = "1" ]; then
+		echo "DRY RUN: would delete ${count} prerelease(s):"
+		cut -f2 "$pending" | sed 's/^/  /'
+		return 0
+	fi
+
+	while IFS=$'\t' read -r id tag; do
+		if [ -z "$id" ]; then continue; fi
+		curl --fail -sS -X DELETE "${AUTH[@]}" "${API}/releases/${id}" > /dev/null
+		# The tag can legitimately already be gone (a release deleted by hand
+		# leaves none), so 404/422 is success here; anything else is real and
+		# must not be swallowed.
+		code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+			"${AUTH[@]}" "${API}/git/refs/tags/${tag}")
+		case "$code" in
+			2* | 404 | 422) ;;
+			*)
+				echo "::error::deleting tag ${tag} returned HTTP ${code}"
+				exit 1
+				;;
+		esac
+		echo "deleted ${tag}"
+	done < "$pending"
+	echo "removed ${count} prerelease(s)"
+}
+
+cmd_selftest() {
+	local fails=0
+	check() { # check <desc> <expected: yes|no> <base> <stable>
+		local want="$2" got="no"
+		if version_superseded "$3" "$4"; then got="yes"; fi
+		if [ "$got" != "$want" ]; then
+			echo "FAIL: $1 (want ${want}, got ${got})"
+			fails=$((fails + 1))
+		fi
+	}
+	# The lexical traps are the whole reason this is a numeric compare.
+	check "1.9.26 is spent under 1.20.1" yes 1.9.26 1.20.1
+	check "1.2.0 is spent under 1.20.1" yes 1.2.0 1.20.1
+	check "an RC for the current stable is spent" yes 1.20.1 1.20.1
+	check "1.21.0 RC survives 1.20.1" no 1.21.0 1.20.1
+	check "1.20.2 RC survives 1.20.1" no 1.20.2 1.20.1
+	check "2.0.0 RC survives 1.20.1" no 2.0.0 1.20.1
+
+	local n
+	n=$(preview_pr_number "1.18.2-pr.341.g7e6e1d8")
+	if [ "$n" != "341" ]; then
+		echo "FAIL: pr number from sha-suffixed tag (got ${n})"
+		fails=$((fails + 1))
+	fi
+	n=$(preview_pr_number "1.18.2-pr.341")
+	if [ "$n" != "341" ]; then
+		echo "FAIL: pr number from bare tag (got ${n})"
+		fails=$((fails + 1))
+	fi
+
+	# The PR-number boundary: a prefix match would let #35 delete #354's
+	# preview. This regressed once already when the filter went through
+	# `awk -v`, which unescaped the guard away.
+	local fixture got
+	fixture=$(printf '1\t1.18.2-pr.35.gaaa\n2\t1.18.2-pr.354.gbbb\n3\t1.18.2-pr.3.gccc\n4\t1.3.1-rc.1\n5\t1.18.2-pr.354\n')
+	got=$(filter_pr 35 <<<"$fixture" | cut -f2 | paste -sd, -)
+	if [ "$got" != "1.18.2-pr.35.gaaa" ]; then
+		echo "FAIL: filter_pr 35 matched '${got}' (must not touch 354 or 3)"
+		fails=$((fails + 1))
+	fi
+	got=$(filter_pr 354 <<<"$fixture" | cut -f2 | paste -sd, -)
+	if [ "$got" != "1.18.2-pr.354.gbbb,1.18.2-pr.354" ]; then
+		echo "FAIL: filter_pr 354 matched '${got}' (want both sha and bare forms)"
+		fails=$((fails + 1))
+	fi
+	got=$(filter_pr 354 "1.18.2-pr.354.gbbb" <<<"$fixture" | cut -f2 | paste -sd, -)
+	if [ "$got" != "1.18.2-pr.354" ]; then
+		echo "FAIL: filter_pr with keep matched '${got}' (keep tag must survive)"
+		fails=$((fails + 1))
+	fi
+	# A non-preview tag must never be selected by a PR filter, whatever the number.
+	got=$(filter_pr 1 <<<"$fixture" | cut -f2 | paste -sd, -)
+	if [ -n "$got" ]; then
+		echo "FAIL: filter_pr 1 matched non-preview tag(s) '${got}'"
+		fails=$((fails + 1))
+	fi
+
+	if [ "$fails" -ne 0 ]; then
+		echo "${fails} selftest failure(s)"
+		exit 1
+	fi
+	echo "selftest OK"
+}
+
+case "${1:-}" in
+	list) cmd_list ;;
+	orphans) cmd_orphans ;;
+	for-pr) cmd_for_pr "${2:-}" "${3:-}" ;;
+	delete) cmd_delete ;;
+	selftest) cmd_selftest ;;
+	*)
+		echo "usage: $0 {list|orphans|for-pr <n> [keep-tag]|delete|selftest}" >&2
+		exit 2
+		;;
+esac

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Prune superseded previews for this PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           KEEP: ${{ steps.v.outputs.tag }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
@@ -95,24 +96,6 @@ jobs:
           # tags so an open PR never accumulates one-per-commit. The SHA stays in
           # the tag (each build remains individually pinnable while current);
           # pr-cleanup.yml removes the survivor too when the PR closes.
-          API="https://api.github.com/repos/${{ github.repository }}"
-          tmp=$(mktemp); page=1
-          while :; do
-            batch=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "$API/releases?per_page=100&page=$page")
-            n=$(echo "$batch" | jq 'length'); [ "$n" -eq 0 ] && break
-            echo "$batch" | jq -r --arg pr "$PR_NUM" --arg keep "$KEEP" \
-              '.[] | select(.prerelease==true
-                            and (.tag_name|test("-pr\\."+$pr+"(\\.|$)"))
-                            and .tag_name != $keep)
-               | "\(.id)\t\(.tag_name)"' >> "$tmp"
-            [ "$n" -lt 100 ] && break
-            page=$((page+1))
-          done
-          while IFS=$'\t' read -r id tag; do
-            [ -z "$id" ] && continue
-            curl -sS -X DELETE -H "Authorization: Bearer $GH_TOKEN" "$API/releases/$id" > /dev/null || true
-            curl -sS -X DELETE -H "Authorization: Bearer $GH_TOKEN" "$API/git/refs/tags/$tag" > /dev/null || true
-            echo "pruned $tag"
-          done < "$tmp"
+          SH=.github/scripts/prereleases.sh
+          chmod +x "$SH"
+          "$SH" for-pr "$PR_NUM" "$KEEP" | "$SH" delete

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -17,33 +17,18 @@ jobs:
   cleanup:
     runs-on: [self-hosted, linux, x64, isolated]
     steps:
+      - uses: actions/checkout@v7
+
       - name: Delete this PR's preview releases + tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
           # Match this PR's preview tags: <version>-pr.<PR_NUM>.<sha> and the
           # sha-less form <version>-pr.<PR_NUM>. The (\.|$) boundary after the
           # number stops PR 28 from matching PR 284's tags.
-          API="https://api.github.com/repos/${{ github.repository }}"
-          # Collect all matches across pages BEFORE deleting, so deletions don't
-          # shift pagination out from under us.
-          tmp=$(mktemp); page=1
-          while :; do
-            batch=$(curl -sS -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "$API/releases?per_page=100&page=$page")
-            n=$(echo "$batch" | jq 'length'); [ "$n" -eq 0 ] && break
-            echo "$batch" | jq -r --arg pr "$PR_NUM" \
-              '.[] | select(.prerelease==true and (.tag_name|test("-pr\\."+$pr+"(\\.|$)")))
-               | "\(.id)\t\(.tag_name)"' >> "$tmp"
-            [ "$n" -lt 100 ] && break
-            page=$((page+1))
-          done
-          while IFS=$'\t' read -r id tag; do
-            [ -z "$id" ] && continue
-            curl -sS -X DELETE -H "Authorization: Bearer $GH_TOKEN" "$API/releases/$id" > /dev/null || true
-            curl -sS -X DELETE -H "Authorization: Bearer $GH_TOKEN" "$API/git/refs/tags/$tag" > /dev/null || true
-            echo "deleted $tag"
-          done < "$tmp"
+          SH=.github/scripts/prereleases.sh
+          chmod +x "$SH"
+          "$SH" for-pr "$PR_NUM" | "$SH" delete

--- a/.github/workflows/preview-reconcile.yml
+++ b/.github/workflows/preview-reconcile.yml
@@ -1,0 +1,48 @@
+name: Preview release reconcile
+
+# Safety net for pr-cleanup.yml. That workflow fires on `pull_request: closed`,
+# which is a single event with no retry, and if it never fires, the preview is
+# orphaned forever with nothing to notice. It demonstrably does not fire for
+# dependabot PRs that are closed unmerged after being superseded (the branch
+# conflicts with main once its replacement lands, so GitHub cannot compute the
+# merge ref and never schedules the run). That silently orphaned 11 previews.
+#
+# So instead of trusting the event, reconcile the actual state daily: any
+# preview whose PR is closed, and any legacy `-rc.N` prerelease at or below the
+# current stable release, gets removed. Being state-based rather than
+# event-based, this is self-healing: a missed event costs at most a day.
+#
+# Run it by hand (workflow_dispatch) with dry_run to see what it would remove.
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would be deleted without deleting it"
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  reconcile:
+    runs-on: [self-hosted, linux, x64, isolated]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Select and remove orphaned prereleases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          # Scheduled runs always delete; manual runs default to a dry run.
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          SH=.github/scripts/prereleases.sh
+          chmod +x "$SH"
+          "$SH" selftest
+          "$SH" orphans | "$SH" delete


### PR DESCRIPTION
## What's wrong

33 of the repo's 34 prereleases are orphaned:

- **22 legacy `-rc.N` tags** (1.3.1-rc.1 through 1.12.13-rc.3, May to July) from the retired pre-1.13 release scheme. `pr-cleanup.yml` only ever matched `-pr.<N>`, so nothing has been able to delete these.
- **11 PR previews whose PRs are closed.** Only #354's preview is legitimate (PR still open).

`pr-cleanup.yml` fires only on `pull_request: closed`, a single event with no retry. It never fired for dependabot PRs closed unmerged after being superseded: the branch conflicts with main once its replacement lands, so GitHub cannot compute the merge ref and never schedules the run. Verified across all 63 cleanup runs by head branch, none of the nine orphaned dependabot branches ever got one. Cleanup itself works (PR #393 closed, run fired two seconds later, `deleted 1.19.1-pr.393.g954c5bb`), so this is not tokens, permissions, or the runner.

Nothing surfaced it because all three preview-deleting workflows ended their DELETEs with `|| true` and had no verification step. They reported success whether they removed 11 releases, zero, or got a 403 on every one.

## What this does

- **`preview-reconcile.yml`** (new): daily state-based sweep, plus `workflow_dispatch` defaulting to dry run. Removes any preview whose PR is closed, and any legacy RC at or below the current stable. Being state-based rather than event-based, a missed event self-heals within a day instead of orphaning forever.
- **`.github/scripts/prereleases.sh`** (new): the single path for removing a preview. Deletes use `--fail` and surface a real error; only 404/422 on the tag (already gone) is tolerated.
- **`pr-cleanup.yml` / `pr-build.yml`**: routed through it, deleting three copies of the same paginate-then-delete loop.

## Verification

`prereleases.sh selftest` runs at the top of every reconcile and covers the two things that actually bite:

- The version rule is a **numeric** compare: `1.9.26` and `1.2.0` sort lexically *above* `1.20.1`, which would keep spent RCs forever.
- The PR-number boundary keeps `#35` from deleting `#354`'s preview. This regressed during development when the filter went through `awk -v`, which unescapes the assignment so `\.` degrades to "any character". Caught by testing against the live repo, hence the committed test.

Dry-run against the real repo selects exactly 33 and keeps #354. I'll dispatch the sweep once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqgVPyDtDbXmTqm4PkTioK