### PR TITLE
fix(sync): report first-sync progress in file units

### DIFF
--- a/docs/context/sync-progress-units-files-not-ops.md
+++ b/docs/context/sync-progress-units-files-not-ops.md
@@ -1,0 +1,41 @@
+# Sync progress units: files, not op-log rows
+
+**Trigger:** the progress modal / recap shows a different number than the
+sync-options (preview) modal promised, a progress bar freezes at `0/N`
+during a pull, or "All synced" appears despite real failures.
+
+## The invariant
+
+Every user-facing sync number is in **file units** — the same unit
+`computeSyncPlan` / `optionBreakdown` count. The op-log replay applies
+**rows**, which is a different unit: tombstones, superseded rename rows, and
+folder-marker leaks are rows but not files. Any progress/recap number derived
+from `applied` (row count) will disagree with the plan on a vault with
+delete history. PR #412 fixed three instances of this class:
+
+- `runSeqReplayOnce` counts `files` (non-deleted rows applied without
+  throwing) and `failed` (rows whose apply threw) alongside `applied`, and
+  fires `onFileApplied(path)` per file. `applied` still exists for
+  logs/cursor semantics — do not surface it in UI.
+- The pull legs (`pullAll`, `fullSync` → `catchUp({reportProgress: true})`)
+  forward `onFileApplied` as `pulling {current, total: 0}` events. `total: 0`
+  is deliberate: the modal's `rowCounts` keeps the *plan's* denominator for a
+  planned row and treats 0 as indeterminate otherwise — never fabricate an
+  engine-side total here (the engine's examine-count is the original
+  "Uploading 5 → 50" balloon bug, see `rowCounts` in
+  `src/sync-progress-modal.ts`).
+- Completion events carry real `failed` tallies: `pushModifiedFiles` returns
+  `{pushed, failed}` (genesis-batch failures used to be dropped), and
+  `pullAll` adds wipe-delete failures.
+
+## Traps
+
+- **Background catch-ups stay silent.** The poll/reconnect callers of
+  `catchUp()` pass no `reportProgress` — they have no progress surface and
+  never emit a terminal `complete`, so events from them would strand the
+  settings-pane bar mid-flight. Keep progress opt-in.
+- **Test stubs of `catchupViaSeqReplay` must return the full shape**
+  (`applied, files, failed, serverIds, serverAttachmentPaths, ran,
+  complete`) — a stub missing `files`/`failed` makes `_pullAll` return
+  `undefined`/NaN counts.
+- The pinning tests live in `tests/sync-progress-firstsync.test.ts`.

--- a/main.js
+++ b/main.js
@@ -35,9 +35,9 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
 )), __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: !0 }), mod);
 var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key != "symbol" ? key + "" : key, value);
 
-// ../../node_modules/diff-match-patch/index.js
+// node_modules/diff-match-patch/index.js
 var require_diff_match_patch = __commonJS({
-  "../../node_modules/diff-match-patch/index.js"(exports, module2) {
+  "node_modules/diff-match-patch/index.js"(exports, module2) {
     var diff_match_patch5 = function() {
       this.Diff_Timeout = 1, this.Diff_EditCost = 4, this.Match_Threshold = 0.5, this.Match_Distance = 1e3, this.Patch_DeleteThreshold = 0.5, this.Patch_Margin = 4, this.Match_MaxBits = 32;
     }, DIFF_DELETE = -1, DIFF_INSERT = 1, DIFF_EQUAL = 0;
@@ -2388,7 +2388,7 @@ function textDiffToChangeSpec(before, after) {
 // src/crdt/live/live-binding-decisions.ts
 var import_diff_match_patch2 = __toESM(require_diff_match_patch(), 1);
 
-// ../../node_modules/yaml/browser/dist/nodes/identity.js
+// node_modules/yaml/browser/dist/nodes/identity.js
 var ALIAS = /* @__PURE__ */ Symbol.for("yaml.alias"), DOC = /* @__PURE__ */ Symbol.for("yaml.document"), MAP = /* @__PURE__ */ Symbol.for("yaml.map"), PAIR = /* @__PURE__ */ Symbol.for("yaml.pair"), SCALAR = /* @__PURE__ */ Symbol.for("yaml.scalar"), SEQ = /* @__PURE__ */ Symbol.for("yaml.seq"), NODE_TYPE = /* @__PURE__ */ Symbol.for("yaml.node.type"), isAlias = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === ALIAS, isDocument = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === DOC, isMap = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === MAP, isPair = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === PAIR, isScalar = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SCALAR, isSeq = (node) => !!node && typeof node == "object" && node[NODE_TYPE] === SEQ;
 function isCollection(node) {
   if (node && typeof node == "object")
@@ -2412,7 +2412,7 @@ function isNode(node) {
 }
 var hasAnchor = (node) => (isScalar(node) || isCollection(node)) && !!node.anchor;
 
-// ../../node_modules/yaml/browser/dist/visit.js
+// node_modules/yaml/browser/dist/visit.js
 var BREAK = /* @__PURE__ */ Symbol("break visit"), SKIP = /* @__PURE__ */ Symbol("skip children"), REMOVE = /* @__PURE__ */ Symbol("remove node");
 function visit(node, visitor) {
   let visitor_ = initVisitor(visitor);
@@ -2534,7 +2534,7 @@ function replaceNode(key, path, node) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/doc/directives.js
+// node_modules/yaml/browser/dist/doc/directives.js
 var escapeChars = {
   "!": "%21",
   ",": "%2C",
@@ -2652,7 +2652,7 @@ var escapeChars = {
 Directives.defaultYaml = { explicit: !1, version: "1.2" };
 Directives.defaultTags = { "!!": "tag:yaml.org,2002:" };
 
-// ../../node_modules/yaml/browser/dist/doc/anchors.js
+// node_modules/yaml/browser/dist/doc/anchors.js
 function anchorIsValid(anchor) {
   if (/[\x00-\x19\s,[\]{}]/.test(anchor)) {
     let msg = `Anchor must not contain whitespace or control characters: ${JSON.stringify(anchor)}`;
@@ -2703,7 +2703,7 @@ function createNodeAnchors(doc2, prefix) {
   };
 }
 
-// ../../node_modules/yaml/browser/dist/doc/applyReviver.js
+// node_modules/yaml/browser/dist/doc/applyReviver.js
 function applyReviver(reviver, obj, key, val) {
   if (val && typeof val == "object")
     if (Array.isArray(val))
@@ -2729,7 +2729,7 @@ function applyReviver(reviver, obj, key, val) {
   return reviver.call(obj, key, val);
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/toJS.js
+// node_modules/yaml/browser/dist/nodes/toJS.js
 function toJS(value, arg, ctx) {
   if (Array.isArray(value))
     return value.map((v, i) => toJS(v, String(i), ctx));
@@ -2746,7 +2746,7 @@ function toJS(value, arg, ctx) {
   return typeof value == "bigint" && !(ctx != null && ctx.keep) ? Number(value) : value;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Node.js
+// node_modules/yaml/browser/dist/nodes/Node.js
 var NodeBase = class {
   constructor(type) {
     Object.defineProperty(this, NODE_TYPE, { value: type });
@@ -2775,7 +2775,7 @@ var NodeBase = class {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/nodes/Alias.js
+// node_modules/yaml/browser/dist/nodes/Alias.js
 var Alias = class extends NodeBase {
   constructor(source) {
     super(ALIAS), this.source = source, Object.defineProperty(this, "tag", {
@@ -2855,7 +2855,7 @@ function getAliasCount(doc2, node, anchors) {
   return 1;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Scalar.js
+// node_modules/yaml/browser/dist/nodes/Scalar.js
 var isScalarValue = (value) => !value || typeof value != "function" && typeof value != "object", Scalar = class extends NodeBase {
   constructor(value) {
     super(SCALAR), this.value = value;
@@ -2873,7 +2873,7 @@ Scalar.PLAIN = "PLAIN";
 Scalar.QUOTE_DOUBLE = "QUOTE_DOUBLE";
 Scalar.QUOTE_SINGLE = "QUOTE_SINGLE";
 
-// ../../node_modules/yaml/browser/dist/doc/createNode.js
+// node_modules/yaml/browser/dist/doc/createNode.js
 var defaultTagPrefix = "tag:yaml.org,2002:";
 function findTagObject(value, tagName, tags) {
   var _a;
@@ -2917,7 +2917,7 @@ function createNode(value, tagName, ctx) {
   return tagName ? node.tag = tagName : tagObj.default || (node.tag = tagObj.tag), ref && (ref.node = node), node;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Collection.js
+// node_modules/yaml/browser/dist/nodes/Collection.js
 function collectionFromPath(schema4, path, value) {
   let v = value;
   for (let i = path.length - 1; i >= 0; --i) {
@@ -3034,7 +3034,7 @@ var isEmptyPath = (path) => path == null || typeof path == "object" && !!path[Sy
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyComment.js
+// node_modules/yaml/browser/dist/stringify/stringifyComment.js
 var stringifyComment = (str) => str.replace(/^(?!$)(?: $)?/gm, "#");
 function indentComment(comment, indent) {
   return /^\n+$/.test(comment) ? comment.substring(1) : indent ? comment.replace(/^(?! *$)/gm, indent) : comment;
@@ -3044,7 +3044,7 @@ var lineComment = (str, indent, comment) => str.endsWith(`
 `) ? `
 ` + indentComment(comment, indent) : (str.endsWith(" ") ? "" : " ") + comment;
 
-// ../../node_modules/yaml/browser/dist/stringify/foldFlowLines.js
+// node_modules/yaml/browser/dist/stringify/foldFlowLines.js
 var FOLD_FLOW = "flow", FOLD_BLOCK = "block", FOLD_QUOTED = "quoted";
 function foldFlowLines(text2, indent, mode = "flow", { indentAtStart, lineWidth = 80, minContentWidth = 20, onFold, onOverflow } = {}) {
   if (!lineWidth || lineWidth < 0)
@@ -3126,7 +3126,7 @@ function consumeMoreIndentedLines(text2, i, indent) {
   return end;
 }
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyString.js
+// node_modules/yaml/browser/dist/stringify/stringifyString.js
 var getFoldOptions = (ctx, isBlock2) => ({
   indentAtStart: isBlock2 ? ctx.indent.length : ctx.indentAtStart,
   lineWidth: ctx.options.lineWidth,
@@ -3338,7 +3338,7 @@ function stringifyString(item, ctx, onComment, onChompKeep) {
   return res;
 }
 
-// ../../node_modules/yaml/browser/dist/stringify/stringify.js
+// node_modules/yaml/browser/dist/stringify/stringify.js
 function createStringifyContext(doc2, options) {
   let opt = Object.assign({
     blockQuote: !0,
@@ -3436,7 +3436,7 @@ function stringify(item, ctx, onComment, onChompKeep) {
 ${ctx.indent}${str}` : str;
 }
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyPair.js
+// node_modules/yaml/browser/dist/stringify/stringifyPair.js
 function stringifyPair({ key, value }, ctx, onComment, onChompKeep) {
   var _a, _b;
   let { allNullValues, doc: doc2, indent, indentStep, options: { commentString, indentSeq, simpleKeys } } = ctx, keyComment = isNode(key) && key.comment || null;
@@ -3499,12 +3499,12 @@ ${ctx.indent}`);
   return str += ws + valueStr, ctx.inFlow ? valueCommentDone && onComment && onComment() : valueComment && !valueCommentDone ? str += lineComment(str, ctx.indent, commentString(valueComment)) : chompKeep && onChompKeep && onChompKeep(), str;
 }
 
-// ../../node_modules/yaml/browser/dist/log.js
+// node_modules/yaml/browser/dist/log.js
 function warn(logLevel, warning) {
   (logLevel === "debug" || logLevel === "warn") && console.warn(warning);
 }
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/merge.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/merge.js
 var MERGE_KEY = "<<", merge = {
   identify: (value) => value === MERGE_KEY || typeof value == "symbol" && value.description === MERGE_KEY,
   default: "key",
@@ -3544,7 +3544,7 @@ function resolveAliasValue(ctx, value) {
   return ctx && isAlias(value) ? value.resolve(ctx.doc, ctx) : value;
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/addPairToJSMap.js
+// node_modules/yaml/browser/dist/nodes/addPairToJSMap.js
 function addPairToJSMap(ctx, map3, { key, value }) {
   if (isNode(key) && key.addToJSMap)
     key.addToJSMap(ctx, map3, value);
@@ -3589,7 +3589,7 @@ function stringifyKey(key, jsKey, ctx) {
   return JSON.stringify(jsKey);
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/Pair.js
+// node_modules/yaml/browser/dist/nodes/Pair.js
 function createPair(key, value, ctx) {
   let k = createNode(key, void 0, ctx), v = createNode(value, void 0, ctx);
   return new Pair(k, v);
@@ -3611,7 +3611,7 @@ var Pair = class _Pair {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyCollection.js
+// node_modules/yaml/browser/dist/stringify/stringifyCollection.js
 function stringifyCollection(collection, ctx, options) {
   var _a;
   return (((_a = ctx.inFlow) != null ? _a : collection.flow) ? stringifyFlowCollection : stringifyBlockCollection)(collection, ctx, options);
@@ -3693,7 +3693,7 @@ function addCommentBefore({ indent, options: { commentString } }, lines, comment
   }
 }
 
-// ../../node_modules/yaml/browser/dist/nodes/YAMLMap.js
+// node_modules/yaml/browser/dist/nodes/YAMLMap.js
 function findPair(items, key) {
   let k = isScalar(key) ? key.value : key;
   for (let it of items)
@@ -3791,7 +3791,7 @@ var YAMLMap = class extends Collection {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/common/map.js
+// node_modules/yaml/browser/dist/schema/common/map.js
 var map = {
   collection: "map",
   default: !0,
@@ -3803,7 +3803,7 @@ var map = {
   createNode: (schema4, obj, ctx) => YAMLMap.from(schema4, obj, ctx)
 };
 
-// ../../node_modules/yaml/browser/dist/nodes/YAMLSeq.js
+// node_modules/yaml/browser/dist/nodes/YAMLSeq.js
 var YAMLSeq = class extends Collection {
   static get tagName() {
     return "tag:yaml.org,2002:seq";
@@ -3894,7 +3894,7 @@ function asItemIndex(key) {
   return idx && typeof idx == "string" && (idx = Number(idx)), typeof idx == "number" && Number.isInteger(idx) && idx >= 0 ? idx : null;
 }
 
-// ../../node_modules/yaml/browser/dist/schema/common/seq.js
+// node_modules/yaml/browser/dist/schema/common/seq.js
 var seq = {
   collection: "seq",
   default: !0,
@@ -3906,7 +3906,7 @@ var seq = {
   createNode: (schema4, obj, ctx) => YAMLSeq.from(schema4, obj, ctx)
 };
 
-// ../../node_modules/yaml/browser/dist/schema/common/string.js
+// node_modules/yaml/browser/dist/schema/common/string.js
 var string = {
   identify: (value) => typeof value == "string",
   default: !0,
@@ -3917,7 +3917,7 @@ var string = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/common/null.js
+// node_modules/yaml/browser/dist/schema/common/null.js
 var nullTag = {
   identify: (value) => value == null,
   createNode: () => new Scalar(null),
@@ -3928,7 +3928,7 @@ var nullTag = {
   stringify: ({ source }, ctx) => typeof source == "string" && nullTag.test.test(source) ? source : ctx.options.nullStr
 };
 
-// ../../node_modules/yaml/browser/dist/schema/core/bool.js
+// node_modules/yaml/browser/dist/schema/core/bool.js
 var boolTag = {
   identify: (value) => typeof value == "boolean",
   default: !0,
@@ -3945,7 +3945,7 @@ var boolTag = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyNumber.js
+// node_modules/yaml/browser/dist/stringify/stringifyNumber.js
 function stringifyNumber({ format, minFractionDigits, tag, value }) {
   if (typeof value == "bigint")
     return String(value);
@@ -3963,7 +3963,7 @@ function stringifyNumber({ format, minFractionDigits, tag, value }) {
   return n;
 }
 
-// ../../node_modules/yaml/browser/dist/schema/core/float.js
+// node_modules/yaml/browser/dist/schema/core/float.js
 var floatNaN = {
   identify: (value) => typeof value == "number",
   default: !0,
@@ -3994,7 +3994,7 @@ var floatNaN = {
   stringify: stringifyNumber
 };
 
-// ../../node_modules/yaml/browser/dist/schema/core/int.js
+// node_modules/yaml/browser/dist/schema/core/int.js
 var intIdentify = (value) => typeof value == "bigint" || Number.isInteger(value), intResolve = (str, offset, radix, { intAsBigInt }) => intAsBigInt ? BigInt(str) : parseInt(str.substring(offset), radix);
 function intStringify(node, radix, prefix) {
   let { value } = node;
@@ -4025,7 +4025,7 @@ var intOct = {
   stringify: (node) => intStringify(node, 16, "0x")
 };
 
-// ../../node_modules/yaml/browser/dist/schema/core/schema.js
+// node_modules/yaml/browser/dist/schema/core/schema.js
 var schema = [
   map,
   seq,
@@ -4040,7 +4040,7 @@ var schema = [
   float
 ];
 
-// ../../node_modules/yaml/browser/dist/schema/json/schema.js
+// node_modules/yaml/browser/dist/schema/json/schema.js
 function intIdentify2(value) {
   return typeof value == "bigint" || Number.isInteger(value);
 }
@@ -4094,7 +4094,7 @@ var stringifyJSON = ({ value }) => JSON.stringify(value), jsonScalars = [
   }
 }, schema2 = [map, seq].concat(jsonScalars, jsonError);
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/binary.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/binary.js
 var binary = {
   identify: (value) => value instanceof Uint8Array,
   // Buffer inherits from Uint8Array
@@ -4139,7 +4139,7 @@ var binary = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/pairs.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/pairs.js
 function resolvePairs(seq2, onError) {
   var _a;
   if (isSeq(seq2))
@@ -4197,7 +4197,7 @@ var pairs = {
   createNode: createPairs
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/omap.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/omap.js
 var YAMLOMap = class _YAMLOMap extends YAMLSeq {
   constructor() {
     super(), this.add = YAMLMap.prototype.add.bind(this), this.delete = YAMLMap.prototype.delete.bind(this), this.get = YAMLMap.prototype.get.bind(this), this.has = YAMLMap.prototype.has.bind(this), this.set = YAMLMap.prototype.set.bind(this), this.tag = _YAMLOMap.tag;
@@ -4240,7 +4240,7 @@ var omap = {
   createNode: (schema4, iterable, ctx) => YAMLOMap.from(schema4, iterable, ctx)
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/bool.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/bool.js
 function boolStringify({ value, source }, ctx) {
   return source && (value ? trueTag : falseTag).test.test(source) ? source : value ? ctx.options.trueStr : ctx.options.falseStr;
 }
@@ -4260,7 +4260,7 @@ var trueTag = {
   stringify: boolStringify
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/float.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/float.js
 var floatNaN2 = {
   identify: (value) => typeof value == "number",
   default: !0,
@@ -4295,7 +4295,7 @@ var floatNaN2 = {
   stringify: stringifyNumber
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/int.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/int.js
 var intIdentify3 = (value) => typeof value == "bigint" || Number.isInteger(value);
 function intResolve2(str, offset, radix, { intAsBigInt }) {
   let sign = str[0];
@@ -4358,7 +4358,7 @@ var intBin = {
   stringify: (node) => intStringify2(node, 16, "0x")
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/set.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/set.js
 var YAMLSet = class _YAMLSet extends YAMLMap {
   constructor(schema4) {
     super(schema4), this.tag = _YAMLSet.tag;
@@ -4418,7 +4418,7 @@ var set = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/timestamp.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/timestamp.js
 function parseSexagesimal(str, asBigInt) {
   let sign = str[0], parts = sign === "-" || sign === "+" ? str.substring(1) : str, num = (n) => asBigInt ? BigInt(n) : Number(n), res = parts.replace(/_/g, "").split(":").reduce((res2, p) => res2 * num(60) + num(p), num(0));
   return sign === "-" ? num(-1) * res : res;
@@ -4475,7 +4475,7 @@ var intTime = {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/schema/yaml-1.1/schema.js
+// node_modules/yaml/browser/dist/schema/yaml-1.1/schema.js
 var schema3 = [
   map,
   seq,
@@ -4500,7 +4500,7 @@ var schema3 = [
   timestamp
 ];
 
-// ../../node_modules/yaml/browser/dist/schema/tags.js
+// node_modules/yaml/browser/dist/schema/tags.js
 var schemas = /* @__PURE__ */ new Map([
   ["core", schema],
   ["failsafe", [map, seq, string]],
@@ -4560,7 +4560,7 @@ function getTags(customTags, schemaName, addMergeTag) {
   }, []);
 }
 
-// ../../node_modules/yaml/browser/dist/schema/Schema.js
+// node_modules/yaml/browser/dist/schema/Schema.js
 var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0, Schema = class _Schema {
   constructor({ compat, customTags, merge: merge2, resolveKnownTags, schema: schema4, sortMapEntries, toStringDefaults }) {
     this.compat = Array.isArray(compat) ? getTags(compat, "compat") : compat ? getTags(null, compat) : null, this.name = typeof schema4 == "string" && schema4 || "core", this.knownTags = resolveKnownTags ? coreKnownTags : {}, this.tags = getTags(customTags, this.name, merge2), this.toStringOptions = toStringDefaults != null ? toStringDefaults : null, Object.defineProperty(this, MAP, { value: map }), Object.defineProperty(this, SCALAR, { value: string }), Object.defineProperty(this, SEQ, { value: seq }), this.sortMapEntries = typeof sortMapEntries == "function" ? sortMapEntries : sortMapEntries === !0 ? sortMapEntriesByKey : null;
@@ -4571,7 +4571,7 @@ var sortMapEntriesByKey = (a, b) => a.key < b.key ? -1 : a.key > b.key ? 1 : 0, 
   }
 };
 
-// ../../node_modules/yaml/browser/dist/stringify/stringifyDocument.js
+// node_modules/yaml/browser/dist/stringify/stringifyDocument.js
 function stringifyDocument(doc2, options) {
   var _a;
   let lines = [], hasDirectives = options.directives === !0;
@@ -4615,7 +4615,7 @@ function stringifyDocument(doc2, options) {
 `;
 }
 
-// ../../node_modules/yaml/browser/dist/doc/Document.js
+// node_modules/yaml/browser/dist/doc/Document.js
 var Document = class _Document {
   constructor(value, replacer, options) {
     this.commentBefore = null, this.comment = null, this.errors = [], this.warnings = [], Object.defineProperty(this, NODE_TYPE, { value: DOC });
@@ -4832,7 +4832,7 @@ function assertCollection(contents) {
   throw new Error("Expected a YAML collection as document contents");
 }
 
-// ../../node_modules/yaml/browser/dist/errors.js
+// node_modules/yaml/browser/dist/errors.js
 var YAMLError = class extends Error {
   constructor(name, pos, code, message) {
     super(), this.name = name, this.code = code, this.message = message, this.pos = pos;
@@ -4873,7 +4873,7 @@ ${pointer}
   }
 };
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-props.js
+// node_modules/yaml/browser/dist/compose/resolve-props.js
 function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIndent, startOnNewline }) {
   let spaceBefore = !1, atNewline = startOnNewline, hasSpace = startOnNewline, comment = "", commentSep = "", hasNewline = !1, reqSpace = !1, tab = null, anchor = null, tag = null, newlineAfterProp = null, comma = null, found = null, start = null;
   for (let token of tokens)
@@ -4924,7 +4924,7 @@ function resolveProps(tokens, { flow, indicator, next, offset, onError, parentIn
   };
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-contains-newline.js
+// node_modules/yaml/browser/dist/compose/util-contains-newline.js
 function containsNewline(key) {
   if (!key)
     return null;
@@ -4961,7 +4961,7 @@ function containsNewline(key) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-flow-indent-check.js
+// node_modules/yaml/browser/dist/compose/util-flow-indent-check.js
 function flowIndentCheck(indent, fc, onError) {
   if ((fc == null ? void 0 : fc.type) === "flow-collection") {
     let end = fc.end[0];
@@ -4969,7 +4969,7 @@ function flowIndentCheck(indent, fc, onError) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-map-includes.js
+// node_modules/yaml/browser/dist/compose/util-map-includes.js
 function mapIncludes(ctx, items, search) {
   let { uniqueKeys } = ctx.options;
   if (uniqueKeys === !1)
@@ -4978,7 +4978,7 @@ function mapIncludes(ctx, items, search) {
   return items.some((pair) => isEqual(pair.key, search));
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-block-map.js
+// node_modules/yaml/browser/dist/compose/resolve-block-map.js
 var startColMsg = "All mapping items must start at the same column";
 function resolveBlockMap({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, bm, onError, tag) {
   var _a, _b;
@@ -5029,7 +5029,7 @@ function resolveBlockMap({ composeNode: composeNode2, composeEmptyNode: composeE
   return commentEnd && commentEnd < offset && onError(commentEnd, "IMPOSSIBLE", "Map comment with trailing content"), map3.range = [bm.offset, offset, commentEnd != null ? commentEnd : offset], map3;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-block-seq.js
+// node_modules/yaml/browser/dist/compose/resolve-block-seq.js
 function resolveBlockSeq({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, bs, onError, tag) {
   var _a;
   let NodeClass = (_a = tag == null ? void 0 : tag.nodeClass) != null ? _a : YAMLSeq, seq2 = new NodeClass(ctx.schema);
@@ -5057,7 +5057,7 @@ function resolveBlockSeq({ composeNode: composeNode2, composeEmptyNode: composeE
   return seq2.range = [bs.offset, offset, commentEnd != null ? commentEnd : offset], seq2;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-end.js
+// node_modules/yaml/browser/dist/compose/resolve-end.js
 function resolveEnd(end, offset, reqSpace, onError) {
   let comment = "";
   if (end) {
@@ -5086,7 +5086,7 @@ function resolveEnd(end, offset, reqSpace, onError) {
   return { comment, offset };
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-flow-collection.js
+// node_modules/yaml/browser/dist/compose/resolve-flow-collection.js
 var blockMsg = "Block collections are not allowed within flow collections", isBlock = (token) => token && (token.type === "block-map" || token.type === "block-seq");
 function resolveFlowCollection({ composeNode: composeNode2, composeEmptyNode: composeEmptyNode2 }, ctx, fc, onError, tag) {
   var _a, _b, _c;
@@ -5201,7 +5201,7 @@ function resolveFlowCollection({ composeNode: composeNode2, composeEmptyNode: co
   return coll;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-collection.js
+// node_modules/yaml/browser/dist/compose/compose-collection.js
 function resolveCollection(CN2, ctx, token, onError, tagName, tag) {
   let coll = token.type === "block-map" ? resolveBlockMap(CN2, ctx, token, onError, tag) : token.type === "block-seq" ? resolveBlockSeq(CN2, ctx, token, onError, tag) : resolveFlowCollection(CN2, ctx, token, onError, tag), Coll = coll.constructor;
   return tagName === "!" || tagName === Coll.tagName ? (coll.tag = Coll.tagName, coll) : (tagName && (coll.tag = tagName), coll);
@@ -5228,7 +5228,7 @@ function composeCollection(CN2, ctx, token, props, onError) {
   return node.range = coll.range, node.tag = tagName, tag != null && tag.format && (node.format = tag.format), node;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-block-scalar.js
+// node_modules/yaml/browser/dist/compose/resolve-block-scalar.js
 function resolveBlockScalar(ctx, scalar, onError) {
   let start = scalar.offset, header = parseBlockScalarHeader(scalar, ctx.options.strict, onError);
   if (!header)
@@ -5348,7 +5348,7 @@ function splitLines(source) {
   return lines;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/resolve-flow-scalar.js
+// node_modules/yaml/browser/dist/compose/resolve-flow-scalar.js
 function resolveFlowScalar(scalar, strict, onError) {
   let { offset, type, source, end } = scalar, _type, value, _onError = (rel, code, msg) => onError(offset + rel, code, msg);
   switch (type) {
@@ -5523,7 +5523,7 @@ function parseCharCode(source, offset, length2, onError) {
   }
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-scalar.js
+// node_modules/yaml/browser/dist/compose/compose-scalar.js
 function composeScalar(ctx, token, tagToken, onError) {
   let { value, type, comment, range } = token.type === "block-scalar" ? resolveBlockScalar(ctx, token, onError) : resolveFlowScalar(token, ctx.options.strict, onError), tagName = tagToken ? ctx.directives.tagName(tagToken.source, (msg) => onError(tagToken, "TAG_RESOLVE_FAILED", msg)) : null, tag;
   ctx.options.stringKeys && ctx.atKey ? tag = ctx.schema[SCALAR] : tagName ? tag = findScalarTagByName(ctx.schema, value, tagName, tagToken, onError) : token.type === "scalar" ? tag = findScalarTagByTest(ctx, value, token, onError) : tag = ctx.schema[SCALAR];
@@ -5573,7 +5573,7 @@ function findScalarTagByTest({ atKey, directives, schema: schema4 }, value, toke
   return tag;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/util-empty-scalar-position.js
+// node_modules/yaml/browser/dist/compose/util-empty-scalar-position.js
 function emptyScalarPosition(offset, before, pos) {
   if (before) {
     pos != null || (pos = before.length);
@@ -5594,7 +5594,7 @@ function emptyScalarPosition(offset, before, pos) {
   return offset;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-node.js
+// node_modules/yaml/browser/dist/compose/compose-node.js
 var CN = { composeNode, composeEmptyNode };
 function composeNode(ctx, token, props, onError) {
   let atKey = ctx.atKey, { spaceBefore, comment, anchor, tag } = props, node, isSrcToken = !0;
@@ -5641,7 +5641,7 @@ function composeAlias({ options }, { offset, source, end }, onError) {
   return alias.range = [offset, valueEnd, re.offset], re.comment && (alias.comment = re.comment), alias;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/compose-doc.js
+// node_modules/yaml/browser/dist/compose/compose-doc.js
 function composeDoc(options, directives, { offset, start, value, end }, onError) {
   let opts = Object.assign({ _directives: directives }, options), doc2 = new Document(void 0, opts), ctx = {
     atKey: !1,
@@ -5662,7 +5662,7 @@ function composeDoc(options, directives, { offset, start, value, end }, onError)
   return re.comment && (doc2.comment = re.comment), doc2.range = [offset, contentEnd, re.offset], doc2;
 }
 
-// ../../node_modules/yaml/browser/dist/compose/composer.js
+// node_modules/yaml/browser/dist/compose/composer.js
 function getErrorPos(src) {
   if (typeof src == "number")
     return [src, src + 1];
@@ -5815,7 +5815,7 @@ ${end.comment}` : end.comment;
   }
 };
 
-// ../../node_modules/yaml/browser/dist/parse/cst-visit.js
+// node_modules/yaml/browser/dist/parse/cst-visit.js
 var BREAK2 = /* @__PURE__ */ Symbol("break visit"), SKIP2 = /* @__PURE__ */ Symbol("skip children"), REMOVE2 = /* @__PURE__ */ Symbol("remove item");
 function visit2(cst, visitor) {
   "type" in cst && cst.type === "document" && (cst = { start: cst.start, value: cst.value }), _visit(Object.freeze([]), cst, visitor);
@@ -5863,7 +5863,7 @@ function _visit(path, item, visitor) {
   return typeof ctrl == "function" ? ctrl(item, path) : ctrl;
 }
 
-// ../../node_modules/yaml/browser/dist/parse/cst.js
+// node_modules/yaml/browser/dist/parse/cst.js
 var BOM = "\uFEFF", DOCUMENT = "", FLOW_END = "", SCALAR2 = "";
 function tokenType(source) {
   switch (source) {
@@ -5927,7 +5927,7 @@ function tokenType(source) {
   return null;
 }
 
-// ../../node_modules/yaml/browser/dist/parse/lexer.js
+// node_modules/yaml/browser/dist/parse/lexer.js
 function isEmpty(ch) {
   switch (ch) {
     case void 0:
@@ -6364,7 +6364,7 @@ var hexDigits = new Set("0123456789ABCDEFabcdef"), tagChars = new Set("012345678
   }
 };
 
-// ../../node_modules/yaml/browser/dist/parse/line-counter.js
+// node_modules/yaml/browser/dist/parse/line-counter.js
 var LineCounter = class {
   constructor() {
     this.lineStarts = [], this.addNewLine = (offset) => this.lineStarts.push(offset), this.linePos = (offset) => {
@@ -6383,7 +6383,7 @@ var LineCounter = class {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/parse/parser.js
+// node_modules/yaml/browser/dist/parse/parser.js
 function includesToken(list2, type) {
   for (let i = 0; i < list2.length; ++i)
     if (list2[i].type === type)
@@ -7040,7 +7040,7 @@ var Parser = class {
   }
 };
 
-// ../../node_modules/yaml/browser/dist/public-api.js
+// node_modules/yaml/browser/dist/public-api.js
 function parseOptions(options) {
   let prettyErrors = options.prettyErrors !== !1;
   return { lineCounter: options.lineCounter || prettyErrors && new LineCounter() || null, prettyErrors };
@@ -7990,7 +7990,7 @@ var list = (items, max2 = 5) => {
   }
 };
 
-// ../../node_modules/lib0/map.js
+// node_modules/lib0/map.js
 var create = () => /* @__PURE__ */ new Map(), copy = (m) => {
   let r = create();
   return m.forEach((v, k) => {
@@ -8011,10 +8011,10 @@ var create = () => /* @__PURE__ */ new Map(), copy = (m) => {
   return !1;
 };
 
-// ../../node_modules/lib0/set.js
+// node_modules/lib0/set.js
 var create2 = () => /* @__PURE__ */ new Set();
 
-// ../../node_modules/lib0/array.js
+// node_modules/lib0/array.js
 var last = (arr) => arr[arr.length - 1];
 var appendTo = (dest, src) => {
   for (let i = 0; i < src.length; i++)
@@ -8038,7 +8038,7 @@ var unfold = (len, f) => {
 };
 var isArray = Array.isArray;
 
-// ../../node_modules/lib0/observable.js
+// node_modules/lib0/observable.js
 var ObservableV2 = class {
   constructor() {
     this._observers = create();
@@ -8146,17 +8146,17 @@ var ObservableV2 = class {
   }
 };
 
-// ../../node_modules/lib0/math.js
+// node_modules/lib0/math.js
 var floor = Math.floor;
 var abs = Math.abs;
 var min = (a, b) => a < b ? a : b, max = (a, b) => a > b ? a : b, isNaN2 = Number.isNaN;
 var isNegativeZero = (n) => n !== 0 ? n < 0 : 1 / n < 0;
 
-// ../../node_modules/lib0/number.js
+// node_modules/lib0/number.js
 var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER, MIN_SAFE_INTEGER = Number.MIN_SAFE_INTEGER, LOWEST_INT32 = 1 << 31;
 var isInteger = Number.isInteger || ((num) => typeof num == "number" && isFinite(num) && floor(num) === num), isNaN3 = Number.isNaN, parseInt2 = Number.parseInt;
 
-// ../../node_modules/lib0/string.js
+// node_modules/lib0/string.js
 var fromCharCode = String.fromCharCode, fromCodePoint = String.fromCodePoint, MAX_UTF16_CHARACTER = fromCharCode(65535), toLowerCase = (s) => s.toLowerCase(), trimLeftRegex = /^\s*/g, trimLeft = (s) => s.replace(trimLeftRegex, ""), fromCamelCaseRegex = /([A-Z])/g, fromCamelCase = (s, separator) => trimLeft(s.replace(fromCamelCaseRegex, (match2) => `${separator}${toLowerCase(match2)}`));
 var _encodeUtf8Polyfill = (str) => {
   let encodedString = unescape(encodeURIComponent(str)), len = encodedString.length, buf = new Uint8Array(len);
@@ -8172,7 +8172,7 @@ var utf8TextDecoder = typeof TextDecoder == "undefined" ? null : new TextDecoder
 utf8TextDecoder && utf8TextDecoder.decode(new Uint8Array()).length === 1 && (utf8TextDecoder = null);
 var repeat = (source, n) => unfold(n, () => source).join("");
 
-// ../../node_modules/lib0/encoding.js
+// node_modules/lib0/encoding.js
 var Encoder = class {
   constructor() {
     this.cpos = 0, this.cbuf = new Uint8Array(100), this.bufs = [];
@@ -8349,14 +8349,14 @@ var flushIntDiffOptRleEncoder = (encoder) => {
   }
 };
 
-// ../../node_modules/lib0/error.js
+// node_modules/lib0/error.js
 var create3 = (s) => new Error(s), methodUnimplemented = () => {
   throw create3("Method unimplemented");
 }, unexpectedCase = () => {
   throw create3("Unexpected case");
 };
 
-// ../../node_modules/lib0/decoding.js
+// node_modules/lib0/decoding.js
 var errorUnexpectedEndOfArray = create3("Unexpected end of array"), errorIntegerOutOfRange = create3("Integer out of Range"), Decoder = class {
   /**
    * @param {Uint8Array<Buf>} uint8Array Binary data to decode
@@ -8523,10 +8523,10 @@ var IntDiffOptRleDecoder = class extends Decoder {
   }
 };
 
-// ../../node_modules/lib0/webcrypto.js
+// node_modules/lib0/webcrypto.js
 var subtle = crypto.subtle, getRandomValues = crypto.getRandomValues.bind(crypto);
 
-// ../../node_modules/lib0/random.js
+// node_modules/lib0/random.js
 var uint32 = () => getRandomValues(new Uint32Array(1))[0];
 var uuidv4Template = "10000000-1000-4000-8000" + -1e11, uuidv4 = () => uuidv4Template.replace(
   /[018]/g,
@@ -8534,20 +8534,20 @@ var uuidv4Template = "10000000-1000-4000-8000" + -1e11, uuidv4 = () => uuidv4Tem
   (c) => (c ^ uint32() & 15 >> c / 4).toString(16)
 );
 
-// ../../node_modules/lib0/time.js
+// node_modules/lib0/time.js
 var getUnixTime = Date.now;
 
-// ../../node_modules/lib0/promise.js
+// node_modules/lib0/promise.js
 var create4 = (f) => (
   /** @type {Promise<T>} */
   new Promise(f)
 );
 var all = Promise.all.bind(Promise);
 
-// ../../node_modules/lib0/conditions.js
+// node_modules/lib0/conditions.js
 var undefinedToNull = (v) => v === void 0 ? null : v;
 
-// ../../node_modules/lib0/storage.js
+// node_modules/lib0/storage.js
 var VarStoragePolyfill = class {
   constructor() {
     this.map = /* @__PURE__ */ new Map();
@@ -8572,13 +8572,13 @@ try {
 }
 var varStorage = _localStorage;
 
-// ../../node_modules/lib0/trait/equality.js
+// node_modules/lib0/trait/equality.js
 var EqualityTraitSymbol = /* @__PURE__ */ Symbol("Equality"), equals = (a, b) => {
   var _a;
   return a === b || !!((_a = a == null ? void 0 : a[EqualityTraitSymbol]) != null && _a.call(a, b)) || !1;
 };
 
-// ../../node_modules/lib0/object.js
+// node_modules/lib0/object.js
 var isObject = (o) => typeof o == "object", assign = Object.assign, keys = Object.keys;
 var forEach = (obj, f) => {
   for (let key in obj)
@@ -8602,7 +8602,7 @@ var isEmpty2 = (obj) => {
   return freeze(o);
 };
 
-// ../../node_modules/lib0/function.js
+// node_modules/lib0/function.js
 var callAll = (fs, args2, i = 0) => {
   try {
     for (; i < fs.length; i++)
@@ -8668,7 +8668,7 @@ var equalityDeep = (a, b) => {
   return !0;
 }, isOneOf = (value, options) => options.includes(value);
 
-// ../../node_modules/lib0/environment.js
+// node_modules/lib0/environment.js
 var isNode2 = typeof process != "undefined" && process.release && /node|io\.js/.test(process.release.name) && Object.prototype.toString.call(typeof process != "undefined" ? process : 0) === "[object process]";
 var isMac = typeof navigator != "undefined" ? /Mac/.test(navigator.platform) : !1, params, args = [], computeParams = () => {
   if (params === void 0)
@@ -8692,14 +8692,14 @@ var getVariable = (name) => isNode2 ? undefinedToNull(process.env[name.toUpperCa
 var hasConf = (name) => hasParam("--" + name) || getVariable(name) !== null, production = hasConf("production"), forceColor = isNode2 && isOneOf(process.env.FORCE_COLOR, ["true", "1", "2"]), supportsColor = forceColor || !hasParam("--no-colors") && // @todo deprecate --no-colors
 !hasConf("no-color") && (!isNode2 || process.stdout.isTTY) && (!isNode2 || hasParam("--color") || getVariable("COLORTERM") !== null || (getVariable("TERM") || "").includes("color"));
 
-// ../../node_modules/lib0/buffer.js
+// node_modules/lib0/buffer.js
 var createUint8ArrayFromLen = (len) => new Uint8Array(len);
 var copyUint8Array = (uint8Array) => {
   let newBuf = createUint8ArrayFromLen(uint8Array.byteLength);
   return newBuf.set(uint8Array), newBuf;
 };
 
-// ../../node_modules/lib0/pair.js
+// node_modules/lib0/pair.js
 var Pair2 = class {
   /**
    * @param {L} left
@@ -8710,7 +8710,7 @@ var Pair2 = class {
   }
 }, create5 = (left, right) => new Pair2(left, right);
 
-// ../../node_modules/lib0/prng.js
+// node_modules/lib0/prng.js
 var bool = (gen) => gen.next() >= 0.5, int53 = (gen, min2, max2) => floor(gen.next() * (max2 + 1 - min2) + min2);
 var int32 = (gen, min2, max2) => floor(gen.next() * (max2 + 1 - min2) + min2);
 var int31 = (gen, min2, max2) => int32(gen, min2, max2);
@@ -8722,7 +8722,7 @@ var letter = (gen) => fromCharCode(int31(gen, 97, 122)), word = (gen, minLen = 0
 };
 var oneOf = (gen, array) => array[int31(gen, 0, array.length - 1)];
 
-// ../../node_modules/lib0/schema.js
+// node_modules/lib0/schema.js
 var schemaSymbol = /* @__PURE__ */ Symbol("0schema"), ValidationError = class {
   constructor() {
     this._rerrs = [];
@@ -9316,7 +9316,7 @@ ${err.toString()}`);
   _random($(schema4), gen)
 );
 
-// ../../node_modules/lib0/dom.js
+// node_modules/lib0/dom.js
 var doc = (
   /** @type {Document} */
   typeof document != "undefined" ? document : {}
@@ -9331,10 +9331,10 @@ var $text = $custom((el) => el.nodeType === TEXT_NODE);
 var mapToStyleString = (m) => map2(m, (value, key) => `${key}:${value};`).join("");
 var ELEMENT_NODE = doc.ELEMENT_NODE, TEXT_NODE = doc.TEXT_NODE, CDATA_SECTION_NODE = doc.CDATA_SECTION_NODE, COMMENT_NODE = doc.COMMENT_NODE, DOCUMENT_NODE = doc.DOCUMENT_NODE, DOCUMENT_TYPE_NODE = doc.DOCUMENT_TYPE_NODE, DOCUMENT_FRAGMENT_NODE = doc.DOCUMENT_FRAGMENT_NODE, $node = $custom((el) => el.nodeType === DOCUMENT_NODE);
 
-// ../../node_modules/lib0/symbol.js
+// node_modules/lib0/symbol.js
 var create6 = Symbol;
 
-// ../../node_modules/lib0/logging.common.js
+// node_modules/lib0/logging.common.js
 var BOLD = create6(), UNBOLD = create6(), BLUE = create6(), GREY = create6(), GREEN = create6(), RED = create6(), PURPLE = create6(), ORANGE = create6(), UNCOLOR = create6(), computeNoColorLoggingArgs = (args2) => {
   var _a;
   args2.length === 1 && ((_a = args2[0]) == null ? void 0 : _a.constructor) === Function && (args2 = /** @type {Array<string|Symbol|Object|number>} */
@@ -9358,7 +9358,7 @@ var BOLD = create6(), UNBOLD = create6(), BLUE = create6(), GREY = create6(), GR
 };
 var lastLoggingTime = getUnixTime();
 
-// ../../node_modules/lib0/logging.js
+// node_modules/lib0/logging.js
 var _browserStyleMap = {
   [BOLD]: create5("font-weight", "bold"),
   [UNBOLD]: create5("font-weight", "normal"),
@@ -9402,7 +9402,7 @@ var _browserStyleMap = {
 };
 var vconsoles = create2();
 
-// ../../node_modules/lib0/iterator.js
+// node_modules/lib0/iterator.js
 var createIterator = (next) => ({
   /**
    * @return {IterableIterator<T>}
@@ -9423,7 +9423,7 @@ var createIterator = (next) => ({
   return { done, value: done ? void 0 : fmap(value) };
 });
 
-// ../../node_modules/yjs/dist/yjs.mjs
+// node_modules/yjs/dist/yjs.mjs
 var DeleteItem = class {
   /**
    * @param {number} clock
@@ -14228,7 +14228,7 @@ var Item = class _Item extends AbstractStruct {
 glo[importIdentifier] === !0 && console.error("Yjs was already imported. This breaks constructor checks and will lead to issues! - https://github.com/yjs/yjs/issues/438");
 glo[importIdentifier] = !0;
 
-// ../../node_modules/lib0/indexeddb.js
+// node_modules/lib0/indexeddb.js
 var rtop = (request) => create4((resolve, reject) => {
   request.onerror = (event) => reject(new Error(event.target.error)), request.onsuccess = (event) => resolve(event.target.result);
 }), openDB = (name, initDB) => create4((resolve, reject) => {
@@ -14264,7 +14264,7 @@ var iterateOnRequest = (request, f) => create4((resolve, reject) => {
 var iterateKeys = (store, keyrange, f, direction = "next") => iterateOnRequest(store.openKeyCursor(keyrange, direction), (cursor) => f(cursor.key)), getStore = (t, store) => t.objectStore(store);
 var createIDBKeyRangeUpperBound = (upper, upperOpen) => IDBKeyRange.upperBound(upper, upperOpen), createIDBKeyRangeLowerBound = (lower, lowerOpen) => IDBKeyRange.lowerBound(lower, lowerOpen);
 
-// ../../node_modules/y-indexeddb/src/y-indexeddb.js
+// node_modules/y-indexeddb/src/y-indexeddb.js
 var customStoreName = "custom", updatesStoreName = "updates", PREFERRED_TRIM_SIZE = 500, fetchUpdates = (idbPersistence, beforeApplyUpdatesCallback = () => {
 }, afterApplyUpdatesCallback = () => {
 }) => {
@@ -14507,7 +14507,7 @@ function mergeDiskOntoDoc(base, disk, current) {
   return { text: merged, clean: applied.every(Boolean) };
 }
 
-// ../../node_modules/y-protocols/sync.js
+// node_modules/y-protocols/sync.js
 var messageYjsSyncStep1 = 0, messageYjsSyncStep2 = 1, messageYjsUpdate = 2, writeSyncStep1 = (encoder, doc2) => {
   writeVarUint(encoder, messageYjsSyncStep1);
   let sv = encodeStateVector(doc2);
@@ -21137,9 +21137,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     var _a, _b, _c;
     let serverIds = /* @__PURE__ */ new Set(), serverAttachmentPaths = /* @__PURE__ */ new Set();
     if (this.seqReplayRunning)
-      return this.seqReplayAgain = !0, { applied: 0, serverIds, serverAttachmentPaths, ran: !1, complete: !1 };
+      return this.seqReplayAgain = !0, {
+        applied: 0,
+        files: 0,
+        failed: 0,
+        serverIds,
+        serverAttachmentPaths,
+        ran: !1,
+        complete: !1
+      };
     this.seqReplayRunning = !0;
-    let applied = 0, complete = !0;
+    let applied = 0, files = 0, failed = 0, complete = !0;
     try {
       do {
         this.seqReplayAgain = !1;
@@ -21147,14 +21155,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           ((_a = opts.fromZero) != null ? _a : !1) || ((_b = opts.enumerateOnly) != null ? _b : !1),
           serverIds,
           serverAttachmentPaths,
-          (_c = opts.enumerateOnly) != null ? _c : !1
+          (_c = opts.enumerateOnly) != null ? _c : !1,
+          opts.onFileApplied
         );
-        applied += pass.applied, pass.complete || (complete = !1);
+        applied += pass.applied, files += pass.files, failed += pass.failed, pass.complete || (complete = !1);
       } while (this.seqReplayAgain);
     } finally {
       this.seqReplayRunning = !1;
     }
-    return { applied, serverIds, serverAttachmentPaths, ran: !0, complete };
+    return { applied, files, failed, serverIds, serverAttachmentPaths, ran: !0, complete };
   }
   /** Run `catchupViaSeqReplay` for a DESTRUCTIVE delete decision (pull-all wipe,
    *  push-all replace-remote). Retries until THIS call executes the replay
@@ -21196,23 +21205,34 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *      onto one `catchupSeq` removed it, so this restores that guarantee.
    *   4. `syncExplicitFolders` — pull the server's empty-folder markers to disk
    *      and propagate remote folder deletes.
-   *  Returns the applied-op count (for the progress recap / poll notice). Never
+   *  Returns the downloaded FILE count (non-deleted rows applied — the unit the
+   *  sync plan and recap use) plus the count of rows whose apply threw. Never
    *  throws — mirrors the old pull() error boundary so a caller (fullSync/poll)
    *  never has to guard it. The manifest is fetched once and shared by the
    *  validator plus steps 1
    *  and 3. */
-  async catchUp() {
+  async catchUp(opts = {}) {
+    let pulledFiles = 0, onFileApplied = opts.reportProgress ? (path) => {
+      var _a;
+      (_a = this.onSyncProgress) == null || _a.call(this, {
+        phase: "pulling",
+        current: ++pulledFiles,
+        total: 0,
+        failed: 0,
+        currentPath: path
+      });
+    } : void 0;
     try {
       let authGenAtFetch = this.authGeneration, manifest = await this.api.getManifest(
         this.manifestSeq > 0 ? this.manifestSeq : void 0
       );
       if (manifest != null && manifest.unchanged) {
         await this.seedEmptyFolders();
-        let { applied: applied2 } = await this.catchupViaSeqReplay();
-        return applied2;
+        let { files: files2, failed: failed2 } = await this.catchupViaSeqReplay({ onFileApplied });
+        return { files: files2, failed: failed2 };
       }
       await this.reconcileFromManifest(manifest, authGenAtFetch);
-      let behind = this.validateFromManifest(manifest), { applied } = await this.catchupViaSeqReplay(), poked = await this.healDivergedLiveBoundNotes(manifest);
+      let behind = this.validateFromManifest(manifest), { files, failed } = await this.catchupViaSeqReplay({ onFileApplied }), poked = await this.healDivergedLiveBoundNotes(manifest);
       try {
         await this.syncExplicitFolders();
       } catch (e) {
@@ -21222,25 +21242,26 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           e instanceof Error ? e.stack : void 0
         );
       }
-      return typeof (manifest == null ? void 0 : manifest.change_seq) == "number" && behind === 0 && poked === 0 && (this.setManifestSeq(manifest.change_seq), await this.saveData({ manifestSeq: this.manifestSeq })), applied;
+      return typeof (manifest == null ? void 0 : manifest.change_seq) == "number" && behind === 0 && poked === 0 && (this.setManifestSeq(manifest.change_seq), await this.saveData({ manifestSeq: this.manifestSeq })), { files, failed };
     } catch (e) {
       return rlog().error(
         "pull",
         `Catch-up failed: ${errMsg(e)}`,
         e instanceof Error ? e.stack : void 0
-      ), 0;
+      ), { files: 0, failed: 0 };
     }
   }
-  async runSeqReplayOnce(fromZero, serverIds, serverAttachmentPaths, enumerateOnly = !1) {
+  async runSeqReplayOnce(fromZero, serverIds, serverAttachmentPaths, enumerateOnly = !1, onFileApplied) {
     var _a;
-    if (!this.crdtCatchupSince || !this.crdt) return { applied: 0, complete: !1 };
+    if (!this.crdtCatchupSince || !this.crdt)
+      return { applied: 0, files: 0, failed: 0, complete: !1 };
     let activeVault = (_a = this.settings.vaultId) != null ? _a : null, resumable = !fromZero && this.syncStateVaultId === activeVault, cursor = resumable ? this.getCatchupSeq() : 0, cursorId = resumable ? this.getCatchupId() : null;
     if (this.seqRewindFloor !== null && !fromZero) {
       let floored = Math.min(cursor, this.seqRewindFloor);
       floored !== cursor && (cursorId = null), cursor = floored;
     }
     this.seqRewindFloor = null;
-    let applied = 0;
+    let applied = 0, files = 0, failed = 0;
     try {
       await this.walkOpLog({
         seq: cursor,
@@ -21248,9 +21269,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         onRow: async (c) => {
           if (!enumerateOnly)
             try {
-              await this.applySyncChange(c), applied += 1;
+              await this.applySyncChange(c), applied += 1, c.deleted || (files += 1, onFileApplied == null || onFileApplied(c.path));
             } catch (e) {
-              rlog().error("crdt", `seq-replay: skipped ${c.path} \u2014 ${errMsg(e)}`);
+              failed += 1, rlog().error("crdt", `seq-replay: skipped ${c.path} \u2014 ${errMsg(e)}`);
             }
           c.type === "attachment" ? c.deleted || serverAttachmentPaths.add(c.path) : c.id && !c.deleted && serverIds.add(c.id);
         },
@@ -21263,9 +21284,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       });
     } catch (e) {
       if (!(e instanceof OpLogFetchError)) throw e;
-      return rlog().warn("crdt", `seq-replay: ${e.message}`), { applied, complete: !1 };
+      return rlog().warn("crdt", `seq-replay: ${e.message}`), { applied, files, failed, complete: !1 };
     }
-    return { applied, complete: !0 };
+    return { applied, files, failed, complete: !0 };
   }
   /** Per-note discovery from a room-open announce that carries a path
    *  (`crdt_doc_ready`, backend adds `path`). An EMPTY note's genesis integrates
@@ -21562,9 +21583,21 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     devLog().log("pull", `${label}: replaying note op-log from 0`), rlog().info("pull", `${label} started \u2014 replay from 0`);
     try {
       (_b = this.onSyncProgress) == null || _b.call(this, { phase: "pulling", current: 0, total: 0, failed: 0 });
-      let applied, serverIds, serverAttachmentPaths;
+      let pulledFiles = 0, onFileApplied = (path) => {
+        var _a2;
+        (_a2 = this.onSyncProgress) == null || _a2.call(this, {
+          phase: "pulling",
+          current: ++pulledFiles,
+          total: 0,
+          failed: 0,
+          currentPath: path
+        });
+      }, applied, pulledFileCount, replayFailed, serverIds, serverAttachmentPaths;
       if (wipe) {
-        let replay = await this.catchupViaSeqReplayExclusive({ fromZero: !0 });
+        let replay = await this.catchupViaSeqReplayExclusive({
+          fromZero: !0,
+          onFileApplied
+        });
         if (!replay)
           return this.lastError = "Pull all (delete extras) aborted: could not obtain an exclusive server snapshot (replay contention). Nothing was trashed.", devLog().log(
             "error",
@@ -21573,22 +21606,33 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             "pull",
             `${label} ABORTED \u2014 replay never ran exclusively (persistent contention); refusing to trash on an untrustworthy (possibly empty) server set`
           ), 0;
-        ({ applied, serverIds, serverAttachmentPaths } = replay);
+        ({
+          applied,
+          files: pulledFileCount,
+          failed: replayFailed,
+          serverIds,
+          serverAttachmentPaths
+        } = replay);
       } else
-        ({ applied, serverIds, serverAttachmentPaths } = await this.catchupViaSeqReplay({
-          fromZero: !0
-        }));
-      if (devLog().log(
+        ({
+          applied,
+          files: pulledFileCount,
+          failed: replayFailed,
+          serverIds,
+          serverAttachmentPaths
+        } = await this.catchupViaSeqReplay({ fromZero: !0, onFileApplied }));
+      devLog().log(
         "pull",
         `${label}: replay applied=${applied}, serverIds=${serverIds.size}, serverAttachmentPaths=${serverAttachmentPaths.size}`
-      ), rlog().info("pull", `${label} replay done \u2014 applied=${applied}`), wipe) {
+      ), rlog().info("pull", `${label} replay done \u2014 applied=${applied}`);
+      let deleteFailed = 0;
+      if (wipe) {
         this.suppressDeletes = !0;
         let extras = this.app.vault.getFiles().filter((f) => {
           var _a2, _b2;
           return !this.isSyncable(f) || this.shouldIgnore(f.path) ? !1 : this.isBinaryFile(f) ? !serverAttachmentPaths.has(f.path) : !serverIds.has((_b2 = (_a2 = this.noteIdMap) == null ? void 0 : _a2.get(f.path)) != null ? _b2 : "");
         }), total = extras.length;
         (_c = this.onSyncProgress) == null || _c.call(this, { phase: "deleting", current: 0, total, failed: 0 });
-        let deleteFailed = 0;
         for (let i = 0; i < extras.length; i++) {
           let file = extras[i];
           try {
@@ -21616,10 +21660,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       }
       return (_e = this.onSyncProgress) == null || _e.call(this, {
         phase: "complete",
-        current: applied,
-        total: applied,
-        failed: 0
-      }), devLog().log("pull", `${label}: done \u2014 applied=${applied}`), rlog().info("pull", `${label} done \u2014 applied=${applied}`), applied;
+        current: pulledFileCount,
+        total: pulledFileCount,
+        failed: replayFailed + deleteFailed
+      }), devLog().log(
+        "pull",
+        `${label}: done \u2014 files=${pulledFileCount} (ops applied=${applied})`
+      ), rlog().info("pull", `${label} done \u2014 files=${pulledFileCount} (ops=${applied})`), pulledFileCount;
     } catch (e) {
       return console.error("Engram Sync: pullAll failed", e), devLog().log("error", `pullAll failed: ${errMsg(e)}`), rlog().error(
         "pull",
@@ -22386,12 +22433,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     if (!ok)
       throw this.lastError = error != null ? error : "Connection failed", this.emitStatus(), devLog().log("error", `fullSync auth failed: ${this.lastError}`), rlog().error("lifecycle", `Auth failed: ${this.lastError}`), new Error(this.lastError);
     await this.invalidateIfVaultChanged();
-    let prePullSync = this.lastSync, pulled = await this.catchUp(), pushed = await this.pushModifiedFiles(prePullSync), synced = pulled + pushed;
+    let prePullSync = this.lastSync, pull = await this.catchUp({ reportProgress: !0 }), pulled = pull.files, push = await this.pushModifiedFiles(prePullSync), pushed = push.pushed, synced = pulled + pushed;
     return (_a = this.onSyncProgress) == null || _a.call(this, {
       phase: "complete",
       current: synced,
       total: synced,
-      failed: 0,
+      failed: pull.failed + push.failed,
       skipped: this.lastBatchSkipped
     }), pushed > 0 && await this.saveData({ lastSync: this.lastSync }), devLog().log("lifecycle", `fullSync done \u2014 pulled=${pulled} pushed=${pushed}`), rlog().info("lifecycle", `FullSync done \u2014 pulled=${pulled} pushed=${pushed}`), { pulled, pushed };
   }
@@ -22664,7 +22711,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let total = toSync.length;
     total > 0 && this.emitPushing(0, total, 0);
     let outcome = await this.pushPartitioned(toSync, "incremental");
-    return pushed += outcome.pushed, this.flushAttachmentLimitedToast(), this.flushFailureSummaryToast(), pushed;
+    return pushed += outcome.pushed, this.flushAttachmentLimitedToast(), this.flushFailureSummaryToast(), { pushed, failed: outcome.failed };
   }
   /** Compute what a sync would do without executing it (dry-run preview).
    *
@@ -23803,7 +23850,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         if (gateOpen)
           try {
             (_c2 = this.noteStream) != null && _c2.isCrdtConnected() && await this.syncEngine.catchupViaSeqReplay();
-            let pushed = await this.syncEngine.pushModifiedFiles();
+            let { pushed } = await this.syncEngine.pushModifiedFiles();
             pushed > 0 && new import_obsidian26.Notice(`Engram Sync: pushed ${pushed}`);
           } catch (e) {
             this.handleSyncError("Startup sync", e);
@@ -24567,7 +24614,7 @@ Last sync: ${date.toLocaleString()}`;
     this.syncInterval && (window.clearInterval(this.syncInterval), this.syncInterval = null), this.hasAuthConfigured() && (this.syncInterval = window.setInterval(() => {
       (async () => {
         try {
-          let pulled = await this.syncEngine.catchUp();
+          let { files: pulled } = await this.syncEngine.catchUp();
           pulled > 0 && new import_obsidian26.Notice(`Engram Sync: pulled ${pulled} changes`);
         } catch (e) {
           console.error("Engram Sync: periodic catch-up failed", e);

--- a/main.js
+++ b/main.js
@@ -1707,7 +1707,11 @@ function expBackoff(baseMs, attempt, capMs) {
 }
 
 // src/channel.ts
-var NO_AUTH_RECONNECT_MS = 3e4, AUTH_FAIL_WINDOW_MS = 5e3, RESUME_PROBE_MS = 5e3, RECONNECT_JITTER_DEFAULT_MS = 5e3, RECONNECT_JITTER_MAX_MS = 6e4, RATE_LIMITED_JOIN_FLOOR_MS = 1e4;
+var NO_AUTH_RECONNECT_MS = 3e4, AUTH_FAIL_WINDOW_MS = 5e3, RESUME_PROBE_MS = 5e3;
+function batchCreateTimeoutMs(count2) {
+  return 1e4 + 400 * count2;
+}
+var RECONNECT_JITTER_DEFAULT_MS = 5e3, RECONNECT_JITTER_MAX_MS = 6e4, RATE_LIMITED_JOIN_FLOOR_MS = 1e4;
 function connectRetryDelayMs(attempt, baseMs = 2e3) {
   return expBackoff(baseMs, attempt, RECONNECT_JITTER_MAX_MS);
 }
@@ -1968,9 +1972,14 @@ var _NoteChannel = class _NoteChannel {
     return (await this.sendRequest("crdt_create", { doc_id: docId, path })).doc_id;
   }
   /** Batch create: mirrors crdtCreate but takes a list (server caps it at 100
-   *  creates per request; chunking is the caller's concern). */
+   *  creates per request; chunking is the caller's concern). The deadline
+   *  scales with the chunk — see batchCreateTimeoutMs. */
   async crdtCreateBatch(creates) {
-    return await this.sendRequest("crdt_create_batch", { creates });
+    return await this.sendRequest(
+      "crdt_create_batch",
+      { creates },
+      batchCreateTimeoutMs(creates.length)
+    );
   }
   /** Delete a note over the socket, AWAITING the server ack (idempotent). The
    *  backend replies `{:ok, %{doc_id}}` even when the note is already gone, so a
@@ -22529,7 +22538,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   async pushGenesisBatch(files, onProgress) {
     var _a, _b, _c, _d;
     if (!this.crdtCreateBatch || !this.crdt) return { pushed: 0, failed: 0 };
-    let MAX_CREATES = 100, PAYLOAD_BUDGET = 6e6, pushed = 0, failed = 0, chunk = [], chunkBytes = 0, flush = async () => {
+    let MAX_CREATES = 25, PAYLOAD_BUDGET = 6e6, pushed = 0, failed = 0, chunk = [], chunkBytes = 0, flush = async () => {
       var _a2;
       if (chunk.length === 0) return;
       let sent = chunk;
@@ -22537,9 +22546,30 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       for (let e of sent) this.pushing.add(e.pushedPath);
       let recentlyDeletedPaths = /* @__PURE__ */ new Set();
       try {
-        let { results } = await this.crdtCreateBatch(
-          sent.map((e) => ({ doc_id: e.noteId, path: e.pushedPath, b64: e.b64 }))
-        );
+        let results;
+        try {
+          ({ results } = await this.crdtCreateBatch(
+            sent.map((e) => ({ doc_id: e.noteId, path: e.pushedPath, b64: e.b64 }))
+          ));
+        } catch (err) {
+          let msg = errMsg(err);
+          rlog().error(
+            "push",
+            `crdt_create_batch chunk failed (${sent.length} notes): ${msg}`
+          );
+          for (let e of sent)
+            failed++, this.logEntry("push", e.file.path, "error", msg), this.issues.record({
+              path: e.file.path,
+              kind: "note",
+              category: "other",
+              message: msg,
+              firstFailedAt: Date.now(),
+              lastFailedAt: Date.now(),
+              attempts: 1
+            });
+          onProgress == null || onProgress(pushed, failed);
+          return;
+        }
         for (let i = 0; i < sent.length; i++) {
           let e = sent[i], r = results[i];
           if ((r == null ? void 0 : r.status) === "ok")

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -32,6 +32,15 @@ const RESUME_PROBE_MS = 5_000;
  *  reconnects over random(0, window) so the freshly-booted node isn't
  *  stampeded. Overridden per-connection by the server-advertised value from
  *  the sync join reply; this constant is the crash-safe floor. */
+/** Deadline for one crdt_create_batch request. The server does real per-note
+ *  work inline (transaction + encrypt + CRDT room spawn + seed + checkpoint —
+ *  measured ~130ms/note on a dev backend), so a flat 10s deadline lost to a
+ *  legitimately-working large chunk: the client aborted while the server kept
+ *  committing. Base + per-note budget with ~3× headroom over the measurement. */
+export function batchCreateTimeoutMs(count: number): number {
+	return 10_000 + 400 * count;
+}
+
 export const RECONNECT_JITTER_DEFAULT_MS = 5_000;
 /** Hard ceiling on any server-advertised jitter window — guards against a
  *  malformed/hostile join reply making the client hang. Non-positive windows
@@ -447,11 +456,16 @@ export class NoteChannel {
 	}
 
 	/** Batch create: mirrors crdtCreate but takes a list (server caps it at 100
-	 *  creates per request; chunking is the caller's concern). */
+	 *  creates per request; chunking is the caller's concern). The deadline
+	 *  scales with the chunk — see batchCreateTimeoutMs. */
 	async crdtCreateBatch(creates: { doc_id: string; path: string; b64: string }[]): Promise<{
 		results: { doc_id: string; status: "ok" | "error"; reason?: string; limit?: number }[];
 	}> {
-		return (await this.sendRequest("crdt_create_batch", { creates })) as {
+		return (await this.sendRequest(
+			"crdt_create_batch",
+			{ creates },
+			batchCreateTimeoutMs(creates.length),
+		)) as {
 			results: { doc_id: string; status: "ok" | "error"; reason?: string; limit?: number }[];
 		};
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1070,7 +1070,7 @@ export default class EngramSyncPlugin extends Plugin {
 					// offline-created note here routes through pushFile's genesis branch,
 					// which itself enqueues a durable crdt_create when the topic is not yet
 					// joined (sync.ts:2546). The queue is the safety net either way.
-					const pushed = await this.syncEngine.pushModifiedFiles();
+					const { pushed } = await this.syncEngine.pushModifiedFiles();
 					if (pushed > 0) {
 						new Notice(`Engram Sync: pushed ${pushed}`);
 					}
@@ -2647,7 +2647,7 @@ export default class EngramSyncPlugin extends Plugin {
 					// Socket-only fallback poll (no REST): reconcile manifest
 					// server-deletes/folder-markers + replay the op-log. No-ops when
 					// the socket is down; a wedged socket recovers on reconnect.
-					const pulled = await this.syncEngine.catchUp();
+					const { files: pulled } = await this.syncEngine.catchUp();
 					if (pulled > 0) {
 						new Notice(`Engram Sync: pulled ${pulled} changes`);
 					}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -6721,9 +6721,13 @@ export class SyncEngine {
 		onProgress?: (pushed: number, failed: number) => void,
 	): Promise<{ pushed: number; failed: number }> {
 		if (!this.crdtCreateBatch || !this.crdt) return { pushed: 0, failed: 0 };
-		// Server caps creates at 100; keep the accumulated frames under the
-		// Plug.Parsers request-body limit (same budget as pushNotesViaBatch).
-		const MAX_CREATES = 100;
+		// Server caps creates at 100, but 25 is the sweet spot: the server does
+		// real per-note work (~130ms/note measured on dev), so a 25-chunk stays
+		// a few seconds per request — the Uploading row ticks every chunk, and a
+		// failed/timed-out chunk strands 25 notes, not 100. Keep the accumulated
+		// frames under the Plug.Parsers request-body limit (same budget as
+		// pushNotesViaBatch).
+		const MAX_CREATES = 25;
 		const PAYLOAD_BUDGET = 6_000_000;
 
 		let pushed = 0;
@@ -6749,9 +6753,39 @@ export class SyncEngine {
 			// track them and skip the mark in the finally below.
 			const recentlyDeletedPaths = new Set<string>();
 			try {
-				const { results } = await this.crdtCreateBatch!(
-					sent.map((e) => ({ doc_id: e.noteId, path: e.pushedPath, b64: e.b64 })),
-				);
+				let results: Awaited<ReturnType<CrdtCreateBatchFn>>["results"];
+				try {
+					({ results } = await this.crdtCreateBatch!(
+						sent.map((e) => ({ doc_id: e.noteId, path: e.pushedPath, b64: e.b64 })),
+					));
+				} catch (err) {
+					// Chunk-level failure (timeout / socket drop): count every entry
+					// as failed and keep going — a single bad chunk must not abort
+					// the whole first sync. NOTE: on a timeout the server may STILL
+					// commit these creates (the reply just arrived too late); the
+					// next sync re-runs them and converges via the id_conflict ADOPT
+					// path below.
+					const msg = errMsg(err);
+					rlog().error(
+						"push",
+						`crdt_create_batch chunk failed (${sent.length} notes): ${msg}`,
+					);
+					for (const e of sent) {
+						failed++;
+						this.logEntry("push", e.file.path, "error", msg);
+						this.issues.record({
+							path: e.file.path,
+							kind: "note",
+							category: "other",
+							message: msg,
+							firstFailedAt: Date.now(),
+							lastFailedAt: Date.now(),
+							attempts: 1,
+						});
+					}
+					onProgress?.(pushed, failed);
+					return;
+				}
 				// Match by INDEX, not id: the backend guarantees `results` is
 				// index-aligned with `creates` (ordered Task.async_stream phases
 				// since engram#1194, pinned by a backend channel test with a

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3773,8 +3773,23 @@ export class SyncEngine {
 		return { notes, attachments };
 	}
 
-	async catchupViaSeqReplay(opts: { fromZero?: boolean; enumerateOnly?: boolean } = {}): Promise<{
+	async catchupViaSeqReplay(
+		opts: {
+			fromZero?: boolean;
+			enumerateOnly?: boolean;
+			/** Fired once per non-deleted note/attachment row successfully applied —
+			 *  FILE units (the plan's denominator), not op-log rows. Drives the
+			 *  per-file "pulling" progress the UI seeds from the plan. */
+			onFileApplied?: (path: string) => void;
+		} = {},
+	): Promise<{
 		applied: number;
+		/** Non-deleted rows applied without throwing — the "files downloaded"
+		 *  count in the same units the sync plan counts. Tombstones and folder
+		 *  markers are excluded, so this is the honest "N synced" numerator. */
+		files: number;
+		/** Rows whose apply threw (logged + skipped so the feed never wedges). */
+		failed: number;
 		serverIds: Set<string>;
 		serverAttachmentPaths: Set<string>;
 		/** `true` when THIS call executed the replay loop exclusively (so
@@ -3794,10 +3809,20 @@ export class SyncEngine {
 		const serverAttachmentPaths = new Set<string>();
 		if (this.seqReplayRunning) {
 			this.seqReplayAgain = true;
-			return { applied: 0, serverIds, serverAttachmentPaths, ran: false, complete: false };
+			return {
+				applied: 0,
+				files: 0,
+				failed: 0,
+				serverIds,
+				serverAttachmentPaths,
+				ran: false,
+				complete: false,
+			};
 		}
 		this.seqReplayRunning = true;
 		let applied = 0;
+		let files = 0;
+		let failed = 0;
 		let complete = true;
 		try {
 			do {
@@ -3807,8 +3832,11 @@ export class SyncEngine {
 					serverIds,
 					serverAttachmentPaths,
 					opts.enumerateOnly ?? false,
+					opts.onFileApplied,
 				);
 				applied += pass.applied;
+				files += pass.files;
+				failed += pass.failed;
 				// The sets accumulate across coalesced passes, so ONE short pass taints
 				// the whole result — never OR this back to true.
 				if (!pass.complete) complete = false;
@@ -3816,7 +3844,7 @@ export class SyncEngine {
 		} finally {
 			this.seqReplayRunning = false;
 		}
-		return { applied, serverIds, serverAttachmentPaths, ran: true, complete };
+		return { applied, files, failed, serverIds, serverAttachmentPaths, ran: true, complete };
 	}
 
 	/** Run `catchupViaSeqReplay` for a DESTRUCTIVE delete decision (pull-all wipe,
@@ -3832,8 +3860,11 @@ export class SyncEngine {
 	private async catchupViaSeqReplayExclusive(opts: {
 		fromZero?: boolean;
 		enumerateOnly?: boolean;
+		onFileApplied?: (path: string) => void;
 	}): Promise<{
 		applied: number;
+		files: number;
+		failed: number;
 		serverIds: Set<string>;
 		serverAttachmentPaths: Set<string>;
 	} | null> {
@@ -3876,12 +3907,30 @@ export class SyncEngine {
 	 *      onto one `catchupSeq` removed it, so this restores that guarantee.
 	 *   4. `syncExplicitFolders` — pull the server's empty-folder markers to disk
 	 *      and propagate remote folder deletes.
-	 *  Returns the applied-op count (for the progress recap / poll notice). Never
+	 *  Returns the downloaded FILE count (non-deleted rows applied — the unit the
+	 *  sync plan and recap use) plus the count of rows whose apply threw. Never
 	 *  throws — mirrors the old pull() error boundary so a caller (fullSync/poll)
 	 *  never has to guard it. The manifest is fetched once and shared by the
 	 *  validator plus steps 1
 	 *  and 3. */
-	async catchUp(): Promise<number> {
+	async catchUp(
+		opts: { reportProgress?: boolean } = {},
+	): Promise<{ files: number; failed: number }> {
+		// FILE-unit progress for the sync UI (fullSync's pull leg). Opt-in: the
+		// background poll/reconnect callers emit nothing, exactly as before —
+		// they have no progress surface and never emit a terminal "complete".
+		let pulledFiles = 0;
+		const onFileApplied = opts.reportProgress
+			? (path: string): void => {
+					this.onSyncProgress?.({
+						phase: "pulling",
+						current: ++pulledFiles,
+						total: 0,
+						failed: 0,
+						currentPath: path,
+					});
+				}
+			: undefined;
 		try {
 			// #283: capture before the fetch so reconcileFromManifest can refuse its
 			// destructive pass if an OAuth swap lands while the manifest is in flight.
@@ -3901,12 +3950,12 @@ export class SyncEngine {
 				// watermark — an idle vault must not strand a local empty folder
 				// forever. Cheap: no-ops when nothing local is untracked.
 				await this.seedEmptyFolders();
-				const { applied } = await this.catchupViaSeqReplay();
-				return applied;
+				const { files, failed } = await this.catchupViaSeqReplay({ onFileApplied });
+				return { files, failed };
 			}
 			await this.reconcileFromManifest(manifest, authGenAtFetch);
 			const behind = this.validateFromManifest(manifest);
-			const { applied } = await this.catchupViaSeqReplay();
+			const { files, failed } = await this.catchupViaSeqReplay({ onFileApplied });
 			const poked = await this.healDivergedLiveBoundNotes(manifest);
 			try {
 				await this.syncExplicitFolders();
@@ -3926,14 +3975,14 @@ export class SyncEngine {
 				this.setManifestSeq(manifest.change_seq);
 				await this.saveData({ manifestSeq: this.manifestSeq });
 			}
-			return applied;
+			return { files, failed };
 		} catch (e) {
 			rlog().error(
 				"pull",
 				`Catch-up failed: ${errMsg(e)}`,
 				e instanceof Error ? e.stack : undefined,
 			);
-			return 0;
+			return { files: 0, failed: 0 };
 		}
 	}
 
@@ -3942,15 +3991,17 @@ export class SyncEngine {
 		serverIds: Set<string>,
 		serverAttachmentPaths: Set<string>,
 		enumerateOnly = false,
+		onFileApplied?: (path: string) => void,
 		/** `complete` is false when the walk did NOT reach the end of the feed, so
 		 *  `serverIds`/`serverAttachmentPaths` are a PARTIAL view of the server. Any
 		 *  caller making a delete decision must refuse them: a partial set is
 		 *  indistinguishable from "the server doesn't have these" and would trash
 		 *  every local file the walk never reached. */
-	): Promise<{ applied: number; complete: boolean }> {
+	): Promise<{ applied: number; files: number; failed: number; complete: boolean }> {
 		// Never walked at all — sets are empty, which must NOT read as "server is
 		// empty" to a destructive caller.
-		if (!this.crdtCatchupSince || !this.crdt) return { applied: 0, complete: false };
+		if (!this.crdtCatchupSince || !this.crdt)
+			return { applied: 0, files: 0, failed: 0, complete: false };
 		// The seq cursor is per-vault: `seq` is allocated per vault, so a cursor
 		// from one vault is meaningless in another. If our recorded per-vault
 		// state belongs to a DIFFERENT vault than the active one — an OAuth /
@@ -3980,6 +4031,8 @@ export class SyncEngine {
 		}
 		this.seqRewindFloor = null;
 		let applied = 0;
+		let files = 0;
+		let failed = 0;
 		try {
 			await this.walkOpLog({
 				seq: cursor,
@@ -3989,9 +4042,17 @@ export class SyncEngine {
 						try {
 							await this.applySyncChange(c);
 							applied += 1;
+							// FILE units for the progress UI: tombstones and folder-marker
+							// rows are op-log bookkeeping, not downloaded files — counting
+							// them made the recap disagree with the plan's file count.
+							if (!c.deleted) {
+								files += 1;
+								onFileApplied?.(c.path);
+							}
 						} catch (e) {
 							// One bad op (e.g. illegal filename) must not wedge the feed — log
 							// and skip, same isolation as pullViaCursor.
+							failed += 1;
 							rlog().error("crdt", `seq-replay: skipped ${c.path} — ${errMsg(e)}`);
 						}
 					}
@@ -4037,9 +4098,9 @@ export class SyncEngine {
 			// still real (and the cursor is persisted), so the pull itself succeeded —
 			// but a delete decision built on these sets would trash every file the
 			// walk never reached.
-			return { applied, complete: false };
+			return { applied, files, failed, complete: false };
 		}
-		return { applied, complete: true };
+		return { applied, files, failed, complete: true };
 	}
 
 	/** Per-note discovery from a room-open announce that carries a path
@@ -4546,16 +4607,34 @@ export class SyncEngine {
 		try {
 			this.onSyncProgress?.({ phase: "pulling", current: 0, total: 0, failed: 0 });
 
+			// Per-file progress in FILE units (the plan's denominator) — the raw
+			// op-count would balloon past the plan on vaults with delete history.
+			let pulledFiles = 0;
+			const onFileApplied = (path: string): void => {
+				this.onSyncProgress?.({
+					phase: "pulling",
+					current: ++pulledFiles,
+					total: 0,
+					failed: 0,
+					currentPath: path,
+				});
+			};
+
 			// Destructive wipe MUST decide the trash set from an EXCLUSIVE replay
 			// (real, complete server sets). A coalesced replay returns EMPTY sets —
 			// treating those as "server has nothing" trashes the whole vault. Abort
 			// the wipe rather than trash on untrustworthy sets. Pull-all-keep is
 			// non-destructive, so it may coalesce harmlessly.
 			let applied: number;
+			let pulledFileCount: number;
+			let replayFailed: number;
 			let serverIds: Set<string>;
 			let serverAttachmentPaths: Set<string>;
 			if (wipe) {
-				const replay = await this.catchupViaSeqReplayExclusive({ fromZero: true });
+				const replay = await this.catchupViaSeqReplayExclusive({
+					fromZero: true,
+					onFileApplied,
+				});
 				if (!replay) {
 					this.lastError =
 						"Pull all (delete extras) aborted: could not obtain an exclusive server snapshot (replay contention). Nothing was trashed.";
@@ -4569,11 +4648,21 @@ export class SyncEngine {
 					);
 					return 0;
 				}
-				({ applied, serverIds, serverAttachmentPaths } = replay);
+				({
+					applied,
+					files: pulledFileCount,
+					failed: replayFailed,
+					serverIds,
+					serverAttachmentPaths,
+				} = replay);
 			} else {
-				({ applied, serverIds, serverAttachmentPaths } = await this.catchupViaSeqReplay({
-					fromZero: true,
-				}));
+				({
+					applied,
+					files: pulledFileCount,
+					failed: replayFailed,
+					serverIds,
+					serverAttachmentPaths,
+				} = await this.catchupViaSeqReplay({ fromZero: true, onFileApplied }));
 			}
 
 			devLog().log(
@@ -4582,6 +4671,7 @@ export class SyncEngine {
 			);
 			rlog().info("pull", `${label} replay done — applied=${applied}`);
 
+			let deleteFailed = 0;
 			if (wipe) {
 				// Suppress delete sync — these are locally-decided extras, not a
 				// server-originated delete; stays true until the local trash pass
@@ -4596,7 +4686,6 @@ export class SyncEngine {
 				});
 				const total = extras.length;
 				this.onSyncProgress?.({ phase: "deleting", current: 0, total, failed: 0 });
-				let deleteFailed = 0;
 				for (let i = 0; i < extras.length; i++) {
 					const file = extras[i]!;
 					try {
@@ -4629,16 +4718,23 @@ export class SyncEngine {
 				);
 			}
 
+			// The recap counts FILES (the plan's unit), not op-log rows — `applied`
+			// includes tombstones and superseded rows and overshoots the plan's
+			// promise on any vault with delete history. Failures are real: replay
+			// rows that threw plus local-extra trashes that failed.
 			this.onSyncProgress?.({
 				phase: "complete",
-				current: applied,
-				total: applied,
-				failed: 0,
+				current: pulledFileCount,
+				total: pulledFileCount,
+				failed: replayFailed + deleteFailed,
 			});
 
-			devLog().log("pull", `${label}: done — applied=${applied}`);
-			rlog().info("pull", `${label} done — applied=${applied}`);
-			return applied;
+			devLog().log(
+				"pull",
+				`${label}: done — files=${pulledFileCount} (ops applied=${applied})`,
+			);
+			rlog().info("pull", `${label} done — files=${pulledFileCount} (ops=${applied})`);
+			return pulledFileCount;
 		} catch (e) {
 			// biome-ignore lint/suspicious/noConsole: error boundary
 			console.error("Engram Sync: pullAll failed", e);
@@ -6490,22 +6586,26 @@ export class SyncEngine {
 		// the old and new lastSync values.
 		const prePullSync = this.lastSync;
 
-		const pulled = await this.catchUp();
-		const pushed = await this.pushModifiedFiles(prePullSync);
+		const pull = await this.catchUp({ reportProgress: true });
+		const pulled = pull.files;
+		const push = await this.pushModifiedFiles(prePullSync);
+		const pushed = push.pushed;
 
 		// Close out the progress UI (mirrors pushAll's terminal "complete").
 		// The recap's "N synced" reads `current`, so it must count BOTH legs —
 		// a download-only sync (pushed=0) still synced `pulled` notes and must
-		// not report "Nothing needed syncing". pushModifiedFiles already flushed
-		// the plan-skip tally into lastBatchSkipped, so surface it here as
-		// `skipped` (disjoint from failed — informational skips never increment
-		// the failure counter).
+		// not report "Nothing needed syncing". Both legs are FILE counts (the
+		// plan's unit). `failed` carries both legs too — the recap used to
+		// hardcode 0 and claim "All synced" over real genesis-batch failures.
+		// pushModifiedFiles already flushed the plan-skip tally into
+		// lastBatchSkipped, so surface it here as `skipped` (disjoint from
+		// failed — informational skips never increment the failure counter).
 		const synced = pulled + pushed;
 		this.onSyncProgress?.({
 			phase: "complete",
 			current: synced,
 			total: synced,
-			failed: 0,
+			failed: pull.failed + push.failed,
 			skipped: this.lastBatchSkipped,
 		});
 
@@ -6933,7 +7033,7 @@ export class SyncEngine {
 	 *  wired. Public: also called directly by the connect path (onLayoutReady,
 	 *  Plan B1 Task 6), which no longer runs fullSync's REST pull leg but still
 	 *  needs this push leg to create/upload local-only notes on (re)connect. */
-	async pushModifiedFiles(sinceTimestamp?: string): Promise<number> {
+	async pushModifiedFiles(sinceTimestamp?: string): Promise<{ pushed: number; failed: number }> {
 		// Use ?? not || so an empty-string prePullSync (first connect, never
 		// synced) is preserved and maps to epoch below — || would discard "" and
 		// fall back to this.lastSync, which pull() just advanced to server_time,
@@ -6963,7 +7063,10 @@ export class SyncEngine {
 
 		this.flushAttachmentLimitedToast();
 		this.flushFailureSummaryToast();
-		return pushed;
+		// `failed` counts genesis-batch failures — per-file throws propagate to
+		// the caller instead. It used to be silently dropped here, letting
+		// fullSync's recap claim "All synced" over real failures.
+		return { pushed, failed: outcome.failed };
 	}
 
 	/** Compute what a sync would do without executing it (dry-run preview).

--- a/tests/channel-crdt.test.ts
+++ b/tests/channel-crdt.test.ts
@@ -5,8 +5,8 @@
  * - inbound crdt_msg routes to onCrdtMessage callback
  * - crdt topic join error is graceful (does not affect connected state)
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { NoteChannel } from "../src/channel";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { batchCreateTimeoutMs, NoteChannel } from "../src/channel";
 
 let _lastWsUrl: string | null = null;
 let lastWsInstance: any = null;
@@ -1182,6 +1182,34 @@ describe("in-flight sendRequest on unclean close (repo-review 2026-08)", () => {
 			new Promise((r) => setTimeout(() => r("still-pending"), 100)),
 		]);
 		expect(outcome).toBe("rejected");
+		channel.disconnect();
+	});
+});
+
+describe("crdtCreateBatch timeout scales with chunk size", () => {
+	// A flat 10s deadline lost to a measured ~13s server cost for a big chunk
+	// (per-note transaction + room spawn + seed). The deadline must grow with
+	// the number of creates so a legitimately slow-but-working batch is not
+	// aborted client-side while the server commits it anyway.
+	test("passes a size-scaled timeout to sendRequest", async () => {
+		const { channel } = await joinedCrdtChannel();
+		const spy = spyOn(channel, "sendRequest").mockResolvedValue({ results: [] });
+		const creates = Array.from({ length: 25 }, (_, i) => ({
+			doc_id: `id${i}`,
+			path: `N${i}.md`,
+			b64: "Zg==",
+		}));
+
+		await channel.crdtCreateBatch(creates);
+
+		expect(spy).toHaveBeenCalledWith(
+			"crdt_create_batch",
+			{ creates },
+			batchCreateTimeoutMs(25),
+		);
+		// Scaling must be real: a full chunk gets strictly more budget than one note.
+		expect(batchCreateTimeoutMs(25)).toBeGreaterThan(batchCreateTimeoutMs(1));
+
 		channel.disconnect();
 	});
 });

--- a/tests/sync-plan.test.ts
+++ b/tests/sync-plan.test.ts
@@ -741,6 +741,8 @@ describe("SyncEngine.pushAll with progress", () => {
 		engine.syncLog = new SyncLog();
 		(engine as any).catchupViaSeqReplay = async () => ({
 			applied: 1,
+			files: 1,
+			failed: 0,
 			serverIds: new Set<string>(),
 			serverAttachmentPaths: new Set<string>(),
 			ran: true,

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -184,3 +184,31 @@ describe("first-sync progress reporting (op-log replay)", () => {
 		expect(complete?.failed).toBe(1);
 	});
 });
+
+describe("pushGenesisBatch — a timed-out chunk is counted, not fatal", () => {
+	// Root cause (measured on local dev): the server needs ~13s to create a
+	// 100-note chunk, the channel deadline was a flat 10s, and the resulting
+	// throw aborted the ENTIRE first sync — while the server kept committing
+	// the creates. A chunk-level failure must degrade to counted failures so
+	// the remaining chunks (and the rest of the sync) still run. Chunks are
+	// 25 notes so the Uploading row ticks every few seconds instead of
+	// per-hundred.
+	test("first chunk rejects → its files count as failed, second chunk still pushes", async () => {
+		const { engine } = makeEngine([]);
+		const files = Array.from({ length: 26 }, (_, i) => new TFile(`Notes/n${i}.md`, Date.now()));
+		let calls = 0;
+		engine.setCrdtCreateBatch(async (creates) => {
+			calls++;
+			if (calls === 1) throw new Error("sendRequest timeout: crdt_create_batch");
+			return {
+				results: creates.map((c) => ({ doc_id: c.doc_id, status: "ok" as const })),
+			};
+		});
+
+		const out = await (engine as any).pushGenesisBatch(files);
+
+		expect(calls).toBe(2); // the second chunk was still attempted
+		expect(out.failed).toBe(25); // the whole first chunk, counted not thrown
+		expect(out.pushed).toBe(1);
+	});
+});

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests: first-sync progress reporting over the op-log replay.
+ *
+ * The sync-options modal counts FILES (the plan), but the engine used to
+ * report op-log ROWS: tombstones inflated the "N synced" recap, the pull leg
+ * emitted no per-file progress at all (the Downloading row froze at 0/N),
+ * and both pullAll and fullSync hardcoded failed:0 on completion. These pin
+ * the fixed contract: per-file "pulling" events, file-unit completion counts,
+ * and real failure tallies. Mock-engine pattern mirrors
+ * tests/sync-socket-catchup.test.ts.
+ */
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import "fake-indexeddb/auto";
+import { TFile } from "obsidian";
+import type { EngramApi } from "../src/api";
+import { NoteIdMap } from "../src/crdt/note-id-map";
+import type { ProviderRegistry as CrdtManager } from "../src/crdt/provider-registry";
+import { SyncEngine } from "../src/sync";
+import { DEFAULT_SETTINGS, type SyncChange, type SyncProgress } from "../src/types";
+
+const makeApi = () =>
+	({
+		pushNote: mock().mockResolvedValue({ note: {}, chunks_indexed: 1 }),
+		pushNotesBatch: mock().mockRejectedValue({ status: 404 }),
+		deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
+		health: mock().mockResolvedValue(true),
+		ping: mock().mockResolvedValue({ ok: true }),
+		pushAttachment: mock().mockResolvedValue({ attachment: {} }),
+		getAttachment: mock().mockResolvedValue({
+			path: "",
+			content_base64: "",
+			mime_type: "",
+			size_bytes: 0,
+			mtime: 0,
+		}),
+		deleteAttachment: mock().mockResolvedValue({ deleted: true, path: "" }),
+		getRateLimit: mock().mockResolvedValue(0),
+		getManifest: mock().mockResolvedValue({ unchanged: true }),
+		registerVault: mock().mockResolvedValue({
+			id: "v1",
+			name: "Test",
+			slug: "test",
+			is_default: true,
+		}),
+	}) as unknown as EngramApi;
+
+const makeApp = () =>
+	({
+		vault: {
+			configDir: ".obsidian",
+			read: mock().mockResolvedValue("body"),
+			cachedRead: mock().mockResolvedValue("body"),
+			readBinary: mock().mockResolvedValue(new ArrayBuffer(3)),
+			getMarkdownFiles: mock().mockReturnValue([]),
+			getFiles: mock().mockReturnValue([]),
+			getAbstractFileByPath: mock().mockReturnValue(null),
+			getFileByPath: mock().mockReturnValue(null),
+			modify: mock().mockResolvedValue(undefined),
+			process: mock().mockImplementation((_f: any, fn: (d: string) => string) =>
+				Promise.resolve(fn("")),
+			),
+			modifyBinary: mock().mockResolvedValue(undefined),
+			create: mock().mockResolvedValue(undefined),
+			createBinary: mock().mockResolvedValue(undefined),
+			createFolder: mock().mockResolvedValue(undefined),
+			trash: mock().mockResolvedValue(undefined),
+			rename: mock().mockResolvedValue(undefined),
+			getName: mock().mockReturnValue("Test Vault"),
+		},
+		fileManager: { trashFile: mock().mockResolvedValue(undefined) },
+		workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
+	}) as any;
+
+const noteRow = (over: Partial<Extract<SyncChange, { type: "note" }>>): SyncChange => ({
+	type: "note",
+	id: "id-x",
+	seq: 1,
+	path: "Notes/x.md",
+	title: "x",
+	content: "hello",
+	content_hash: "h",
+	folder: "Notes",
+	tags: [],
+	mtime: 1,
+	updated_at: "2026-01-01T00:00:00Z",
+	deleted: false,
+	...over,
+});
+
+/** 2 live notes + 1 tombstone: 3 op-log rows, 2 files. */
+const threeRowFeed = (): SyncChange[] => [
+	noteRow({ id: "id-a", seq: 1, path: "Notes/a.md" }),
+	noteRow({ id: "id-b", seq: 2, path: "Notes/b.md" }),
+	noteRow({ id: "id-dead", seq: 3, path: "Notes/dead.md", deleted: true, content: undefined }),
+];
+
+function makeEngine(feed: SyncChange[]): { engine: SyncEngine; events: SyncProgress[] } {
+	const crdt: Partial<CrdtManager> = {
+		hasHistory: () => Promise.resolve(false),
+		applyRemoteUpdate: () => Promise.resolve(),
+		encodeStateVector: () => Promise.resolve(new Uint8Array([0])),
+		encodeGenesisUpdate: () => new Uint8Array([1, 2]),
+		projectedText: () => Promise.resolve(""),
+		closeDoc: () => {},
+	};
+	const engine = new SyncEngine(
+		makeApp(),
+		makeApi(),
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
+		mock().mockResolvedValue(undefined),
+	);
+	engine.setCrdtManager(crdt as unknown as CrdtManager);
+	engine.setReady();
+	engine.setNoteIdMap(new NoteIdMap());
+	engine.setCrdtCatchupSince(async () => ({
+		changes: feed,
+		has_more: false,
+		next_seq: null,
+	}));
+	const events: SyncProgress[] = [];
+	engine.onSyncProgress = (p) => events.push({ ...p });
+	return { engine, events };
+}
+
+describe("first-sync progress reporting (op-log replay)", () => {
+	test("pullAll emits per-file pulling progress; tombstones are not counted", async () => {
+		const { engine, events } = makeEngine(threeRowFeed());
+
+		await engine.pullAll();
+
+		const pulling = events.filter((p) => p.phase === "pulling" && p.current > 0);
+		expect(pulling.map((p) => p.current)).toEqual([1, 2]);
+		// The tombstone row must never show up as a third downloaded file.
+		expect(Math.max(...pulling.map((p) => p.current))).toBe(2);
+	});
+
+	test("pullAll completion counts files, not op-log rows", async () => {
+		const { engine, events } = makeEngine(threeRowFeed());
+
+		const pulled = await engine.pullAll();
+
+		const complete = events.find((p) => p.phase === "complete");
+		expect(complete?.current).toBe(2);
+		// The Notice reads the return value — same unit.
+		expect(pulled).toBe(2);
+	});
+
+	test("pullAll completion reports replay apply failures", async () => {
+		const { engine, events } = makeEngine(threeRowFeed());
+		const apply = spyOn(engine, "applySyncChange");
+		apply.mockRejectedValueOnce(new Error("boom"));
+
+		await engine.pullAll();
+
+		const complete = events.find((p) => p.phase === "complete");
+		expect(complete?.failed).toBe(1);
+		// The failed row is not a synced file.
+		expect(complete?.current).toBe(1);
+	});
+
+	test("fullSync emits pulling progress and counts pulled files on completion", async () => {
+		const { engine, events } = makeEngine(threeRowFeed());
+
+		const { pulled } = await engine.fullSync();
+
+		const pulling = events.filter((p) => p.phase === "pulling" && p.current > 0);
+		expect(pulling.map((p) => p.current)).toEqual([1, 2]);
+		const complete = events.find((p) => p.phase === "complete");
+		expect(complete?.current).toBe(2);
+		expect(pulled).toBe(2);
+	});
+
+	test("fullSync completion carries genesis-batch push failures", async () => {
+		const { engine, events } = makeEngine([]);
+		const file = new TFile("Notes/new.md", Date.now());
+		(engine as any).app.vault.getFiles = mock().mockReturnValue([file]);
+		engine.setCrdtCreateBatch(async () => ({
+			results: [{ doc_id: "id-new", status: "error" as const, reason: "create_failed" }],
+		}));
+
+		await engine.fullSync();
+
+		const complete = events.find((p) => p.phase === "complete");
+		expect(complete?.failed).toBe(1);
+	});
+});

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -215,7 +215,7 @@ describe("pushGenesisBatch — direct", () => {
 		expect((engine as any).issues.get("Notes/Bad.md")?.message).toContain("notes_cap_reached");
 	});
 
-	test("chunks at 100 notes per crdt_create_batch call (never exceeds the server cap)", async () => {
+	test("chunks at 25 notes per crdt_create_batch call (progress ticks, small blast radius, under the server cap)", async () => {
 		const files = Array.from(
 			{ length: 250 },
 			(_, i) => new TFile(`Notes/n${i}.md`, Date.now()),
@@ -230,7 +230,7 @@ describe("pushGenesisBatch — direct", () => {
 
 		const out = await (engine as any).pushGenesisBatch(files);
 
-		expect(chunkSizes).toEqual([100, 100, 50]);
+		expect(chunkSizes).toEqual([25, 25, 25, 25, 25, 25, 25, 25, 25, 25]);
 		expect(chunkSizes.every((n) => n <= 100)).toBe(true);
 		expect(out.pushed).toBe(250);
 	});

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -424,6 +424,8 @@ describe("SyncEngine.pullAll — replay-from-0 (Task 5)", () => {
 			fromZero = o?.fromZero;
 			return {
 				applied: 1,
+				files: 1,
+				failed: 0,
 				serverIds: new Set(["s1"]),
 				serverAttachmentPaths: new Set<string>(),
 			};

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -418,6 +418,8 @@ describe("catchupViaSeqReplay", () => {
 		const engine = makeEngineWithCrdt({ closeDoc: () => {} });
 		await expect(engine.catchupViaSeqReplay()).resolves.toEqual({
 			applied: 0,
+			files: 0,
+			failed: 0,
 			serverIds: new Set(),
 			serverAttachmentPaths: new Set(),
 			ran: true,

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1239,9 +1239,11 @@ describe("SyncEngine.fullSync (catch-up wiring)", () => {
 	// silent reconnect/startup catch-up.
 	test("fullSync routes its pull-half through catchUp (seq-replay), not the REST pull()", async () => {
 		const engine = createEngine();
-		const catchUp = jest.spyOn(engine, "catchUp").mockResolvedValue(0);
+		const catchUp = jest.spyOn(engine, "catchUp").mockResolvedValue({ files: 0, failed: 0 });
 		const pull = jest.spyOn(engine as any, "pull");
-		const pushModified = jest.spyOn(engine as any, "pushModifiedFiles").mockResolvedValue(0);
+		const pushModified = jest
+			.spyOn(engine as any, "pushModifiedFiles")
+			.mockResolvedValue({ pushed: 0, failed: 0 });
 
 		await engine.fullSync();
 
@@ -1257,9 +1259,9 @@ describe("SyncEngine.fullSync (catch-up wiring)", () => {
 			if (p.phase === "complete") completeCurrent = p.current;
 		};
 
-		// Download-only sync: 2 ops applied via seq-replay, nothing local to push.
-		jest.spyOn(engine, "catchUp").mockResolvedValue(2);
-		jest.spyOn(engine as any, "pushModifiedFiles").mockResolvedValue(0);
+		// Download-only sync: 2 files applied via seq-replay, nothing local to push.
+		jest.spyOn(engine, "catchUp").mockResolvedValue({ files: 2, failed: 0 });
+		jest.spyOn(engine as any, "pushModifiedFiles").mockResolvedValue({ pushed: 0, failed: 0 });
 
 		const { pulled, pushed } = await engine.fullSync();
 


### PR DESCRIPTION
## Problem

The first-sync options modal shows the correct file count (it reads the plan, which counts files), but the progress screen then shows no real progress and a wrong "N synced" number.

Three root causes, all on the engine's progress-event seam:

1. **The pull side emitted no progress at all.** `catchUp()` emitted zero events; `pullAll()` emitted a single `pulling 0/0`. The op-log replay (`walkOpLog` → `applySyncChange`) had no progress hook, so the Downloading row froze at `0 / N` for the entire first sync, and smart-merge sat on "Getting started…" through the whole pull leg.
2. **The completion recap counted op-log rows, not files.** `applied` includes tombstones and superseded rows, so "N synced" disagreed with the plan's file count on any vault with delete history.
3. **`failed` was hardcoded to 0** in both `fullSync` and `pullAll` completion events — genesis-batch failures and wipe-delete failures were silently dropped, letting the recap claim "All synced. Your vault and the cloud now match."

## Fix

- `runSeqReplayOnce` now counts **files** (non-deleted rows applied) and **failed** (rows whose apply threw) alongside `applied`, and fires an optional per-file callback.
- `pullAll` and `fullSync` (via `catchUp({reportProgress: true})`) forward that callback as `pulling` events with `total: 0` — the modal's existing `rowCounts` logic keeps the plan's denominator, so the Downloading bar fills against the same number the options modal promised.
- Both completion events now report file-unit `current` and real `failed` tallies; `pushModifiedFiles` returns `{pushed, failed}` instead of dropping the failure count. Background poll/reconnect catch-ups are unchanged (no progress surface, no events).

## Tests

TDD: 5 new tests in `tests/sync-progress-firstsync.test.ts` (written first, watched fail) pinning per-file pulling events, tombstone exclusion, file-unit completion counts, and both failure tallies. Full suite 2482 pass; biome/eslint/stylelint/tsc/build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC