### PR TITLE
fix(deps): raise the js-yaml override past GHSA-5p4m-2wfm-xmqj

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
   "overrides": {
     "brace-expansion": "^5.0.9",
     "fast-uri": "^3.1.5",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "minimatch": "^10.0.1",
     "picomatch": "^2.3.2",
     "postcss": "^8.5.23",
@@ -571,7 +571,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "brace-expansion": "^5.0.9",
     "minimatch": "^10.0.1",
     "picomatch": "^2.3.2",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "fast-uri": "^3.1.5",
     "postcss": "^8.5.23"
   }


### PR DESCRIPTION
`bun audit` is failing on **main** and on every open PR. Not a branch problem — GHSA-5p4m-2wfm-xmqj published today.

> **js-yaml** `>=4.0.0 <4.3.1` — high — quadratic CPU consumption in `!!omap` resolution (CVE-2026-59870 fix not backported)

We already pin js-yaml through `overrides`, at `^4.3.0` — which the advisory range still covers. One digit.

```diff
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
```

Dev-only chain (`eslint › @eslint/eslintrc › js-yaml` and `stylelint › cosmiconfig › js-yaml`). js-yaml is not a runtime dependency and does not reach the plugin bundle.

## Verified

- lockfile resolves `js-yaml@4.3.1` and nothing else
- `bun audit` → no vulnerabilities
- `bun run build` passes
- `bun test` → 2437 tests, 0 fail
- lockfile-registry guard passes

No version bump — release-please owns that.

Unblocks #398.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2