### PR TITLE
fix(sync): delete-push fence — engine trashes and unsynced paths never delete server data

### DIFF
--- a/main.js
+++ b/main.js
@@ -19501,6 +19501,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     this.seqRewindFloor = null;
     /** When true, vault delete events are suppressed (used during local wipe). */
     this.suppressDeletes = !1;
+    /** Paths THIS ENGINE trashed (wipe pass, orphan sweep, remote-delete
+     *  apply, recently_deleted convergence). Durable — consumed by
+     *  handleDelete, cleared when the path is recreated — never expired by a
+     *  timer. The 5s `remotelyDeleted` TTL was the 2026-08-12 data-loss seam
+     *  (#416): a mass trash outlives the TTL, the late vault delete events
+     *  look user-made, and the engine pushes them as real server deletions. */
+    this.engineTrashedPaths = /* @__PURE__ */ new Set();
     /** Paths modified during a pull that need pushing once pull completes. */
     this.pendingPostPullPushes = /* @__PURE__ */ new Set();
     this.crdtCatchupSince = null;
@@ -20554,8 +20561,13 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   }
   // --- Push: local → Engram ---
   /** Handle a vault modify/create event with debounce. */
+  /** A file (re)appeared at `path` — any engine-trash record for it is
+   *  stale and must not swallow a future genuine delete of the new file. */
+  noteRecreatedPath(path) {
+    this.engineTrashedPaths.delete(path);
+  }
   handleModify(file) {
-    if (this.syncBlocked) {
+    if (this.noteRecreatedPath(file.path), this.syncBlocked) {
       devLog().log("sync-blocked", "handleModify short-circuited \u2014 gate closed");
       return;
     }
@@ -20591,8 +20603,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let isBinary = this.isBinaryFile(file), existing = this.debounceTimers.get(file.path);
     existing && (this.time.clearTimeout(existing), this.debounceTimers.delete(file.path));
     let crdtNoteId = isBinary ? null : (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(file.path)) != null ? _b : null;
-    if (crdtNoteId && this.markRecentlyDeleted(crdtNoteId), isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path), this.dropPath((0, import_obsidian24.normalizePath)(file.path), { dropBase: !1 }), this.files.has(file.path, "remotelyDeleted")) {
-      this.files.clearMarker(file.path, "remotelyDeleted"), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
+    crdtNoteId && this.markRecentlyDeleted(crdtNoteId), isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path);
+    let hadSyncEvidence = this.syncState.has((0, import_obsidian24.normalizePath)(file.path));
+    if (this.dropPath((0, import_obsidian24.normalizePath)(file.path), { dropBase: !1 }), this.files.has(file.path, "remotelyDeleted") || this.engineTrashedPaths.has(file.path)) {
+      this.files.clearMarker(file.path, "remotelyDeleted"), this.engineTrashedPaths.delete(file.path), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
+      return;
+    }
+    if (!hadSyncEvidence) {
+      rlog().warn("push", `Delete push REFUSED (no sync evidence): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
       return;
     }
     try {
@@ -21045,7 +21063,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  handleDelete — every sync-applied deletion must route through here, or
    *  its echo-push can tombstone a note recreated at the path since. */
   async trashRemotelyDeleted(file) {
-    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), await this.app.fileManager.trashFile(file);
+    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), this.engineTrashedPaths.add(file.path), await this.app.fileManager.trashFile(file);
   }
   /** Suppress WebSocket echoes for a path for ECHO_COOLDOWN_MS after push. */
   markRecentlyPushed(path) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2257,7 +2257,14 @@ export class SyncEngine {
 	// --- Push: local → Engram ---
 
 	/** Handle a vault modify/create event with debounce. */
+	/** A file (re)appeared at `path` — any engine-trash record for it is
+	 *  stale and must not swallow a future genuine delete of the new file. */
+	noteRecreatedPath(path: string): void {
+		this.engineTrashedPaths.delete(path);
+	}
+
 	handleModify(file: TAbstractFile): void {
+		this.noteRecreatedPath(file.path);
 		if (this.syncBlocked) {
 			devLog().log("sync-blocked", "handleModify short-circuited — gate closed");
 			return;
@@ -2341,6 +2348,14 @@ export class SyncEngine {
 	/** When true, vault delete events are suppressed (used during local wipe). */
 	suppressDeletes = false;
 
+	/** Paths THIS ENGINE trashed (wipe pass, orphan sweep, remote-delete
+	 *  apply, recently_deleted convergence). Durable — consumed by
+	 *  handleDelete, cleared when the path is recreated — never expired by a
+	 *  timer. The 5s `remotelyDeleted` TTL was the 2026-08-12 data-loss seam
+	 *  (#416): a mass trash outlives the TTL, the late vault delete events
+	 *  look user-made, and the engine pushes them as real server deletions. */
+	private readonly engineTrashedPaths = new Set<string>();
+
 	/** Handle a vault delete event. */
 	async handleDelete(file: TAbstractFile): Promise<void> {
 		if (this.syncBlocked) {
@@ -2387,6 +2402,7 @@ export class SyncEngine {
 		// recreated file's push is skipped and it never reaches the server.
 		// (dropBase:false — the local-delete path never dropped the merge base
 		// here; base cleanup belongs to the remote-removal path.)
+		const hadSyncEvidence = this.syncState.has(normalizePath(file.path));
 		this.dropPath(normalizePath(file.path), { dropBase: false });
 
 		// This trash APPLIED a remote change (trashRemotelyDeleted marked it):
@@ -2395,9 +2411,28 @@ export class SyncEngine {
 		// (replace-remote wipe→re-push, delete→recreate) and tombstones the
 		// FRESH note. Local bookkeeping above still ran; mirror the CRDT
 		// teardown the push path would have done and stop.
-		if (this.files.has(file.path, "remotelyDeleted")) {
+		if (
+			this.files.has(file.path, "remotelyDeleted") ||
+			this.engineTrashedPaths.has(file.path)
+		) {
 			this.files.clearMarker(file.path, "remotelyDeleted");
+			this.engineTrashedPaths.delete(file.path);
 			rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`);
+			if (this.isCrdtEligible(file) && crdtNoteId) {
+				await this.teardownCrdtDoc(crdtNoteId);
+			}
+			return;
+		}
+
+		// EVIDENCE RULE (#416): a delete may be pushed ONLY for a path this
+		// engine recorded sync evidence for. No syncState entry = we never
+		// completed a sync of this path = nothing of the user's to delete
+		// server-side; pushing anyway is how the 2026-08-12 incident turned a
+		// client-side bookkeeping hole into 39 prod tombstones. Cost of a
+		// false refusal is benign resurrection on the next pull; cost of a
+		// false push is data loss. Local bookkeeping above already ran.
+		if (!hadSyncEvidence) {
+			rlog().warn("push", `Delete push REFUSED (no sync evidence): ${file.path}`);
 			if (this.isCrdtEligible(file) && crdtNoteId) {
 				await this.teardownCrdtDoc(crdtNoteId);
 			}
@@ -3494,6 +3529,7 @@ export class SyncEngine {
 	 *  its echo-push can tombstone a note recreated at the path since. */
 	private async trashRemotelyDeleted(file: TAbstractFile): Promise<void> {
 		this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS);
+		this.engineTrashedPaths.add(file.path);
 		await this.app.fileManager.trashFile(file);
 	}
 

--- a/tests/sync-crdt-route.test.ts
+++ b/tests/sync-crdt-route.test.ts
@@ -1193,6 +1193,8 @@ describe("Task 4: local delete enqueues a durable crdt_delete", () => {
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("Notes/gone.md", "note-uuid");
 		const engine = createEngine(noteIdMap);
+		// #416 evidence rule: a delete push requires recorded sync evidence.
+		(engine as any).syncState.set("Notes/gone.md", { hash: 1 });
 		const enqueued: Array<{ kind: string; docId: string; path: string }> = [];
 		engine.setCrdtEnqueue((op) => enqueued.push(op));
 
@@ -1211,6 +1213,8 @@ describe("Task 4: local delete enqueues a durable crdt_delete", () => {
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("Notes/gone.md", "note-uuid");
 		const engine = createEngine(noteIdMap);
+		// #416 evidence rule: a delete push requires recorded sync evidence.
+		(engine as any).syncState.set("Notes/gone.md", { hash: 1 });
 		const enqueued: Array<{ kind: string; docId: string; path: string }> = [];
 		engine.setCrdtEnqueue((op) => enqueued.push(op));
 

--- a/tests/sync-delete-fence.test.ts
+++ b/tests/sync-delete-fence.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests: the delete-push fence (#416 — 2026-08-12 prod data-loss incident).
+ *
+ * A first sync into a switched vault trashed freshly-pulled files (replay
+ * bookkeeping lost rows → orphan sweep) and the late vault delete events —
+ * past the 5s remotelyDeleted echo TTL — were pushed to the server as REAL
+ * deletions (20 notes + 19 attachments tombstoned in prod).
+ *
+ * Two independent layers close it:
+ *  1. Engine-trashed paths are recorded DURABLY (consumed on the delete
+ *     event, cleared on recreate) — never by a timer. Anything the engine
+ *     itself trashed can never be pushed back as a user delete.
+ *  2. Evidence rule: a delete push requires a recorded syncState entry for
+ *     the path. No sync evidence = the server was never told about this
+ *     path by us = nothing legitimate to delete.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import "fake-indexeddb/auto";
+import { TFile } from "obsidian";
+import type { EngramApi } from "../src/api";
+import { NoteIdMap } from "../src/crdt/note-id-map";
+import { SyncEngine } from "../src/sync";
+import { DEFAULT_SETTINGS } from "../src/types";
+
+function makeAttachmentFile(path: string): TFile {
+	return new TFile(path);
+}
+
+function makeNoteFile(path: string): TFile {
+	return new TFile(path);
+}
+
+function makeEngine() {
+	const deleteAttachment = mock().mockResolvedValue({ deleted: true, path: "" });
+	const api = {
+		deleteAttachment,
+		deleteNote: mock().mockResolvedValue({ deleted: true, path: "" }),
+	} as unknown as EngramApi;
+	const app = {
+		vault: {
+			configDir: ".obsidian",
+			read: mock().mockResolvedValue("body"),
+			cachedRead: mock().mockResolvedValue("body"),
+			getAbstractFileByPath: mock().mockReturnValue(null),
+			getFileByPath: mock().mockReturnValue(null),
+			getName: mock().mockReturnValue("Test Vault"),
+		},
+		fileManager: { trashFile: mock().mockResolvedValue(undefined) },
+		workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
+	} as any;
+	const e = new SyncEngine(
+		app,
+		api,
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
+		mock().mockResolvedValue(undefined),
+	);
+	e.setReady();
+	const crdtDeletes: string[] = [];
+	e.setCrdtEnqueue((op: any) => {
+		if (op.kind === "delete") crdtDeletes.push(op.path);
+	});
+	e.setNoteIdMap(new NoteIdMap());
+	return { e, deleteAttachment, crdtDeletes };
+}
+
+function recordSyncEvidence(e: SyncEngine, path: string): void {
+	(e as any).syncState.set(path, { hash: 1 });
+}
+
+describe("engine-trashed paths never push their delete", () => {
+	test("delete event AFTER the echo TTL would have expired still skips the push", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("a/pic.png");
+		recordSyncEvidence(e, file.path);
+
+		await (e as any).trashRemotelyDeleted(file);
+		// Simulate the 5s remotelyDeleted TTL expiring before Obsidian's async
+		// delete event lands (the incident's exact window).
+		(e as any).files.clearMarker(file.path, "remotelyDeleted");
+
+		await e.handleDelete(file);
+
+		expect(deleteAttachment).not.toHaveBeenCalled();
+	});
+
+	test("a recreate clears the record, so a later REAL user delete pushes", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("a/pic.png");
+		recordSyncEvidence(e, file.path);
+
+		await (e as any).trashRemotelyDeleted(file);
+		(e as any).files.clearMarker(file.path, "remotelyDeleted");
+
+		// File comes back (pull or user recreate) — the trash record must not
+		// outlive it and swallow the next genuine delete.
+		e.noteRecreatedPath(file.path);
+		recordSyncEvidence(e, file.path);
+
+		await e.handleDelete(file);
+
+		expect(deleteAttachment).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("evidence rule: no syncState entry → no delete push", () => {
+	test("attachment delete without sync evidence is refused", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("never/synced.png");
+
+		await e.handleDelete(file);
+
+		expect(deleteAttachment).not.toHaveBeenCalled();
+	});
+
+	test("attachment delete WITH sync evidence pushes as before", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("known/synced.png");
+		recordSyncEvidence(e, file.path);
+
+		await e.handleDelete(file);
+
+		expect(deleteAttachment).toHaveBeenCalledTimes(1);
+	});
+
+	test("note delete without sync evidence enqueues no crdt_delete", async () => {
+		const { e, crdtDeletes } = makeEngine();
+		const file = makeNoteFile("never/synced.md");
+		// The note has an id BINDING but no crdtHead and no syncState row —
+		// the server never confirmed it. The id alone must not be enough to
+		// delete. (A crdtHead WOULD be evidence — it is only ever set from
+		// server-delivered state; that shape is covered by the durable
+		// engine-trash record instead.)
+		(e as any).noteIdMap.set(file.path, "id-x");
+
+		await e.handleDelete(file);
+
+		expect(crdtDeletes).toHaveLength(0);
+	});
+
+	test("note delete WITH sync evidence still enqueues crdt_delete", async () => {
+		const { e, crdtDeletes } = makeEngine();
+		const file = makeNoteFile("known/synced.md");
+		(e as any).noteIdMap.set(file.path, "id-y");
+		(e as any).setCrdtHead(file.path, "h1");
+		recordSyncEvidence(e, file.path);
+
+		await e.handleDelete(file);
+
+		expect(crdtDeletes).toEqual([file.path]);
+	});
+});

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -293,6 +293,8 @@ describe("SyncEngine.handleDelete", () => {
 		const noteIdMap = new NoteIdMap();
 		noteIdMap.set("Notes/Old.canvas", "id-canvas-del");
 		engine.setNoteIdMap(noteIdMap);
+		// #416 evidence rule: a delete push requires recorded sync evidence.
+		(engine as any).syncState.set("Notes/Old.canvas", { hash: 1 });
 
 		const file = new TFile("Notes/Old.canvas");
 		await engine.handleDelete(file);
@@ -1535,6 +1537,8 @@ describe("SyncEngine offline queue integration", () => {
 		(mockApi.deleteAttachment as jest.Mock).mockRejectedValueOnce(new Error("network"));
 
 		const engine = createEngine();
+		// #416 evidence rule: a delete push requires recorded sync evidence.
+		(engine as any).syncState.set("Notes/Deleted.png", { hash: 1 });
 		const file = new TFile("Notes/Deleted.png");
 
 		await engine.handleDelete(file);
@@ -1872,6 +1876,8 @@ describe("SyncEngine binary push", () => {
 
 	test("binary file delete calls deleteAttachment", async () => {
 		const engine = createEngine();
+		// #416 evidence rule: a delete push requires recorded sync evidence.
+		(engine as any).syncState.set("Assets/old.png", { hash: 1 });
 		const file = new TFile("Assets/old.png");
 
 		await engine.handleDelete(file);


### PR DESCRIPTION
## Why

The 2026-08-12 prod incident (#416): a first sync into a switched vault trashed ~40 freshly-pulled files (replay bookkeeping lost 299 rows → orphan sweep), and the late vault delete events — past the 5-second `remotelyDeleted` echo TTL — were pushed to the server as REAL deletions. 20 notes + 19 attachments were tombstoned in prod (since restored by hand; S3 versioning saved the blobs).

## What

Two independent defense layers in `SyncEngine`:

1. **Durable engine-trash record** (`engineTrashedPaths`): anything `trashRemotelyDeleted` touches is recorded until the delete event consumes it or a file reappears at the path — never expired by a timer. The 5s TTL stays for the plain echo case but is no longer the only line of defense.
2. **Evidence rule**: `handleDelete` refuses to push a delete for a path with no recorded `syncState` entry, with a Loki-visible tripwire (`Delete push REFUSED (no sync evidence)`). Deleting requires proof the server ever knew the path through us. A `crdtHead` counts as evidence (only ever set from server-delivered state).

Failure economics: a false refusal = benign resurrection on the next pull; a false push = data loss. The fence picks the cheap failure.

## Not in this PR

The root trigger — seq-replay bookkeeping losing 299 rows under load — is still open in #416. These layers make that class non-destructive while it's hunted.

## Tests

6 new fence tests (TDD, watched red). 5 existing delete tests gained the sync-evidence arrange step their scenarios always implied. Full suite: 2501 pass.

Refs #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC