### PR TITLE
fix(sync): stamp outbound CRDT ops with their vault instead of wiping the outbox

### DIFF
--- a/main.js
+++ b/main.js
@@ -15270,7 +15270,7 @@ var MAX_QUEUE = 500, OP_TTL_MS = 300 * 1e3, MAX_ATTEMPTS = 8, BASE_BACKOFF_MS = 
     this.persistFn = null;
     this.persistTimer = null;
     var _a;
-    this.send = deps.send, this.now = deps.now, this.onDrop = deps.onDrop, this.opts = { ...DEFAULT_OPTIONS, ...deps.options }, this.persistDelayMs = (_a = deps.persistDelayMs) != null ? _a : PERSIST_DELAY_MS;
+    this.send = deps.send, this.now = deps.now, this.onDrop = deps.onDrop, this.currentVaultId = deps.currentVaultId, this.opts = { ...DEFAULT_OPTIONS, ...deps.options }, this.persistDelayMs = (_a = deps.persistDelayMs) != null ? _a : PERSIST_DELAY_MS;
   }
   /** Number of distinct pending ops (docIds). */
   size() {
@@ -15304,23 +15304,6 @@ var MAX_QUEUE = 500, OP_TTL_MS = 300 * 1e3, MAX_ATTEMPTS = 8, BASE_BACKOFF_MS = 
       }
       this.entries.size >= this.opts.maxQueue && this.evictOldest(), this.entries.set(op.docId, { op: { ...op, attempts: 0 }, nextAttemptAt: 0 });
     }
-  }
-  /** Drop every pending op and persist the empty queue.
-   *
-   *  A queued op carries a bare `docId` and NO vault (see CrdtOp), so it is
-   *  delivered blind on whatever crdt: topic is joined when it finally flushes.
-   *  Across a vault change that means the PREVIOUS vault's note ids arriving on
-   *  the NEW vault's channel, where the server cannot place them -- the client
-   *  half of the cross-vault id-collision class (engram #1318). The ops are per-
-   *  vault state, exactly like the note-id map and the relocation timestamps
-   *  that SyncEngine.wipePerVaultState already drops, so they are dropped in
-   *  lockstep with those.
-   *
-   *  Dropping is safe, not lossy: switching vaults clears `lastSync`, so the
-   *  next full sync against the old vault re-derives and re-pushes anything
-   *  these ops carried. */
-  clear() {
-    this.entries.size !== 0 && (this.entries.clear(), this.schedulePersist());
   }
   /** Cancel any pending persist timer. Call on plugin unload. */
   dispose() {
@@ -15357,6 +15340,22 @@ var MAX_QUEUE = 500, OP_TTL_MS = 300 * 1e3, MAX_ATTEMPTS = 8, BASE_BACKOFF_MS = 
     let entry = this.entries.get(first.value);
     this.entries.delete(first.value), entry && ((_a = this.onDrop) == null || _a.call(this, entry.op, "overflow")), this.schedulePersist();
   }
+  /** Drop and notify if the op belongs to a vault we are no longer syncing.
+   *
+   *  Checked HERE, at send time, rather than by a hook on the vault switch: the
+   *  crdt: topic rejoin flushes this queue, and on the OAuth-relogin route that
+   *  happens BEFORE any sync-start hook runs, so a switch-time clear was already
+   *  too late. Checking per op also keeps a same-vault reset non-destructive --
+   *  a queued delete has no REST fallback, so dropping the whole outbox on any
+   *  vault-state reset resurrected deleted notes.
+   *
+   *  Goes through onDrop like every other undelivered removal, so a discarded op
+   *  leaves the same warn-level trail the others do. */
+  dropIfForeignVault(docId, entry) {
+    var _a, _b, _c, _d;
+    let current = (_b = (_a = this.currentVaultId) == null ? void 0 : _a.call(this)) != null ? _b : null, owner = (_c = entry.op.vaultId) != null ? _c : null;
+    return !owner || !current || owner === current ? !1 : (this.entries.delete(docId), (_d = this.onDrop) == null || _d.call(this, entry.op, "vault-changed"), this.schedulePersist(), !0);
+  }
   /** Drop and notify if the op has aged past its TTL. Returns true if dropped. */
   dropIfExpired(docId, entry) {
     var _a;
@@ -15382,7 +15381,7 @@ var MAX_QUEUE = 500, OP_TTL_MS = 300 * 1e3, MAX_ATTEMPTS = 8, BASE_BACKOFF_MS = 
       try {
         for (let docId of [...this.entries.keys()]) {
           let entry = this.entries.get(docId);
-          entry && (this.dropIfExpired(docId, entry) || entry.nextAttemptAt > this.now() || await this.attempt(docId, entry));
+          entry && (this.dropIfExpired(docId, entry) || this.dropIfForeignVault(docId, entry) || entry.nextAttemptAt > this.now() || await this.attempt(docId, entry));
         }
       } finally {
         this.flushing = !1;
@@ -23462,6 +23461,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         }
       }),
       now: () => Date.now(),
+      // Read live, never captured: the queue re-checks each op against the
+      // vault we are syncing RIGHT NOW, at send time.
+      currentVaultId: () => {
+        var _a2;
+        return (_a2 = this.settings.vaultId) != null ? _a2 : null;
+      },
       onDrop: (op, reason) => rlog().warn(
         "crdt",
         `crdt_${op.kind} dropped (${reason}) without delivery: ${op.docId}`
@@ -23473,25 +23478,33 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.tick();
     }, 5e3)), this.syncEngine.setCrdtPorts({
       enqueue: (op) => {
-        var _a2;
-        return (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.enqueue({
+        var _a2, _b2;
+        return (_b2 = this.crdtOpQueue) == null ? void 0 : _b2.enqueue({
           id: crypto.randomUUID(),
           kind: op.kind,
           docId: op.docId,
           payload: { path: op.path },
           enqueuedAt: Date.now(),
-          attempts: 0
+          attempts: 0,
+          // A docId only means anything inside its vault; stamp the op so a
+          // switch cannot deliver it blind on another vault's topic.
+          vaultId: (_a2 = this.settings.vaultId) != null ? _a2 : null
         });
       },
-      // Vault change: discard the previous vault's outbound work. Both halves
-      // key by note_id with no vault attached, so both would otherwise be
-      // delivered against the NEW vault's topic under ids the OLD vault owns.
-      // Wired here (not inside SyncEngine) because the queue and the CRDT
-      // wiring are owned by the plugin; SyncEngine calls this from
-      // wipePerVaultState so BOTH vault-change routes stay in lockstep.
+      // Vault change: drop the unsent-doc tracking set, which holds the
+      // PREVIOUS vault's note ids and would otherwise be STEP1'd against the
+      // new topic by reEnrollUnsent.
+      //
+      // The op QUEUE is deliberately NOT wiped here. It used to be, and that
+      // was wrong twice over: this hook runs at the head of a sync, by which
+      // point the topic rejoin has already flushed the queue (so the leak
+      // stayed open on the OAuth-relogin route), and it discarded queued
+      // DELETES, which have no REST fallback and cannot be re-derived from
+      // disk -- the deleted note came back on the next catch-up. Ops now carry
+      // their vaultId and self-drop at send time instead.
       resetOutbox: () => {
-        var _a2, _b2;
-        (_a2 = this.crdtOpQueue) == null || _a2.clear(), (_b2 = this.crdtWiring) == null || _b2.clearUnsent();
+        var _a2;
+        (_a2 = this.crdtWiring) == null || _a2.clearUnsent();
       }
     });
     let saved = await this.loadPluginData();
@@ -24416,7 +24429,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           createVault: (name) => this.api.createVault(name),
           applyVaultChange: async (id2, name) => {
             var _a2, _b2;
-            return this.settings.vaultId = id2, this.settings.remoteVaultName = name, this.api.setVaultId(id2), this.syncEngine.updateSettings(this.settings), await this.syncEngine.resetForVaultChange(), this.syncGateAcceptedFor = null, this.lastMapReconcileAt = 0, (_a2 = this.crdtWiring) == null || _a2.clearStrandHealAttempts(), this.syncEngine.setSyncBlocked(!0), await this.savePluginData(this.syncEngine.getLastSync()), (_b2 = this.settingTab) == null || _b2.rerender(), this.setupNoteStream(), this.syncEngine.computeSyncPlan("full");
+            return id2 === this.settings.vaultId ? (this.settings.remoteVaultName = name, this.syncEngine.computeSyncPlan("full")) : (this.settings.vaultId = id2, this.settings.remoteVaultName = name, this.api.setVaultId(id2), this.syncEngine.updateSettings(this.settings), await this.syncEngine.resetForVaultChange(), this.syncGateAcceptedFor = null, this.lastMapReconcileAt = 0, (_a2 = this.crdtWiring) == null || _a2.clearStrandHealAttempts(), this.syncEngine.setSyncBlocked(!0), await this.savePluginData(this.syncEngine.getLastSync()), (_b2 = this.settingTab) == null || _b2.rerender(), this.setupNoteStream(), this.syncEngine.computeSyncPlan("full"));
           }
         });
         this.syncEngine.computeSyncPlan("full").then((plan) => modal.setPlan(plan)).catch((e) => {

--- a/src/crdt-op-queue.ts
+++ b/src/crdt-op-queue.ts
@@ -27,10 +27,15 @@ export type CrdtOp = {
 	payload: unknown;
 	enqueuedAt: number;
 	attempts: number;
+	/** Vault this op was minted against. A docId is only meaningful WITHIN a
+	 *  vault, so an op that outlives a vault switch must not be delivered blind
+	 *  on the new vault's topic. Optional: ops persisted before this field
+	 *  existed have none and are delivered as before. */
+	vaultId?: string | null;
 };
 
 /** Why an op was dropped without being acked. */
-export type DropReason = "ttl" | "overflow" | "max-attempts";
+export type DropReason = "ttl" | "overflow" | "max-attempts" | "vault-changed";
 
 /** Result of an outbound send attempt. */
 export type SendResult = "ok" | "error" | "timeout";
@@ -66,6 +71,9 @@ export type CrdtOpQueueDeps = {
 	send: (op: CrdtOp) => Promise<SendResult>;
 	now: () => number;
 	onDrop?: (op: CrdtOp, reason: DropReason) => void;
+	/** The vault the plugin is syncing RIGHT NOW. Ops stamped with a different
+	 *  vault are dropped at send time rather than delivered on its topic. */
+	currentVaultId?: () => string | null;
 	options?: Partial<CrdtOpQueueOptions>;
 	/** Debounce window for persist writes, coalescing rapid mutations. */
 	persistDelayMs?: number;
@@ -95,6 +103,7 @@ export class CrdtOpQueue {
 	private readonly send: (op: CrdtOp) => Promise<SendResult>;
 	private readonly now: () => number;
 	private readonly onDrop?: (op: CrdtOp, reason: DropReason) => void;
+	private readonly currentVaultId?: () => string | null;
 	private readonly opts: CrdtOpQueueOptions;
 
 	private persistFn: ((ops: CrdtOp[]) => Promise<void> | void) | null = null;
@@ -105,6 +114,7 @@ export class CrdtOpQueue {
 		this.send = deps.send;
 		this.now = deps.now;
 		this.onDrop = deps.onDrop;
+		this.currentVaultId = deps.currentVaultId;
 		this.opts = { ...DEFAULT_OPTIONS, ...deps.options };
 		this.persistDelayMs = deps.persistDelayMs ?? PERSIST_DELAY_MS;
 	}
@@ -144,26 +154,6 @@ export class CrdtOpQueue {
 			if (this.entries.size >= this.opts.maxQueue) this.evictOldest();
 			this.entries.set(op.docId, { op: { ...op, attempts: 0 }, nextAttemptAt: 0 });
 		}
-	}
-
-	/** Drop every pending op and persist the empty queue.
-	 *
-	 *  A queued op carries a bare `docId` and NO vault (see CrdtOp), so it is
-	 *  delivered blind on whatever crdt: topic is joined when it finally flushes.
-	 *  Across a vault change that means the PREVIOUS vault's note ids arriving on
-	 *  the NEW vault's channel, where the server cannot place them -- the client
-	 *  half of the cross-vault id-collision class (engram #1318). The ops are per-
-	 *  vault state, exactly like the note-id map and the relocation timestamps
-	 *  that SyncEngine.wipePerVaultState already drops, so they are dropped in
-	 *  lockstep with those.
-	 *
-	 *  Dropping is safe, not lossy: switching vaults clears `lastSync`, so the
-	 *  next full sync against the old vault re-derives and re-pushes anything
-	 *  these ops carried. */
-	clear(): void {
-		if (this.entries.size === 0) return;
-		this.entries.clear();
-		this.schedulePersist();
 	}
 
 	/** Cancel any pending persist timer. Call on plugin unload. */
@@ -218,6 +208,28 @@ export class CrdtOpQueue {
 		this.schedulePersist();
 	}
 
+	/** Drop and notify if the op belongs to a vault we are no longer syncing.
+	 *
+	 *  Checked HERE, at send time, rather than by a hook on the vault switch: the
+	 *  crdt: topic rejoin flushes this queue, and on the OAuth-relogin route that
+	 *  happens BEFORE any sync-start hook runs, so a switch-time clear was already
+	 *  too late. Checking per op also keeps a same-vault reset non-destructive --
+	 *  a queued delete has no REST fallback, so dropping the whole outbox on any
+	 *  vault-state reset resurrected deleted notes.
+	 *
+	 *  Goes through onDrop like every other undelivered removal, so a discarded op
+	 *  leaves the same warn-level trail the others do. */
+	private dropIfForeignVault(docId: string, entry: Entry): boolean {
+		const current = this.currentVaultId?.() ?? null;
+		const owner = entry.op.vaultId ?? null;
+		// No stamp (pre-upgrade op) or no current vault: nothing to compare.
+		if (!owner || !current || owner === current) return false;
+		this.entries.delete(docId);
+		this.onDrop?.(entry.op, "vault-changed");
+		this.schedulePersist();
+		return true;
+	}
+
 	/** Drop and notify if the op has aged past its TTL. Returns true if dropped. */
 	private dropIfExpired(docId: string, entry: Entry): boolean {
 		if (this.now() - entry.op.enqueuedAt <= this.opts.opTtlMs) return false;
@@ -255,6 +267,7 @@ export class CrdtOpQueue {
 				const entry = this.entries.get(docId);
 				if (!entry) continue;
 				if (this.dropIfExpired(docId, entry)) continue;
+				if (this.dropIfForeignVault(docId, entry)) continue;
 				if (entry.nextAttemptAt > this.now()) continue;
 				await this.attempt(docId, entry);
 			}

--- a/src/main.ts
+++ b/src/main.ts
@@ -553,6 +553,9 @@ export default class EngramSyncPlugin extends Plugin {
 				},
 			}),
 			now: () => Date.now(),
+			// Read live, never captured: the queue re-checks each op against the
+			// vault we are syncing RIGHT NOW, at send time.
+			currentVaultId: () => this.settings.vaultId ?? null,
 			onDrop: (op, reason) =>
 				rlog().warn(
 					"crdt",
@@ -577,15 +580,22 @@ export default class EngramSyncPlugin extends Plugin {
 					payload: { path: op.path },
 					enqueuedAt: Date.now(),
 					attempts: 0,
+					// A docId only means anything inside its vault; stamp the op so a
+					// switch cannot deliver it blind on another vault's topic.
+					vaultId: this.settings.vaultId ?? null,
 				}),
-			// Vault change: discard the previous vault's outbound work. Both halves
-			// key by note_id with no vault attached, so both would otherwise be
-			// delivered against the NEW vault's topic under ids the OLD vault owns.
-			// Wired here (not inside SyncEngine) because the queue and the CRDT
-			// wiring are owned by the plugin; SyncEngine calls this from
-			// wipePerVaultState so BOTH vault-change routes stay in lockstep.
+			// Vault change: drop the unsent-doc tracking set, which holds the
+			// PREVIOUS vault's note ids and would otherwise be STEP1'd against the
+			// new topic by reEnrollUnsent.
+			//
+			// The op QUEUE is deliberately NOT wiped here. It used to be, and that
+			// was wrong twice over: this hook runs at the head of a sync, by which
+			// point the topic rejoin has already flushed the queue (so the leak
+			// stayed open on the OAuth-relogin route), and it discarded queued
+			// DELETES, which have no REST fallback and cannot be re-derived from
+			// disk -- the deleted note came back on the next catch-up. Ops now carry
+			// their vaultId and self-drop at send time instead.
 			resetOutbox: () => {
-				this.crdtOpQueue?.clear();
 				this.crdtWiring?.clearUnsent();
 			},
 		});
@@ -2436,6 +2446,15 @@ export default class EngramSyncPlugin extends Plugin {
 					listVaults: () => this.api.listVaults(),
 					createVault: (name) => this.api.createVault(name),
 					applyVaultChange: async (id, name) => {
+						// The picker lists EVERY vault including the active one, so a
+						// user can "change" to the vault they are already on. That is
+						// not a vault change: falling through would wipe lastSync and
+						// the per-vault state for no reason, and the empty lastSync
+						// then pulls back anything deleted-but-not-yet-pushed.
+						if (id === this.settings.vaultId) {
+							this.settings.remoteVaultName = name;
+							return this.syncEngine.computeSyncPlan("full");
+						}
 						// Persist the new vault target without going through
 						// saveSettings — that path would re-fire
 						// doSyncWithFirstSyncCheck for the closed gate and stack

--- a/tests/crdt-op-queue.test.ts
+++ b/tests/crdt-op-queue.test.ts
@@ -382,58 +382,63 @@ describe("strict TTL", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 8. clear(): vault change drops the whole outbox
+// 8. vault-stamped ops: a foreign vault's op is dropped at send time
 // ---------------------------------------------------------------------------
 
-describe("clear on vault change", () => {
-	test("drops every pending op so none is delivered on the new vault's topic", async () => {
-		// A queued op carries a bare docId and NO vault, so after a vault switch it
-		// would be sent blind on the new vault's channel under an id the PREVIOUS
-		// vault owns. That is the client half of the cross-vault id-collision class
-		// (engram #1318): the server sees an id it cannot place in this vault.
+describe("vault-stamped ops", () => {
+	test("an op for another vault is dropped before send, with an onDrop trail", async () => {
+		// A CrdtOp used to carry no vault, so anything still queued at switch time
+		// was delivered blind on the NEW vault's topic under the OLD vault's ids.
+		// Checked at SEND rather than at switch time on purpose: the topic rejoin
+		// flushes the queue before any switch-time hook runs.
 		const clock = fakeClock();
 		const { fn: send, calls } = scriptedSend();
-		const q = makeQueue({ send, now: clock.now });
+		const drops: [CrdtOp, DropReason][] = [];
+		const q = new CrdtOpQueue({
+			send,
+			now: clock.now,
+			onDrop: (op, reason) => drops.push([op, reason]),
+			currentVaultId: () => "vault-B",
+		});
 
-		q.enqueue(makeOp("doc-a", "create"));
-		q.enqueue(makeOp("doc-b", "delete"));
-
-		q.clear();
+		q.enqueue(makeOp("doc-a", "create", { vaultId: "vault-A" }));
 		await q.onJoined();
 
 		expect(calls).toHaveLength(0);
+		expect(drops.map(([op, reason]) => [op.docId, reason])).toEqual([
+			["doc-a", "vault-changed"],
+		]);
 	});
 
-	test("persists the emptied queue, so a reload cannot resurrect the old vault's ops", async () => {
-		// Without the persist the ops survive on disk and come back through load()
-		// on the next start, re-arming the exact collision the clear prevents.
+	test("an op for the CURRENT vault still sends (deletes must survive a same-vault reset)", async () => {
+		// A delete has no REST fallback: the tombstone lives only here. Dropping
+		// the whole outbox on any vault-state reset resurrected deleted notes.
 		const clock = fakeClock();
-		const { fn: send } = scriptedSend();
-		const persisted: CrdtOp[][] = [];
-		const q = new CrdtOpQueue({ send, now: clock.now, persistDelayMs: 0 });
-		q.setPersist((ops) => {
-			persisted.push(ops);
+		const { fn: send, calls } = scriptedSend();
+		const q = new CrdtOpQueue({
+			send,
+			now: clock.now,
+			currentVaultId: () => "vault-B",
 		});
 
-		q.enqueue(makeOp("doc-a", "create"));
-		q.clear();
+		q.enqueue(makeOp("doc-b", "delete", { vaultId: "vault-B" }));
+		await q.onJoined();
 
-		await new Promise((r) => setTimeout(r, 5));
-		expect(persisted.at(-1)).toEqual([]);
+		expect(calls.map((o) => o.docId)).toEqual(["doc-b"]);
 	});
 
-	test("is a no-op on an already-empty queue (no pointless write)", async () => {
+	test("an op persisted before vault stamping (no vaultId) still sends", async () => {
 		const clock = fakeClock();
-		const { fn: send } = scriptedSend();
-		const persisted: CrdtOp[][] = [];
-		const q = new CrdtOpQueue({ send, now: clock.now, persistDelayMs: 0 });
-		q.setPersist((ops) => {
-			persisted.push(ops);
+		const { fn: send, calls } = scriptedSend();
+		const q = new CrdtOpQueue({
+			send,
+			now: clock.now,
+			currentVaultId: () => "vault-B",
 		});
 
-		q.clear();
+		q.enqueue(makeOp("doc-legacy", "create"));
+		await q.onJoined();
 
-		await new Promise((r) => setTimeout(r, 5));
-		expect(persisted).toHaveLength(0);
+		expect(calls.map((o) => o.docId)).toEqual(["doc-legacy"]);
 	});
 });

--- a/tests/note-id-map-hygiene.test.ts
+++ b/tests/note-id-map-hygiene.test.ts
@@ -106,13 +106,16 @@ describe("vault change wipes note identity (plugin #200)", () => {
 	});
 
 	test("both vault-change routes also drop the outbound CRDT work", async () => {
-		// The note-id map was never the only carrier. A queued CrdtOp holds a bare
-		// docId with NO vault, and the unsent-doc set is the same shape, so both
-		// survive a switch and get delivered against the NEW vault's topic under
-		// ids the OLD vault owns. That is the client half of the cross-vault
-		// collision the server now re-mints around (engram #1318). Asserted on BOTH
-		// routes because wipePerVaultState exists precisely to keep them in
-		// lockstep -- a drop wired to only one re-opens the hazard on the other.
+		// The note-id map was never the only carrier: unsentDocIds holds the same
+		// per-vault note ids, and reEnrollUnsent would STEP1 them against the NEW
+		// vault's topic. Asserted on BOTH routes because wipePerVaultState exists
+		// precisely to keep them in lockstep -- a drop wired to only one re-opens
+		// the hazard on the other.
+		//
+		// The op QUEUE is NOT dropped here. Ops carry their own vaultId and
+		// self-drop at send time, which is both earlier (the topic rejoin flushes
+		// before this hook runs) and narrower (a queued delete for the CURRENT
+		// vault has no REST fallback and must survive).
 		for (const route of ["backstop", "picker"] as const) {
 			const engine = createEngine("vault-B");
 			const resetOutbox = mock();


### PR DESCRIPTION
## What

Review follow-up to #409. That PR was wrong in two ways that cancelled its own point, both found by a deep review after it merged. Nothing shipped (latest stable is v1.20.1), so this is a correction on main, not an incident.

## What #409 got wrong

**Too late.** `resetOutbox` hangs off `wipePerVaultState`, which runs at the head of `fullSync`/`pushAll`. The crdt: topic rejoin flushes the op queue **before** that. On the OAuth-relogin route the previous vault's queued creates were already delivered to the new vault by the time anything was cleared, so the cross-vault leak it existed to close **stayed open**.

**Too broad.** It discarded queued `crdt_delete`s. `handleDelete` has no REST fallback, so the tombstone lives *only* in that queue, and the same wipe clears `lastSync` -- the next catch-up pulled the still-live note back and **the deleted file came back**. My "safe because lastSync re-derives it" reasoning only ever held for creates, which disk can reproduce. A delete cannot be re-derived from a file that is gone.

The picker made it worse: `sync-preview-modal` lists the **active** vault too, so re-confirming the vault you are already on ran the entire wipe with no vault change at all.

## The fix

Ops now carry the `vaultId` they were minted against, and are dropped at **send** time when it no longer matches the vault being synced.

| | old (#409) | new |
|---|---|---|
| when | at sync start, after the rejoin already flushed | per op, at send |
| what | the whole queue | only ops whose vault no longer matches |
| queued delete, same vault | **discarded** -> note resurrects | delivered |
| trail | none | `onDrop(op, "vault-changed")` -> the existing warn line |

Dropping goes through the same `onDrop` path as `ttl` / `overflow` / `max-attempts`, so a discarded op leaves the warn-level trail #409's blanket clear left no trace of. Ops persisted before this field have no stamp and are delivered exactly as before.

`resetOutbox` now drops only `unsentDocIds`, and `applyVaultChange` returns early when the selected vault is the one already active.

## Tests

Written test-first (the foreign-vault case was red before the implementation).

- an op for another vault is dropped before send, with an `onDrop` trail
- an op for the **current** vault still sends (the delete-survival case)
- an op persisted before stamping (no `vaultId`) still sends
- both vault-change routes still drop `unsentDocIds`; a same-vault call does not

## Gates

`bun run build` ✓ · `bun test` 2446 pass / 0 fail ✓ · `biome ci` ✓ · `lint:obsidian` ✓ · `lint:css` ✓

## Not covered

The same-vault picker guard is in `main.ts` and has no unit-test seam. It is a two-line early return, but it is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC