### PR TITLE
chore(deps): bump transitive nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -651,7 +651,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 


### PR DESCRIPTION
## Why now

`bun audit` is failing the `build-and-test` job on **every** open PR, including ones that change no dependencies (spotted on #404):

```
nanoid  <3.3.17
  stylelint › postcss-safe-parser › postcss › nanoid
  high: nanoid: custom generators can loop indefinitely when size is zero
  GHSA-2v37-7h3g-55p8
```

No code change caused it. The advisory was published after main's last green run, and `bun audit` queries the live advisory DB — so main itself is red on a fresh checkout, and every PR inherits it.

## The fix

postcss already declares `nanoid: ^3.3.16`, so 3.3.18 satisfies the existing range. No override, no `package.json` change, no dependency bump — just the one resolved lockfile entry:

```diff
-    "nanoid": ["nanoid@3.3.16", ... ],
+    "nanoid": ["nanoid@3.3.18", ... ],
```

## Why exactly one line

A plain `bun install` re-resolve "fixes" the audit too, but it also drifted **yjs 13.6.31 → 13.6.32**, biome, eslint and acorn (38 insertions / 78 deletions). A CRDT dependency has no business riding along inside a security fix, where a sync regression would be attributed to the wrong change. Held to the single entry that the advisory actually concerns.

## Verification

- `bun install --frozen-lockfile` — consistent, no lockfile churn
- `bun audit` — **No vulnerabilities found**
- `bun run lint:css` — stylelint, the actual consumer of this dep, passes
- `bun run lint:lockfile` — no private-registry hosts
- `bun run build` — tsc + esbuild clean
- `bun test` — 2435 pass / 0 fail

Unblocks #404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016D4V5B8Yixkk6TjG8Yc4B2