### PR TITLE
fix(sync): drop the outbound CRDT work on a vault change

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,9 +35,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 )), __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: !0 }), mod);
 var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key != "symbol" ? key + "" : key, value);
 
-// node_modules/diff-match-patch/index.js
+// ../../node_modules/diff-match-patch/index.js
 var require_diff_match_patch = __commonJS({
-  "node_modules/diff-match-patch/index.js"(exports, module2) {
+  "../../node_modules/diff-match-patch/index.js"(exports, module2) {
     var diff_match_patch5 = function() {
       this.Diff_Timeout = 1, this.Diff_EditCost = 4, this.Match_Threshold = 0.5, this.Match_Distance = 1e3, this.Patch_DeleteThreshold = 0.5, this.Patch_Margin = 4, this.Match_MaxBits = 32;
     }, DIFF_DELETE = -1, DIFF_INSERT = 1, DIFF_EQUAL = 0;
@@ -2303,7 +2303,7 @@ function textDiffToChangeSpec(before, after) {
 // src/crdt/live/live-binding-decisions.ts
 var import_diff_match_patch2 = __toESM(require_diff_match_patch(), 1);
 
-// node_modules/yaml/browser/dist/nodes/identity.js
+// ../../node_modules/yaml/browser/dist/nodes/identity.js
 var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias"), DOC = /* @__PURE__ */ Symbol.for("yaml.document"), MAP = /* @__PURE__ */ Symbol.for("yaml.map"), PAIR = /* @__PURE__ */ Symbol.for("yaml.pair"), SCALAR = /* @__PURE__ */ Symbol.for("yaml.scalar"), SEQ = /* @__PURE__ */ Symbol.for("yaml.seq"), NODE_TYPE = /* @__PURE__ */ Symbol.for("yaml.node.type"), isAlias = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === ALIAS, isDocument = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === DOC, isMap = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === MAP, isPair = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === PAIR, isScalar = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SCALAR, isSeq = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SEQ;
 function isCollection(node) {
   if (node && typeof node == "object")
@@ -2327,7 +2327,7 @@ function isNode(node) {
 }
 var hasAnchor = (node) => (isScalar(node) || isCollection(node)) && !!node.anchor;
 
-// node_modules/yaml/browser/dist/visit.js
+// ../../node_modules/yaml/browser/dist/visit.js
 var BREAK = /* @__PURE__ */ Symbol("break visit"), SKIP = /* @__PURE__ */ Symbol("skip children"), REMOVE = /* @__PURE__ */ Symbol("remove node");
 function visit(node, visitor) {
   let visitor_ = initVisitor(visitor);
@@ -2449,7 +2449,7 @@ function replaceNode(key, path, node) {
   }
 }
 
-// node_modules/yaml/browser/dist/doc/directives.js
+// ../../node_modules/yaml/browser/dist/doc/directives.js
 var escapeChars = {
   "!": "%21",
   ",": "%2C",
@@ -2567,7 +2567,7 @@ var escapeChars = {
 Directives.defaultYaml = { explicit: !1, version: "1.2" };
 Directives.defaultTags = { "!!": "tag:yaml.org,2002:" };
 
-// node_modules/yaml/browser/dist/doc/anchors.js
+// ../../node_modules/yaml/browser/dist/doc/anchors.js
 function anchorIsValid(anchor) {
   if (/[\x00-\x19\s,[\]{}]/.test(anchor)) {
     let msg = `Anchor must not contain whitespace or control characters: ${JSON.stringify(anchor)}`;
@@ -2618,7 +2618,7 @@ function createNodeAnchors(doc2, prefix) {
   };
 }
 
-// node_modules/yaml/browser/dist/doc/applyReviver.js
+// ../../node_modules/yaml/browser/dist/doc/applyReviver.js
 function applyReviver(reviver, obj, key, val) {
   if (val && typeof val == "object")
     if (Array.isArray(val))
@@ -2644,7 +2644,7 @@ function applyReviver(reviver, obj, key, val) {
   return reviver.call(obj, key, val);
 }
 
-// node_modules/yaml/browser/dist/nodes/toJS.js
+// ../../node_modules/yaml/browser/dist/nodes/toJS.js
 function toJS(value, arg, ctx) {
   if (Array.isArray(value))
     return value.map((v, i) => toJS(v, String(i), ctx));
@@ -2661,7 +2661,7 @@ function toJS(value, arg, ctx) {
   return typeof value == "bigint" && !(ctx != null && ctx.keep) ? Number(value) : value;
 }
 
-// node_modules/yaml/browser/dist/nodes/Node.js
+// ../../node_modules/yaml/browser/dist/nodes/Node.js
 var NodeBase = class {
   constructor(type) {
     Object.defineProperty(this, NODE_TYPE, { value: type });
@@ -2690,7 +2690,7 @@ var NodeBase = class {
   }
 };
 
-// node_modules/yaml/browser/dist/nodes/Alias.js
+// ../../node_modules/yaml/browser/dist/nodes/Alias.js
 var Alias = class extends NodeBase {
   constructor(source) {
     super(ALIAS), this.source = source, Object.defineProperty(this, "tag", {
@@ -2770,7 +2770,7 @@ function getAliasCount(doc2, node, anchors) {
   return 1;
 }
 
-// node_modules/yaml/browser/dist/nodes/Scalar.js
+// ../../node_modules/yaml/browser/dist/nodes/Scalar.js
 var isScalarValue = (value) => !value || typeof value != "function" && typeof value != "object", Scalar = class extends NodeBase {
   constructor(value) {
     super(SCALAR), this.value = value;
@@ -2788,7 +2788,7 @@ Scalar.PLAIN = "PLAIN";
 Scalar.QUOTE_DOUBLE = "QUOTE_DOUBLE";
 Scalar.QUOTE_SINGLE = "QUOTE_SINGLE";
 
-// node_modules/yaml/browser/dist/doc/createNode.js
+// ../../node_modules/yaml/browser/dist/doc/createNode.js
 var defaultTagPrefix = "tag:yaml.org,2002:";
 function findTagObject(value, tagName, tags) {
   var _a;
@@ -2832,7 +2832,7 @@ function createNode(value, tagName, ctx) {
   return tagName ? node.tag = tagName : tagObj.default || (node.tag = tagObj.tag), ref && (ref.node = node), node;
 }
 
-// node_modules/yaml/browser/dist/nodes/Collection.js
+// ../../node_modules/yaml/browser/dist/nodes/Collection.js
 function collectionFromPath(schema4, path, value) {
   let v = value;
   for (let i = path.length - 1; i >= 0; --i) {
@@ -2949,7 +2949,7 @@ var isEmptyPath = (path) => path == null || typeof path == "object" && !!path[Sy
   }
 };
 
-// node_modules/yaml/browser/dist/stringify/stringifyComment.js
+// ../../node_modules/yaml/browser/dist/stringify/stringifyComment.js
 var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
 function indentComment(comment, indent) {
   return /^\n+$/.test(comment) ? comment.substring(1) : indent ? comment.replace(/^(?! *$)/gm, indent) : comment;
@@ -2959,7 +2959,7 @@ var lineComment = (str, indent, comment) => str.endsWith(`
 `) ? `
 ` + indentComment(comment, indent) : (str.endsWith(" ") ? "" : " ") + comment;
 
-// node_modules/yaml/browser/dist/stringify/foldFlowLines.js
+// ../../node_modules/yaml/browser/dist/stringify/foldFlowLines.js
 var FOLD_FLOW = "flow", FOLD_BLOCK = "block", FOLD_QUOTED = "quoted";
 function foldFlowLines(text2, indent, mode = "flow", { indentAtStart, lineWidth = 80, minContentWidth = 20, onFold, onOverflow } = {}) {
   if (!lineWidth || lineWidth < 0)
@@ -3041,7 +3041,7 @@ function consumeMoreIndentedLines(text2, i, indent) {
   return end;
 }
 
-// node_modules/yaml/browser/dist/stringify/stringifyString.js
+// ../../node_modules/yaml/browser/dist/stringify/stringifyString.js
 var getFoldOptions = (ctx, isBlock2) => ({
   indentAtStart: isBlock2 ? ctx.indent.length : ctx.indentAtStart,
   lineWidth: ctx.options.lineWidth,
@@ -3253,7 +3253,7 @@ function stringifyString(item, ctx, onComment, onChompKeep) {
   return res;
 }
 
-// node_modules/yaml/browser/dist/stringify/stringify.js
+// ../../node_modules/yaml/browser/dist/stringify/stringify.js
 function createStringifyContext(doc2, options) {
   let opt = Object.assign({
     blockQuote: !0,
@@ -3351,7 +3351,7 @@ function stringify(item, ctx, onComment, onChompKeep) {
 ${ctx.indent}${str}` : str;
 }
 
-// node_modules/yaml/browser/dist/stringify/stringifyPair.js
+// ../../node_modules/yaml/browser/dist/stringify/stringifyPair.js
 function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
   var _a, _b;
   let { allNullValues, doc: doc2, indent, indentStep, options: { commentString, indentSeq, simpleKeys } } = ctx, keyComment = isNode(key) && key.comment || null;
@@ -3414,12 +3414,12 @@ ${ctx.indent}`);
   return str += ws + valueStr, ctx.inFlow ? valueCommentDone && onComment && onComment() : valueComment && !valueCommentDone ? str += lineComment(str, ctx.indent, commentString(valueComment)) : chompKeep && onChompKeep && onChompKeep(), str;
 }
 
-// node_modules/yaml/browser/dist/log.js
+// ../../node_modules/yaml/browser/dist/log.js
 function warn(logLevel, warning) {
   (logLevel === "debug" || logLevel === "warn") && console.warn(warning);
 }
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/merge.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/merge.js
 var MERGE_KEY = "<<", merge = {
   identify: (value) => value === MERGE_KEY || typeof value == "symbol" && value.description === MERGE_KEY,
   default: "key",
@@ -3459,7 +3459,7 @@ function resolveAliasValue(ctx, value) {
   return ctx && isAlias(value) ? value.resolve(ctx.doc, ctx) : value;
 }
 
-// node_modules/yaml/browser/dist/nodes/addPairToJSMap.js
+// ../../node_modules/yaml/browser/dist/nodes/addPairToJSMap.js
 function addPairToJSMap(ctx, map3, { key, value }) {
   if (isNode(key) && key.addToJSMap)
     key.addToJSMap(ctx, map3, value);
@@ -3504,7 +3504,7 @@ function stringifyKey(key, jsKey, ctx) {
   return JSON.stringify(jsKey);
 }
 
-// node_modules/yaml/browser/dist/nodes/Pair.js
+// ../../node_modules/yaml/browser/dist/nodes/Pair.js
 function createPair(key, value, ctx) {
   let k = createNode(key, void 0, ctx), v = createNode(value, void 0, ctx);
   return new Pair(k, v);
@@ -3526,7 +3526,7 @@ var Pair = class _Pair {
   }
 };
 
-// node_modules/yaml/browser/dist/stringify/stringifyCollection.js
+// ../../node_modules/yaml/browser/dist/stringify/stringifyCollection.js
 function stringifyCollection(collection, ctx, options) {
   var _a;
   return (((_a = ctx.inFlow) != null ? _a : collection.flow) ? stringifyFlowCollection : stringifyBlockCollection)(collection, ctx, options);
@@ -3608,7 +3608,7 @@ function addCommentBefore({ indent, options: { commentString } }, lines, comment
   }
 }
 
-// node_modules/yaml/browser/dist/nodes/YAMLMap.js
+// ../../node_modules/yaml/browser/dist/nodes/YAMLMap.js
 function findPair(items, key) {
   let k = isScalar(key) ? key.value : key;
   for (let it of items)
@@ -3706,7 +3706,7 @@ var YAMLMap = class extends Collection {
   }
 };
 
-// node_modules/yaml/browser/dist/schema/common/map.js
+// ../../node_modules/yaml/browser/dist/schema/common/map.js
 var map = {
   collection: "map",
   default: !0,
@@ -3718,7 +3718,7 @@ var map = {
   createNode: (schema4, obj, ctx) => YAMLMap.from(schema4, obj, ctx)
 };
 
-// node_modules/yaml/browser/dist/nodes/YAMLSeq.js
+// ../../node_modules/yaml/browser/dist/nodes/YAMLSeq.js
 var YAMLSeq = class extends Collection {
   static get tagName() {
     return "tag:yaml.org,2002:seq";
@@ -3809,7 +3809,7 @@ function asItemIndex(key) {
   return idx && typeof idx == "string" && (idx = Number(idx)), typeof idx == "number" && Number.isInteger(idx) && idx >= 0 ? idx : null;
 }
 
-// node_modules/yaml/browser/dist/schema/common/seq.js
+// ../../node_modules/yaml/browser/dist/schema/common/seq.js
 var seq = {
   collection: "seq",
   default: !0,
@@ -3821,7 +3821,7 @@ var seq = {
   createNode: (schema4, obj, ctx) => YAMLSeq.from(schema4, obj, ctx)
 };
 
-// node_modules/yaml/browser/dist/schema/common/string.js
+// ../../node_modules/yaml/browser/dist/schema/common/string.js
 var string = {
   identify: (value) => typeof value == "string",
   default: !0,
@@ -3832,7 +3832,7 @@ var string = {
   }
 };
 
-// node_modules/yaml/browser/dist/schema/common/null.js
+// ../../node_modules/yaml/browser/dist/schema/common/null.js
 var nullTag = {
   identify: (value) => value == null,
   createNode: () => new Scalar(null),
@@ -3843,7 +3843,7 @@ var nullTag = {
   stringify: ({ source }, ctx) => typeof source == "string" && nullTag.test.test(source) ? source : ctx.options.nullStr
 };
 
-// node_modules/yaml/browser/dist/schema/core/bool.js
+// ../../node_modules/yaml/browser/dist/schema/core/bool.js
 var boolTag = {
   identify: (value) => typeof value == "boolean",
   default: !0,
@@ -3860,7 +3860,7 @@ var boolTag = {
   }
 };
 
-// node_modules/yaml/browser/dist/stringify/stringifyNumber.js
+// ../../node_modules/yaml/browser/dist/stringify/stringifyNumber.js
 function stringifyNumber({ format, minFractionDigits, tag, value }) {
   if (typeof value == "bigint")
     return String(value);
@@ -3878,7 +3878,7 @@ function stringifyNumber({ format, minFractionDigits, tag, value }) {
   return n;
 }
 
-// node_modules/yaml/browser/dist/schema/core/float.js
+// ../../node_modules/yaml/browser/dist/schema/core/float.js
 var floatNaN = {
   identify: (value) => typeof value == "number",
   default: !0,
@@ -3909,7 +3909,7 @@ var floatNaN = {
   stringify: stringifyNumber
 };
 
-// node_modules/yaml/browser/dist/schema/core/int.js
+// ../../node_modules/yaml/browser/dist/schema/core/int.js
 var intIdentify = (value) => typeof value == "bigint" || Number.isInteger(value), intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
 function intStringify(node, radix, prefix) {
   let { value } = node;
@@ -3940,7 +3940,7 @@ var intOct = {
   stringify: (node) => intStringify(node, 16, "0x")
 };
 
-// node_modules/yaml/browser/dist/schema/core/schema.js
+// ../../node_modules/yaml/browser/dist/schema/core/schema.js
 var schema = [
   map,
   seq,
@@ -3955,7 +3955,7 @@ var schema = [
   float
 ];
 
-// node_modules/yaml/browser/dist/schema/json/schema.js
+// ../../node_modules/yaml/browser/dist/schema/json/schema.js
 function intIdentify2(value) {
   return typeof value == "bigint" || Number.isInteger(value);
 }
@@ -4009,7 +4009,7 @@ var stringifyJSON = ({ value }) => JSON.stringify(value), jsonScalars = [
   }
 }, schema2 = [map, seq].concat(jsonScalars, jsonError);
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/binary.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/binary.js
 var binary = {
   identify: (value) => value instanceof Uint8Array,
   // Buffer inherits from Uint8Array
@@ -4054,7 +4054,7 @@ var binary = {
   }
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/pairs.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/pairs.js
 function resolvePairs(seq2, onError) {
   var _a;
   if (isSeq(seq2))
@@ -4112,7 +4112,7 @@ var pairs = {
   createNode: createPairs
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/omap.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/omap.js
 var YAMLOMap = class _YAMLOMap extends YAMLSeq {
   constructor() {
     super(), this.add = YAMLMap.prototype.add.bind(this), this.delete = YAMLMap.prototype.delete.bind(this), this.get = YAMLMap.prototype.get.bind(this), this.has = YAMLMap.prototype.has.bind(this), this.set = YAMLMap.prototype.set.bind(this), this.tag = _YAMLOMap.tag;
@@ -4155,7 +4155,7 @@ var omap = {
   createNode: (schema4, iterable, ctx) => YAMLOMap.from(schema4, iterable, ctx)
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/bool.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/bool.js
 function boolStringify({ value, source }, ctx) {
   return source && (value ? trueTag : falseTag).test.test(source) ? source : value ? ctx.options.trueStr : ctx.options.falseStr;
 }
@@ -4175,7 +4175,7 @@ var trueTag = {
   stringify: boolStringify
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/float.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/float.js
 var floatNaN2 = {
   identify: (value) => typeof value == "number",
   default: !0,
@@ -4210,7 +4210,7 @@ var floatNaN2 = {
   stringify: stringifyNumber
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/int.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/int.js
 var intIdentify3 = (value) => typeof value == "bigint" || Number.isInteger(value);
 function intResolve2(str, offset, radix, { intAsBigInt }) {
   let sign = str[0];
@@ -4273,7 +4273,7 @@ var intBin = {
   stringify: (node) => intStringify2(node, 16, "0x")
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/set.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/set.js
 var YAMLSet = class _YAMLSet extends YAMLMap {
   constructor(schema4) {
     super(schema4), this.tag = _YAMLSet.tag;
@@ -4333,7 +4333,7 @@ var set = {
   }
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/timestamp.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/timestamp.js
 function parseSexagesimal(str, asBigInt) {
   let sign = str[0], parts = sign === "-" || sign === "+" ? str.substring(1) : str, num = (n) => asBigInt ? BigInt(n) : Number(n), res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
   return sign === "-" ? num(-1) * res : res;
@@ -4390,7 +4390,7 @@ var intTime = {
   }
 };
 
-// node_modules/yaml/browser/dist/schema/yaml-1.1/schema.js
+// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/schema.js
 var schema3 = [
   map,
   seq,
@@ -4415,7 +4415,7 @@ var schema3 = [
   timestamp
 ];
 
-// node_modules/yaml/browser/dist/schema/tags.js
+// ../../node_modules/yaml/browser/dist/schema/tags.js
 var schemas = /* @__PURE__ */ new Map([
   ["core", schema],
   ["failsafe", [map, seq, string]],
@@ -4475,7 +4475,7 @@ function getTags(customTags, schemaName, addMergeTag) {
   }, []);
 }
 
-// node_modules/yaml/browser/dist/schema/Schema.js
+// ../../node_modules/yaml/browser/dist/schema/Schema.js
 var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0, Schema = class _Schema {
   constructor({ compat, customTags, merge: merge2, resolveKnownTags, schema: schema4, sortMapEntries, toStringDefaults }) {
     this.compat = Array.isArray(compat) ? getTags(compat, "compat") : compat ? getTags(null, compat) : null, this.name = typeof schema4 == "string" && schema4 || "core", this.knownTags = resolveKnownTags ? coreKnownTags : {}, this.tags = getTags(customTags, this.name, merge2), this.toStringOptions = toStringDefaults != null ? toStringDefaults : null, Object.defineProperty(this, MAP, { value: map }), Object.defineProperty(this, SCALAR, { value: string }), Object.defineProperty(this, SEQ, { value: seq }), this.sortMapEntries = typeof sortMapEntries == "function" ? sortMapEntries : sortMapEntries === !0 ? sortMapEntriesByKey : null;
@@ -4486,7 +4486,7 @@ var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0, 
   }
 };
 
-// node_modules/yaml/browser/dist/stringify/stringifyDocument.js
+// ../../node_modules/yaml/browser/dist/stringify/stringifyDocument.js
 function stringifyDocument(doc2, options) {
   var _a;
   let lines = [], hasDirectives = options.directives === !0;
@@ -4530,7 +4530,7 @@ function stringifyDocument(doc2, options) {
 `;
 }
 
-// node_modules/yaml/browser/dist/doc/Document.js
+// ../../node_modules/yaml/browser/dist/doc/Document.js
 var Document = class _Document {
   constructor(value, replacer, options) {
     this.commentBefore = null, this.comment = null, this.errors = [], this.warnings = [], Object.defineProperty(this, NODE_TYPE, { value: DOC });
@@ -4747,7 +4747,7 @@ function assertCollection(contents) {
   throw new Error("Expected a YAML collection as document contents");
 }
 
-// node_modules/yaml/browser/dist/errors.js
+// ../../node_modules/yaml/browser/dist/errors.js
 var YAMLError = class extends Error {
   constructor(name, pos, code, message) {
     super(), this.name = name, this.code = code, this.message = message, this.pos = pos;
@@ -4788,7 +4788,7 @@ ${pointer}
   }
 };
 
-// node_modules/yaml/browser/dist/compose/resolve-props.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-props.js
 function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
   let spaceBefore = !1, atNewline = startOnNewline, hasSpace = startOnNewline, comment = "", commentSep = "", hasNewline = !1, reqSpace = !1, tab = null, anchor = null, tag = null, newlineAfterProp = null, comma = null, found = null, start = null;
   for (let token of tokens)
@@ -4839,7 +4839,7 @@ function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIn
   };
 }
 
-// node_modules/yaml/browser/dist/compose/util-contains-newline.js
+// ../../node_modules/yaml/browser/dist/compose/util-contains-newline.js
 function containsNewline(key) {
   if (!key)
     return null;
@@ -4876,7 +4876,7 @@ function containsNewline(key) {
   }
 }
 
-// node_modules/yaml/browser/dist/compose/util-flow-indent-check.js
+// ../../node_modules/yaml/browser/dist/compose/util-flow-indent-check.js
 function flowIndentCheck(indent, fc, onError) {
   if ((fc == null ? void 0 : fc.type) === "flow-collection") {
     let end = fc.end[0];
@@ -4884,7 +4884,7 @@ function flowIndentCheck(indent, fc, onError) {
   }
 }
 
-// node_modules/yaml/browser/dist/compose/util-map-includes.js
+// ../../node_modules/yaml/browser/dist/compose/util-map-includes.js
 function mapIncludes(ctx, items, search) {
   let { uniqueKeys } = ctx.options;
   if (uniqueKeys === !1)
@@ -4893,7 +4893,7 @@ function mapIncludes(ctx, items, search) {
   return items.some((pair) => isEqual(pair.key, search));
 }
 
-// node_modules/yaml/browser/dist/compose/resolve-block-map.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-block-map.js
 var startColMsg = "All mapping items must start at the same column";
 function resolveBlockMap({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, bm, onError, tag) {
   var _a, _b;
@@ -4944,7 +4944,7 @@ function resolveBlockMap({ composeNode: composeNode2, composeEmptyNode: composeE
   return commentEnd && commentEnd < offset && onError(commentEnd, "IMPOSSIBLE", "Map comment with trailing content"), map3.range = [bm.offset, offset, commentEnd != null ? commentEnd : offset], map3;
 }
 
-// node_modules/yaml/browser/dist/compose/resolve-block-seq.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-block-seq.js
 function resolveBlockSeq({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, bs, onError, tag) {
   var _a;
   let NodeClass = (_a = tag == null ? void 0 : tag.nodeClass) != null ? _a : YAMLSeq, seq2 = new NodeClass(ctx.schema);
@@ -4972,7 +4972,7 @@ function resolveBlockSeq({ composeNode: composeNode2, composeEmptyNode: composeE
   return seq2.range = [bs.offset, offset, commentEnd != null ? commentEnd : offset], seq2;
 }
 
-// node_modules/yaml/browser/dist/compose/resolve-end.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-end.js
 function resolveEnd(end, offset, reqSpace, onError) {
   let comment = "";
   if (end) {
@@ -5001,7 +5001,7 @@ function resolveEnd(end, offset, reqSpace, onError) {
   return { comment, offset };
 }
 
-// node_modules/yaml/browser/dist/compose/resolve-flow-collection.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-flow-collection.js
 var blockMsg = "Block collections are not allowed within flow collections", isBlock = (token) => token && (token.type === "block-map" || token.type === "block-seq");
 function resolveFlowCollection({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, fc, onError, tag) {
   var _a, _b, _c;
@@ -5116,7 +5116,7 @@ function resolveFlowCollection({ composeNode: composeNode2, composeEmptyNode: co
   return coll;
 }
 
-// node_modules/yaml/browser/dist/compose/compose-collection.js
+// ../../node_modules/yaml/browser/dist/compose/compose-collection.js
 function resolveCollection(CN2, ctx, token, onError, tagName, tag) {
   let coll = token.type === "block-map" ? resolveBlockMap(CN2, ctx, token, onError, tag) : token.type === "block-seq" ? resolveBlockSeq(CN2, ctx, token, onError, tag) : resolveFlowCollection(CN2, ctx, token, onError, tag), Coll = coll.constructor;
   return tagName === "!" || tagName === Coll.tagName ? (coll.tag = Coll.tagName, coll) : (tagName && (coll.tag = tagName), coll);
@@ -5143,7 +5143,7 @@ function composeCollection(CN2, ctx, token, props, onError) {
   return node.range = coll.range, node.tag = tagName, tag != null && tag.format && (node.format = tag.format), node;
 }
 
-// node_modules/yaml/browser/dist/compose/resolve-block-scalar.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-block-scalar.js
 function resolveBlockScalar(ctx, scalar, onError) {
   let start = scalar.offset, header = parseBlockScalarHeader(scalar, ctx.options.strict, onError);
   if (!header)
@@ -5263,7 +5263,7 @@ function splitLines(source) {
   return lines;
 }
 
-// node_modules/yaml/browser/dist/compose/resolve-flow-scalar.js
+// ../../node_modules/yaml/browser/dist/compose/resolve-flow-scalar.js
 function resolveFlowScalar(scalar, strict, onError) {
   let { offset, type, source, end } = scalar, _type, value, _onError = (rel, code, msg) => onError(offset + rel, code, msg);
   switch (type) {
@@ -5438,7 +5438,7 @@ function parseCharCode(source, offset, length2, onError) {
   }
 }
 
-// node_modules/yaml/browser/dist/compose/compose-scalar.js
+// ../../node_modules/yaml/browser/dist/compose/compose-scalar.js
 function composeScalar(ctx, token, tagToken, onError) {
   let { value, type, comment, range } = token.type === "block-scalar" ? resolveBlockScalar(ctx, token, onError) : resolveFlowScalar(token, ctx.options.strict, onError), tagName = tagToken ? ctx.directives.tagName(tagToken.source, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg)) : null, tag;
   ctx.options.stringKeys && ctx.atKey ? tag = ctx.schema[SCALAR] : tagName ? tag = findScalarTagByName(ctx.schema, value, tagName, tagToken, onError) : token.type === "scalar" ? tag = findScalarTagByTest(ctx, value, token, onError) : tag = ctx.schema[SCALAR];
@@ -5488,7 +5488,7 @@ function findScalarTagByTest({ atKey, directives, schema: schema4 }, value, toke
   return tag;
 }
 
-// node_modules/yaml/browser/dist/compose/util-empty-scalar-position.js
+// ../../node_modules/yaml/browser/dist/compose/util-empty-scalar-position.js
 function emptyScalarPosition(offset, before, pos) {
   if (before) {
     pos != null || (pos = before.length);
@@ -5509,7 +5509,7 @@ function emptyScalarPosition(offset, before, pos) {
   return offset;
 }
 
-// node_modules/yaml/browser/dist/compose/compose-node.js
+// ../../node_modules/yaml/browser/dist/compose/compose-node.js
 var CN = { composeNode, composeEmptyNode };
 function composeNode(ctx, token, props, onError) {
   let atKey = ctx.atKey, { spaceBefore, comment, anchor, tag } = props, node, isSrcToken = !0;
@@ -5556,7 +5556,7 @@ function composeAlias({ options }, { offset, source, end }, onError) {
   return alias.range = [offset, valueEnd, re.offset], re.comment && (alias.comment = re.comment), alias;
 }
 
-// node_modules/yaml/browser/dist/compose/compose-doc.js
+// ../../node_modules/yaml/browser/dist/compose/compose-doc.js
 function composeDoc(options, directives, { offset, start, value, end }, onError) {
   let opts = Object.assign({ _directives: directives }, options), doc2 = new Document(void 0, opts), ctx = {
     atKey: !1,
@@ -5577,7 +5577,7 @@ function composeDoc(options, directives, { offset, start, value, end }, onError)
   return re.comment && (doc2.comment = re.comment), doc2.range = [offset, contentEnd, re.offset], doc2;
 }
 
-// node_modules/yaml/browser/dist/compose/composer.js
+// ../../node_modules/yaml/browser/dist/compose/composer.js
 function getErrorPos(src) {
   if (typeof src == "number")
     return [src, src + 1];
@@ -5730,7 +5730,7 @@ ${end.comment}` : end.comment;
   }
 };
 
-// node_modules/yaml/browser/dist/parse/cst-visit.js
+// ../../node_modules/yaml/browser/dist/parse/cst-visit.js
 var BREAK2 = /* @__PURE__ */ Symbol("break visit"), SKIP2 = /* @__PURE__ */ Symbol("skip children"), REMOVE2 = /* @__PURE__ */ Symbol("remove item");
 function visit2(cst, visitor) {
   "type" in cst && cst.type === "document" && (cst = { start: cst.start, value: cst.value }), _visit(Object.freeze([]), cst, visitor);
@@ -5778,7 +5778,7 @@ function _visit(path, item, visitor) {
   return typeof ctrl == "function" ? ctrl(item, path) : ctrl;
 }
 
-// node_modules/yaml/browser/dist/parse/cst.js
+// ../../node_modules/yaml/browser/dist/parse/cst.js
 var BOM = "\uFEFF", DOCUMENT = "", FLOW_END = "", SCALAR2 = "";
 function tokenType(source) {
   switch (source) {
@@ -5842,7 +5842,7 @@ function tokenType(source) {
   return null;
 }
 
-// node_modules/yaml/browser/dist/parse/lexer.js
+// ../../node_modules/yaml/browser/dist/parse/lexer.js
 function isEmpty(ch) {
   switch (ch) {
     case void 0:
@@ -6279,7 +6279,7 @@ var hexDigits = new Set("0123456789ABCDEFabcdef"), tagChars = new Set("012345678
   }
 };
 
-// node_modules/yaml/browser/dist/parse/line-counter.js
+// ../../node_modules/yaml/browser/dist/parse/line-counter.js
 var LineCounter = class {
   constructor() {
     this.lineStarts = [], this.addNewLine = (offset) => this.lineStarts.push(offset), this.linePos = (offset) => {
@@ -6298,7 +6298,7 @@ var LineCounter = class {
   }
 };
 
-// node_modules/yaml/browser/dist/parse/parser.js
+// ../../node_modules/yaml/browser/dist/parse/parser.js
 function includesToken(list2, type) {
   for (let i = 0; i < list2.length; ++i)
     if (list2[i].type === type)
@@ -6955,7 +6955,7 @@ var Parser = class {
   }
 };
 
-// node_modules/yaml/browser/dist/public-api.js
+// ../../node_modules/yaml/browser/dist/public-api.js
 function parseOptions(options) {
   let prettyErrors = options.prettyErrors !== !1;
   return { lineCounter: options.lineCounter || prettyErrors && new LineCounter() || null, prettyErrors };
@@ -7905,7 +7905,7 @@ var list = (items, max2 = 5) => {
   }
 };
 
-// node_modules/lib0/map.js
+// ../../node_modules/lib0/map.js
 var create = () => /* @__PURE__ */ new Map(), copy = (m) => {
   let r = create();
   return m.forEach((v, k) => {
@@ -7926,10 +7926,10 @@ var create = () => /* @__PURE__ */ new Map(), copy = (m) => {
   return !1;
 };
 
-// node_modules/lib0/set.js
+// ../../node_modules/lib0/set.js
 var create2 = () => /* @__PURE__ */ new Set();
 
-// node_modules/lib0/array.js
+// ../../node_modules/lib0/array.js
 var last = (arr) => arr[arr.length - 1];
 var appendTo = (dest, src) => {
   for (let i = 0; i < src.length; i++)
@@ -7953,7 +7953,7 @@ var unfold = (len, f) => {
 };
 var isArray = Array.isArray;
 
-// node_modules/lib0/observable.js
+// ../../node_modules/lib0/observable.js
 var ObservableV2 = class {
   constructor() {
     this._observers = create();
@@ -8061,17 +8061,17 @@ var ObservableV2 = class {
   }
 };
 
-// node_modules/lib0/math.js
+// ../../node_modules/lib0/math.js
 var floor = Math.floor;
 var abs = Math.abs;
 var min = (a, b) => a < b ? a : b, max = (a, b) => a > b ? a : b, isNaN2 = Number.isNaN;
 var isNegativeZero = (n) => n !== 0 ? n < 0 : 1 / n < 0;
 
-// node_modules/lib0/number.js
+// ../../node_modules/lib0/number.js
 var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER, MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER, LOWEST_INT32 = 1 << 31;
 var isInteger = Number.isInteger || ((num) => typeof num == "number" && isFinite(num) && floor(num) === num), isNaN3 = Number.isNaN, parseInt2 = Number.parseInt;
 
-// node_modules/lib0/string.js
+// ../../node_modules/lib0/string.js
 var fromCharCode = String.fromCharCode, fromCodePoint = String.fromCodePoint, MAX_UTF16_CHARACTER = fromCharCode(65535), toLowerCase = (s) => s.toLowerCase(), trimLeftRegex = /^\s*/g, trimLeft = (s) => s.replace(trimLeftRegex, ""), fromCamelCaseRegex = /([A-Z])/g, fromCamelCase = (s, separator) => trimLeft(s.replace(fromCamelCaseRegex, (match2) => `${separator}${toLowerCase(match2)}`));
 var _encodeUtf8Polyfill = (str) => {
   let encodedString = unescape(encodeURIComponent(str)), len = encodedString.length, buf = new Uint8Array(len);
@@ -8087,7 +8087,7 @@ var utf8TextDecoder = typeof TextDecoder == "undefined" ? null : new TextDecoder
 utf8TextDecoder && utf8TextDecoder.decode(new Uint8Array()).length === 1 && (utf8TextDecoder = null);
 var repeat = (source, n) => unfold(n, () => source).join("");
 
-// node_modules/lib0/encoding.js
+// ../../node_modules/lib0/encoding.js
 var Encoder = class {
   constructor() {
     this.cpos = 0, this.cbuf = new Uint8Array(100), this.bufs = [];
@@ -8264,14 +8264,14 @@ var flushIntDiffOptRleEncoder = (encoder) => {
   }
 };
 
-// node_modules/lib0/error.js
+// ../../node_modules/lib0/error.js
 var create3 = (s) => new Error(s), methodUnimplemented = () => {
   throw create3("Method unimplemented");
 }, unexpectedCase = () => {
   throw create3("Unexpected case");
 };
 
-// node_modules/lib0/decoding.js
+// ../../node_modules/lib0/decoding.js
 var errorUnexpectedEndOfArray = create3("Unexpected end of array"), errorIntegerOutOfRange = create3("Integer out of Range"), Decoder = class {
   /**
    * @param {Uint8Array<Buf>} uint8Array Binary data to decode
@@ -8438,10 +8438,10 @@ var IntDiffOptRleDecoder = class extends Decoder {
   }
 };
 
-// node_modules/lib0/webcrypto.js
+// ../../node_modules/lib0/webcrypto.js
 var subtle = crypto.subtle, getRandomValues = crypto.getRandomValues.bind(crypto);
 
-// node_modules/lib0/random.js
+// ../../node_modules/lib0/random.js
 var uint32 = () => getRandomValues(new Uint32Array(1))[0];
 var uuidv4Template = "10000000-1000-4000-8000" + -1e11, uuidv4 = () => uuidv4Template.replace(
   /[018]/g,
@@ -8449,20 +8449,20 @@ var uuidv4Template = "10000000-1000-4000-8000" + -1e11, uuidv4 = () => uuidv4Tem
   (c) => (c ^ uint32() & 15 >> c / 4).toString(16)
 );
 
-// node_modules/lib0/time.js
+// ../../node_modules/lib0/time.js
 var getUnixTime = Date.now;
 
-// node_modules/lib0/promise.js
+// ../../node_modules/lib0/promise.js
 var create4 = (f) => (
   /** @type {Promise<T>} */
   new Promise(f)
 );
 var all = Promise.all.bind(Promise);
 
-// node_modules/lib0/conditions.js
+// ../../node_modules/lib0/conditions.js
 var undefinedToNull = (v) => v === void 0 ? null : v;
 
-// node_modules/lib0/storage.js
+// ../../node_modules/lib0/storage.js
 var VarStoragePolyfill = class {
   constructor() {
     this.map = /* @__PURE__ */ new Map();
@@ -8487,13 +8487,13 @@ try {
 }
 var varStorage = _localStorage;
 
-// node_modules/lib0/trait/equality.js
+// ../../node_modules/lib0/trait/equality.js
 var EqualityTraitSymbol = /* @__PURE__ */ Symbol("Equality"), equals = (a, b) => {
   var _a;
   return a === b || !!((_a = a == null ? void 0 : a[EqualityTraitSymbol]) != null && _a.call(a, b)) || !1;
 };
 
-// node_modules/lib0/object.js
+// ../../node_modules/lib0/object.js
 var isObject = (o) => typeof o == "object", assign = Object.assign, keys = Object.keys;
 var forEach = (obj, f) => {
   for (let key in obj)
@@ -8517,7 +8517,7 @@ var isEmpty2 = (obj) => {
   return freeze(o);
 };
 
-// node_modules/lib0/function.js
+// ../../node_modules/lib0/function.js
 var callAll = (fs, args2, i = 0) => {
   try {
     for (; i < fs.length; i++)
@@ -8583,7 +8583,7 @@ var equalityDeep = (a, b) => {
   return !0;
 }, isOneOf = (value, options) => options.includes(value);
 
-// node_modules/lib0/environment.js
+// ../../node_modules/lib0/environment.js
 var isNode2 = typeof process != "undefined" && process.release && /node|io\.js/.test(process.release.name) && Object.prototype.toString.call(typeof process != "undefined" ? process : 0) === "[object process]";
 var isMac = typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : !1, params, args = [], computeParams = () => {
   if (params === void 0)
@@ -8607,14 +8607,14 @@ var getVariable = (name) => isNode2 ? undefinedToNull(process.env[name.toUpperCa
 var hasConf = (name) => hasParam("--" + name) || getVariable(name) !== null, production = hasConf("production"), forceColor = isNode2 && isOneOf(process.env.FORCE_COLOR, ["true", "1", "2"]), supportsColor = forceColor || !hasParam("--no-colors") && // @todo deprecate --no-colors
 !hasConf("no-color") && (!isNode2 || process.stdout.isTTY) && (!isNode2 || hasParam("--color") || getVariable("COLORTERM") !== null || (getVariable("TERM") || "").includes("color"));
 
-// node_modules/lib0/buffer.js
+// ../../node_modules/lib0/buffer.js
 var createUint8ArrayFromLen = (len) => new Uint8Array(len);
 var copyUint8Array = (uint8Array) => {
   let newBuf = createUint8ArrayFromLen(uint8Array.byteLength);
   return newBuf.set(uint8Array), newBuf;
 };
 
-// node_modules/lib0/pair.js
+// ../../node_modules/lib0/pair.js
 var Pair2 = class {
   /**
    * @param {L} left
@@ -8625,7 +8625,7 @@ var Pair2 = class {
   }
 }, create5 = (left, right) => new Pair2(left, right);
 
-// node_modules/lib0/prng.js
+// ../../node_modules/lib0/prng.js
 var bool = (gen) => gen.next() >= 0.5, int53 = (gen, min2, max2) => floor(gen.next() * (max2 + 1 - min2) + min2);
 var int32 = (gen, min2, max2) => floor(gen.next() * (max2 + 1 - min2) + min2);
 var int31 = (gen, min2, max2) => int32(gen, min2, max2);
@@ -8637,7 +8637,7 @@ var letter = (gen) => fromCharCode(int31(gen, 97, 122)), word = (gen, minLen = 0
 };
 var oneOf = (gen, array) => array[int31(gen, 0, array.length - 1)];
 
-// node_modules/lib0/schema.js
+// ../../node_modules/lib0/schema.js
 var schemaSymbol = /* @__PURE__ */ Symbol("0schema"), ValidationError = class {
   constructor() {
     this._rerrs = [];
@@ -9231,7 +9231,7 @@ ${err.toString()}`);
   _random($(schema4), gen)
 );
 
-// node_modules/lib0/dom.js
+// ../../node_modules/lib0/dom.js
 var doc = (
   /** @type {Document} */
   typeof document != "undefined" ? document : {}
@@ -9246,10 +9246,10 @@ var $text = $custom((el) => el.nodeType === TEXT_NODE);
 var mapToStyleString = (m) => map2(m, (value, key) => `${key}:${value};`).join("");
 var ELEMENT_NODE = doc.ELEMENT_NODE, TEXT_NODE = doc.TEXT_NODE, CDATA_SECTION_NODE = doc.CDATA_SECTION_NODE, COMMENT_NODE = doc.COMMENT_NODE, DOCUMENT_NODE = doc.DOCUMENT_NODE, DOCUMENT_TYPE_NODE = doc.DOCUMENT_TYPE_NODE, DOCUMENT_FRAGMENT_NODE = doc.DOCUMENT_FRAGMENT_NODE, $node = $custom((el) => el.nodeType === DOCUMENT_NODE);
 
-// node_modules/lib0/symbol.js
+// ../../node_modules/lib0/symbol.js
 var create6 = Symbol;
 
-// node_modules/lib0/logging.common.js
+// ../../node_modules/lib0/logging.common.js
 var BOLD = create6(), UNBOLD = create6(), BLUE = create6(), GREY = create6(), GREEN = create6(), RED = create6(), PURPLE = create6(), ORANGE = create6(), UNCOLOR = create6(), computeNoColorLoggingArgs = (args2) => {
   var _a;
   args2.length === 1 && ((_a = args2[0]) == null ? void 0 : _a.constructor) === Function && (args2 = /** @type {Array<string|Symbol|Object|number>} */
@@ -9273,7 +9273,7 @@ var BOLD = create6(), UNBOLD = create6(), BLUE = create6(), GREY = create6(), GR
 };
 var lastLoggingTime = getUnixTime();
 
-// node_modules/lib0/logging.js
+// ../../node_modules/lib0/logging.js
 var _browserStyleMap = {
   [BOLD]: create5("font-weight", "bold"),
   [UNBOLD]: create5("font-weight", "normal"),
@@ -9317,7 +9317,7 @@ var _browserStyleMap = {
 };
 var vconsoles = create2();
 
-// node_modules/lib0/iterator.js
+// ../../node_modules/lib0/iterator.js
 var createIterator = (next) => ({
   /**
    * @return {IterableIterator<T>}
@@ -9338,7 +9338,7 @@ var createIterator = (next) => ({
   return { done, value: done ? void 0 : fmap(value) };
 });
 
-// node_modules/yjs/dist/yjs.mjs
+// ../../node_modules/yjs/dist/yjs.mjs
 var DeleteItem = class {
   /**
    * @param {number} clock
@@ -14143,7 +14143,7 @@ var Item = class _Item extends AbstractStruct {
 glo[importIdentifier] === !0 && console.error("Yjs was already imported. This breaks constructor checks and will lead to issues! - https://github.com/yjs/yjs/issues/438");
 glo[importIdentifier] = !0;
 
-// node_modules/lib0/indexeddb.js
+// ../../node_modules/lib0/indexeddb.js
 var rtop = (request) => create4((resolve, reject) => {
   request.onerror = (event) => reject(new Error(event.target.error)), request.onsuccess = (event) => resolve(event.target.result);
 }), openDB = (name, initDB) => create4((resolve, reject) => {
@@ -14179,7 +14179,7 @@ var iterateOnRequest = (request, f) => create4((resolve, reject) => {
 var iterateKeys = (store, keyrange, f, direction = "next") => iterateOnRequest(store.openKeyCursor(keyrange, direction), (cursor) => f(cursor.key)), getStore = (t, store) => t.objectStore(store);
 var createIDBKeyRangeUpperBound = (upper, upperOpen) => IDBKeyRange.upperBound(upper, upperOpen), createIDBKeyRangeLowerBound = (lower, lowerOpen) => IDBKeyRange.lowerBound(lower, lowerOpen);
 
-// node_modules/y-indexeddb/src/y-indexeddb.js
+// ../../node_modules/y-indexeddb/src/y-indexeddb.js
 var customStoreName = "custom", updatesStoreName = "updates", PREFERRED_TRIM_SIZE = 500, fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {
 }, afterApplyUpdatesCallback = () => {
 }) => {
@@ -14422,7 +14422,7 @@ function mergeDiskOntoDoc(base, disk, current) {
   return { text: merged, clean: applied.every(Boolean) };
 }
 
-// node_modules/y-protocols/sync.js
+// ../../node_modules/y-protocols/sync.js
 var messageYjsSyncStep1 = 0, messageYjsSyncStep2 = 1, messageYjsUpdate = 2, writeSyncStep1 = (encoder, doc2) => {
   writeVarUint(encoder, messageYjsSyncStep1);
   let sv = encodeStateVector(doc2);
@@ -15199,6 +15199,9 @@ function createCrdtWiring(deps) {
     forgetUnsent: (docId) => {
       unsentDocIds.delete(docId);
     },
+    clearUnsent: () => {
+      unsentDocIds.clear();
+    },
     dispose
   };
 }
@@ -15301,6 +15304,23 @@ var MAX_QUEUE = 500, OP_TTL_MS = 300 * 1e3, MAX_ATTEMPTS = 8, BASE_BACKOFF_MS = 
       }
       this.entries.size >= this.opts.maxQueue && this.evictOldest(), this.entries.set(op.docId, { op: { ...op, attempts: 0 }, nextAttemptAt: 0 });
     }
+  }
+  /** Drop every pending op and persist the empty queue.
+   *
+   *  A queued op carries a bare `docId` and NO vault (see CrdtOp), so it is
+   *  delivered blind on whatever crdt: topic is joined when it finally flushes.
+   *  Across a vault change that means the PREVIOUS vault's note ids arriving on
+   *  the NEW vault's channel, where the server cannot place them -- the client
+   *  half of the cross-vault id-collision class (engram #1318). The ops are per-
+   *  vault state, exactly like the note-id map and the relocation timestamps
+   *  that SyncEngine.wipePerVaultState already drops, so they are dropped in
+   *  lockstep with those.
+   *
+   *  Dropping is safe, not lossy: switching vaults clears `lastSync`, so the
+   *  next full sync against the old vault re-derives and re-pushes anything
+   *  these ops carried. */
+  clear() {
+    this.entries.size !== 0 && (this.entries.clear(), this.schedulePersist());
   }
   /** Cancel any pending persist timer. Call on plugin unload. */
   dispose() {
@@ -19297,6 +19317,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  because it arrived FROM the server: handleDelete's remote-echo early-return
      *  runs first. */
     this.crdtEnqueue = null;
+    /** See CrdtPorts.resetOutbox. */
+    this.crdtResetOutbox = null;
     /** Optional level-triggered check: is the `crdt:` topic JOINED right now?
      *  The `crdt` manager latch above is edge-triggered (set on join via
      *  onCrdtJoined, cleared on disconnect), so it can go STALE — set, but the
@@ -19457,8 +19479,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  keys present in the patch are assigned, so each lifecycle stage names
    *  exactly what it wires (or clears, via explicit null). */
   setCrdtPorts(ports) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o;
-    "manager" in ports && (this.crdt = (_a = ports.manager) != null ? _a : null), "deviceId" in ports && (this.deviceId = (_b = ports.deviceId) != null ? _b : null), "editorDetach" in ports && (this.crdtEditorDetach = (_c = ports.editorDetach) != null ? _c : null), "editorRebind" in ports && (this.crdtEditorRebind = (_d = ports.editorRebind) != null ? _d : null), "boundBufferText" in ports && (this.crdtBoundBufferText = (_e = ports.boundBufferText) != null ? _e : null), "requestSave" in ports && (this.crdtRequestSave = (_f = ports.requestSave) != null ? _f : null), "noteIdMap" in ports && (this.noteIdMap = (_g = ports.noteIdMap) != null ? _g : null), "enrollment" in ports && (this.crdtEnrollment = (_h = ports.enrollment) != null ? _h : null), "create" in ports && (this.crdtCreate = (_i = ports.create) != null ? _i : null), "createBatch" in ports && (this.crdtCreateBatch = (_j = ports.createBatch) != null ? _j : null), "delete" in ports && (this.crdtDelete = (_k = ports.delete) != null ? _k : null), "enqueue" in ports && (this.crdtEnqueue = (_l = ports.enqueue) != null ? _l : null), "live" in ports && (this.crdtLive = (_m = ports.live) != null ? _m : null), "liveBound" in ports && (this.isLiveBound = (_n = ports.liveBound) != null ? _n : (() => !1)), "catchupSince" in ports && (this.crdtCatchupSince = (_o = ports.catchupSince) != null ? _o : null);
+    var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m, _n, _o, _p;
+    "manager" in ports && (this.crdt = (_a = ports.manager) != null ? _a : null), "deviceId" in ports && (this.deviceId = (_b = ports.deviceId) != null ? _b : null), "editorDetach" in ports && (this.crdtEditorDetach = (_c = ports.editorDetach) != null ? _c : null), "editorRebind" in ports && (this.crdtEditorRebind = (_d = ports.editorRebind) != null ? _d : null), "boundBufferText" in ports && (this.crdtBoundBufferText = (_e = ports.boundBufferText) != null ? _e : null), "requestSave" in ports && (this.crdtRequestSave = (_f = ports.requestSave) != null ? _f : null), "noteIdMap" in ports && (this.noteIdMap = (_g = ports.noteIdMap) != null ? _g : null), "enrollment" in ports && (this.crdtEnrollment = (_h = ports.enrollment) != null ? _h : null), "create" in ports && (this.crdtCreate = (_i = ports.create) != null ? _i : null), "createBatch" in ports && (this.crdtCreateBatch = (_j = ports.createBatch) != null ? _j : null), "delete" in ports && (this.crdtDelete = (_k = ports.delete) != null ? _k : null), "enqueue" in ports && (this.crdtEnqueue = (_l = ports.enqueue) != null ? _l : null), "resetOutbox" in ports && (this.crdtResetOutbox = (_m = ports.resetOutbox) != null ? _m : null), "live" in ports && (this.crdtLive = (_n = ports.live) != null ? _n : null), "liveBound" in ports && (this.isLiveBound = (_o = ports.liveBound) != null ? _o : (() => !1)), "catchupSince" in ports && (this.crdtCatchupSince = (_p = ports.catchupSince) != null ? _p : null);
   }
   setCrdtManager(mgr) {
     this.setCrdtPorts({ manager: mgr });
@@ -20191,8 +20213,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  `invalidateIfVaultChanged`) call this — keeping them in lockstep is the
    *  point; a wipe that exists on only one path re-opens #200. */
   async wipePerVaultState() {
-    var _a;
-    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
+    var _a, _b;
+    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), (_b = this.crdtResetOutbox) == null || _b.call(this), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
   }
   /** Reset all per-vault sync bookkeeping. Used when the user switches the
    *  active server vault inside the SyncPreviewModal so the next sync starts
@@ -23460,6 +23482,16 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           enqueuedAt: Date.now(),
           attempts: 0
         });
+      },
+      // Vault change: discard the previous vault's outbound work. Both halves
+      // key by note_id with no vault attached, so both would otherwise be
+      // delivered against the NEW vault's topic under ids the OLD vault owns.
+      // Wired here (not inside SyncEngine) because the queue and the CRDT
+      // wiring are owned by the plugin; SyncEngine calls this from
+      // wipePerVaultState so BOTH vault-change routes stay in lockstep.
+      resetOutbox: () => {
+        var _a2, _b2;
+        (_a2 = this.crdtOpQueue) == null || _a2.clear(), (_b2 = this.crdtWiring) == null || _b2.clearUnsent();
       }
     });
     let saved = await this.loadPluginData();

--- a/src/crdt-op-queue.ts
+++ b/src/crdt-op-queue.ts
@@ -146,6 +146,26 @@ export class CrdtOpQueue {
 		}
 	}
 
+	/** Drop every pending op and persist the empty queue.
+	 *
+	 *  A queued op carries a bare `docId` and NO vault (see CrdtOp), so it is
+	 *  delivered blind on whatever crdt: topic is joined when it finally flushes.
+	 *  Across a vault change that means the PREVIOUS vault's note ids arriving on
+	 *  the NEW vault's channel, where the server cannot place them -- the client
+	 *  half of the cross-vault id-collision class (engram #1318). The ops are per-
+	 *  vault state, exactly like the note-id map and the relocation timestamps
+	 *  that SyncEngine.wipePerVaultState already drops, so they are dropped in
+	 *  lockstep with those.
+	 *
+	 *  Dropping is safe, not lossy: switching vaults clears `lastSync`, so the
+	 *  next full sync against the old vault re-derives and re-pushes anything
+	 *  these ops carried. */
+	clear(): void {
+		if (this.entries.size === 0) return;
+		this.entries.clear();
+		this.schedulePersist();
+	}
+
 	/** Cancel any pending persist timer. Call on plugin unload. */
 	dispose(): void {
 		if (this.persistTimer !== null) {

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -121,6 +121,11 @@ export interface CrdtWiring {
 	 *  since-deleted note is never re-enrolled on the next rejoin (a spurious STEP1
 	 *  that could race delete-wins / resurrect the note). */
 	forgetUnsent: (docId: string) => void;
+	/** Drop the WHOLE unsent-tracking set. Call on a vault change: these are the
+	 *  PREVIOUS vault's note ids, and reEnrollUnsent would otherwise STEP1 every
+	 *  one of them against the new vault's topic, where they resolve to nothing.
+	 *  Per-vault state, dropped in lockstep with the note-id map (engram #1318). */
+	clearUnsent: () => void;
 	/** Clear the pending strand-heal timer (call from the plugin's onunload). */
 	dispose: () => void;
 }
@@ -514,6 +519,9 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		},
 		forgetUnsent: (docId) => {
 			unsentDocIds.delete(docId);
+		},
+		clearUnsent: () => {
+			unsentDocIds.clear();
 		},
 		dispose,
 	};

--- a/src/main.ts
+++ b/src/main.ts
@@ -578,6 +578,16 @@ export default class EngramSyncPlugin extends Plugin {
 					enqueuedAt: Date.now(),
 					attempts: 0,
 				}),
+			// Vault change: discard the previous vault's outbound work. Both halves
+			// key by note_id with no vault attached, so both would otherwise be
+			// delivered against the NEW vault's topic under ids the OLD vault owns.
+			// Wired here (not inside SyncEngine) because the queue and the CRDT
+			// wiring are owned by the plugin; SyncEngine calls this from
+			// wipePerVaultState so BOTH vault-change routes stay in lockstep.
+			resetOutbox: () => {
+				this.crdtOpQueue?.clear();
+				this.crdtWiring?.clearUnsent();
+			},
 		});
 
 		// Restore last sync timestamp, offline queue, and sync state

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -339,6 +339,10 @@ export interface CrdtPorts {
 	createBatch?: CrdtCreateBatchFn | null;
 	delete?: ((docId: string) => Promise<{ doc_id: string }>) | null;
 	enqueue?: ((op: { kind: "create" | "delete"; docId: string; path: string }) => void) | null;
+	/** Drop every outbound CRDT op still pending delivery, plus the unsent-doc
+	 *  tracking set. Both key work by note_id with no vault attached, so both are
+	 *  per-vault state that a vault change must discard (engram #1318). */
+	resetOutbox?: (() => void) | null;
 	live?: (() => boolean) | null;
 	/** Nulling this restores the default never-bound check rather than leaving
 	 *  the port empty — `isLiveBound` is called unconditionally on the push
@@ -496,6 +500,7 @@ export class SyncEngine {
 		if ("createBatch" in ports) this.crdtCreateBatch = ports.createBatch ?? null;
 		if ("delete" in ports) this.crdtDelete = ports.delete ?? null;
 		if ("enqueue" in ports) this.crdtEnqueue = ports.enqueue ?? null;
+		if ("resetOutbox" in ports) this.crdtResetOutbox = ports.resetOutbox ?? null;
 		if ("live" in ports) this.crdtLive = ports.live ?? null;
 		if ("liveBound" in ports) this.isLiveBound = ports.liveBound ?? (() => false);
 		if ("catchupSince" in ports) this.crdtCatchupSince = ports.catchupSince ?? null;
@@ -1070,6 +1075,9 @@ export class SyncEngine {
 	private crdtEnqueue:
 		| ((op: { kind: "create" | "delete"; docId: string; path: string }) => void)
 		| null = null;
+
+	/** See CrdtPorts.resetOutbox. */
+	private crdtResetOutbox: (() => void) | null = null;
 
 	setCrdtEnqueue(
 		fn: ((op: { kind: "create" | "delete"; docId: string; path: string }) => void) | null,
@@ -1963,6 +1971,16 @@ export class SyncEngine {
 		// instance is shared with main.ts + live views.
 		this.noteIdMap?.clear();
 		this.clearConfirmedNoteIds();
+		// The durable op queue and the unsent-doc set are the two places a note_id
+		// outlives the vault it was minted in. A CrdtOp carries a bare docId and NO
+		// vault, so a create still pending when the user switches vaults is flushed
+		// blind on the NEW vault's topic under an id the OLD vault owns -- the
+		// server then cannot place it (engram #1318, the cross-vault collision the
+		// server now re-mints around). reEnrollUnsent has the same shape: it would
+		// STEP1 the previous vault's ids against the new topic. Dropping both is
+		// safe because lastSync is cleared above, so a later switch BACK re-derives
+		// and re-pushes anything they carried.
+		this.crdtResetOutbox?.();
 		// note_ids are only unique WITHIN a vault (final review MINOR-6) — a
 		// relocation timestamp recorded for an id under the OLD vault must not
 		// survive to stale-gate an unrelated note that happens to reuse the same

--- a/tests/crdt-op-queue.test.ts
+++ b/tests/crdt-op-queue.test.ts
@@ -380,3 +380,60 @@ describe("strict TTL", () => {
 		expect(drops).toEqual(["ttl"]);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// 8. clear(): vault change drops the whole outbox
+// ---------------------------------------------------------------------------
+
+describe("clear on vault change", () => {
+	test("drops every pending op so none is delivered on the new vault's topic", async () => {
+		// A queued op carries a bare docId and NO vault, so after a vault switch it
+		// would be sent blind on the new vault's channel under an id the PREVIOUS
+		// vault owns. That is the client half of the cross-vault id-collision class
+		// (engram #1318): the server sees an id it cannot place in this vault.
+		const clock = fakeClock();
+		const { fn: send, calls } = scriptedSend();
+		const q = makeQueue({ send, now: clock.now });
+
+		q.enqueue(makeOp("doc-a", "create"));
+		q.enqueue(makeOp("doc-b", "delete"));
+
+		q.clear();
+		await q.onJoined();
+
+		expect(calls).toHaveLength(0);
+	});
+
+	test("persists the emptied queue, so a reload cannot resurrect the old vault's ops", async () => {
+		// Without the persist the ops survive on disk and come back through load()
+		// on the next start, re-arming the exact collision the clear prevents.
+		const clock = fakeClock();
+		const { fn: send } = scriptedSend();
+		const persisted: CrdtOp[][] = [];
+		const q = new CrdtOpQueue({ send, now: clock.now, persistDelayMs: 0 });
+		q.setPersist((ops) => {
+			persisted.push(ops);
+		});
+
+		q.enqueue(makeOp("doc-a", "create"));
+		q.clear();
+
+		await new Promise((r) => setTimeout(r, 5));
+		expect(persisted.at(-1)).toEqual([]);
+	});
+
+	test("is a no-op on an already-empty queue (no pointless write)", async () => {
+		const clock = fakeClock();
+		const { fn: send } = scriptedSend();
+		const persisted: CrdtOp[][] = [];
+		const q = new CrdtOpQueue({ send, now: clock.now, persistDelayMs: 0 });
+		q.setPersist((ops) => {
+			persisted.push(ops);
+		});
+
+		q.clear();
+
+		await new Promise((r) => setTimeout(r, 5));
+		expect(persisted).toHaveLength(0);
+	});
+});

--- a/tests/note-id-map-hygiene.test.ts
+++ b/tests/note-id-map-hygiene.test.ts
@@ -105,6 +105,41 @@ describe("vault change wipes note identity (plugin #200)", () => {
 		expect((engine as any).isNoteConfirmed("id-from-vault-A")).toBe(false);
 	});
 
+	test("both vault-change routes also drop the outbound CRDT work", async () => {
+		// The note-id map was never the only carrier. A queued CrdtOp holds a bare
+		// docId with NO vault, and the unsent-doc set is the same shape, so both
+		// survive a switch and get delivered against the NEW vault's topic under
+		// ids the OLD vault owns. That is the client half of the cross-vault
+		// collision the server now re-mints around (engram #1318). Asserted on BOTH
+		// routes because wipePerVaultState exists precisely to keep them in
+		// lockstep -- a drop wired to only one re-opens the hazard on the other.
+		for (const route of ["backstop", "picker"] as const) {
+			const engine = createEngine("vault-B");
+			const resetOutbox = mock();
+			engine.setCrdtPorts({ resetOutbox });
+
+			if (route === "backstop") {
+				engine.setSyncStateVaultId("vault-A");
+				await (engine as any).invalidateIfVaultChanged();
+			} else {
+				await engine.resetForVaultChange();
+			}
+
+			expect(resetOutbox).toHaveBeenCalledTimes(1);
+		}
+	});
+
+	test("same vault: outbox survives (it is still this vault's work)", async () => {
+		const engine = createEngine("vault-A");
+		const resetOutbox = mock();
+		engine.setCrdtPorts({ resetOutbox });
+		engine.setSyncStateVaultId("vault-A");
+
+		await (engine as any).invalidateIfVaultChanged();
+
+		expect(resetOutbox).not.toHaveBeenCalled();
+	});
+
 	test("same vault: map untouched", async () => {
 		const engine = createEngine("vault-A");
 		const map = new NoteIdMap();


### PR DESCRIPTION
## What

The client half of the cross-vault note-id collision that lost 304 notes. Server half is engram-app/Engram#1318.

## The gap

`SyncEngine.wipePerVaultState` exists to drop everything scoped to the vault you just left, and it already handles the note-id map, the confirmed set, the replay cursor, the manifest watermark and the relocation timestamps.

It missed the two places that actually carry a `note_id` **out over the wire**:

| carrier | why it leaks |
|---|---|
| `CrdtOpQueue` entries | a `CrdtOp` is `{id, kind, docId, payload, enqueuedAt, attempts}` — **no vault**. A create still pending at switch time is flushed blind on the new vault's topic under an id the old vault owns. Persisted to `data.json`, so it survives a restart too. |
| `unsentDocIds` (wiring) | same shape. `reEnrollUnsent()` STEP1s every one of the previous vault's ids against the new topic. |

Server-side that lands as `classify_by_id -> :none` on an id that exists globally: the exact collision #1318 now re-mints around. This PR stops manufacturing it.

## The fix

- `CrdtOpQueue.clear()` — drops every pending op **and** persists the empty queue, so a reload can't resurrect them. No-op when already empty (no pointless write).
- `CrdtWiring.clearUnsent()` — drops the whole unsent set.
- A `resetOutbox` port called from `wipePerVaultState`.

Wiring lives in `main.ts` (the queue and the CRDT wiring are the plugin's, not `SyncEngine`'s); the **call** lives in `wipePerVaultState` so both vault-change routes — the explicit picker (`resetForVaultChange`) and the backstop (`invalidateIfVaultChanged`) — stay in lockstep. That lockstep is the method's stated contract, and a drop wired to only one route re-opens the hazard on the other.

**Dropping is safe, not lossy.** The same wipe clears `lastSync`, so switching back re-derives and re-pushes anything these ops carried.

## Tests

Written test-first (queue tests were red with `q.clear is not a function` before the implementation).

- both vault-change routes call `resetOutbox` — asserted per route, not once
- a same-vault `invalidateIfVaultChanged` leaves the outbox alone
- `clear()` drops pending ops so none is delivered after a rejoin
- `clear()` persists the empty queue
- `clear()` on an empty queue writes nothing

## Gates

`bun run build` ✓ · `bun test` 2446 pass / 0 fail ✓ · `biome ci` ✓ · `lint:obsidian` ✓ · `lint:css` ✓

## Scope

This removes a **carrier**, and it is worth being precise that it is not proof of the original trigger. The reported flow (already signed in → Change vault → create new vault → sync) is still not fully explained; confirming it needs #1318's reason-logging in prod plus a repeat of the flow. This is a real leak on its own terms either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC