### PR TITLE
fix(sync): close every delete-push bypass the post-merge review found

### DIFF
--- a/main.js
+++ b/main.js
@@ -15881,6 +15881,10 @@ var ExplicitFolders = class {
   async add(path) {
     this.set.add(path), await this.persist();
   }
+  /** Drop every marker (vault switch — the set is vault-scoped). */
+  async clear() {
+    this.set.clear(), await this.persist();
+  }
   async delete(path) {
     this.set.delete(path), await this.persist();
   }
@@ -19422,6 +19426,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     this.crdtEnqueue = null;
     /** See CrdtPorts.resetOutbox. */
     this.crdtResetOutbox = null;
+    /** Wired by main.ts to the durable CrdtOpQueue: true when an op for this
+     *  docId is still pending (unsent create/edit). Consulted by the evidence
+     *  rule so a create-then-delete supersedes instead of resurrecting. */
+    this.crdtHasPendingOp = null;
     /** Optional level-triggered check: is the `crdt:` topic JOINED right now?
      *  The `crdt` manager latch above is edge-triggered (set on join via
      *  onCrdtJoined, cleared on disconnect), so it can go STALE — set, but the
@@ -19501,13 +19509,19 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     this.seqRewindFloor = null;
     /** When true, vault delete events are suppressed (used during local wipe). */
     this.suppressDeletes = !1;
-    /** Paths THIS ENGINE trashed (wipe pass, orphan sweep, remote-delete
-     *  apply, recently_deleted convergence). Durable — consumed by
-     *  handleDelete, cleared when the path is recreated — never expired by a
-     *  timer. The 5s `remotelyDeleted` TTL was the 2026-08-12 data-loss seam
-     *  (#416): a mass trash outlives the TTL, the late vault delete events
-     *  look user-made, and the engine pushes them as real server deletions. */
-    this.engineTrashedPaths = /* @__PURE__ */ new Set();
+    /** Per-path count of trashes THIS ENGINE performed (wipe pass, orphan
+     *  sweep, remote-delete apply, recently_deleted convergence). Durable —
+     *  each trash increments, each vault delete event for the path consumes
+     *  one — never expired by a timer and never cleared on recreate. The 5s
+     *  `remotelyDeleted` TTL was the 2026-08-12 data-loss seam (#416): a mass
+     *  trash outlives the TTL and the late delete events push as user deletes.
+     *  Clear-on-recreate was the post-merge review's finding 1: it let the
+     *  late echo of a trash land AFTER a pull recreated the path and push a
+     *  delete against the FRESH note. Counters keep every trash matched 1:1
+     *  with its own event regardless of interleaving; the only leak is a
+     *  crash that eats the event, costing one echo-skipped (resurrectable)
+     *  delete at that path later — the cheap failure. */
+    this.engineTrashedPaths = /* @__PURE__ */ new Map();
     /** Paths modified during a pull that need pushing once pull completes. */
     this.pendingPostPullPushes = /* @__PURE__ */ new Set();
     this.crdtCatchupSince = null;
@@ -19852,6 +19866,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   }
   setCrdtDelete(fn) {
     this.setCrdtPorts({ delete: fn });
+  }
+  setCrdtHasPendingOp(fn) {
+    this.crdtHasPendingOp = fn;
   }
   setCrdtEnqueue(fn) {
     this.setCrdtPorts({ enqueue: fn });
@@ -20354,8 +20371,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  `invalidateIfVaultChanged`) call this — keeping them in lockstep is the
    *  point; a wipe that exists on only one path re-opens #200. */
   async wipePerVaultState() {
-    var _a, _b;
-    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), (_b = this.crdtResetOutbox) == null || _b.call(this), this.lastRelocationTs.clear(), await this.saveData({ lastSync: "" });
+    var _a, _b, _c;
+    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), (_b = this.crdtResetOutbox) == null || _b.call(this), this.lastRelocationTs.clear(), await ((_c = this.explicitFolders) == null ? void 0 : _c.clear()), await this.saveData({ lastSync: "" });
   }
   /** Reset all per-vault sync bookkeeping. Used when the user switches the
    *  active server vault inside the SyncPreviewModal so the next sync starts
@@ -20561,13 +20578,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   }
   // --- Push: local → Engram ---
   /** Handle a vault modify/create event with debounce. */
-  /** A file (re)appeared at `path` — any engine-trash record for it is
-   *  stale and must not swallow a future genuine delete of the new file. */
-  noteRecreatedPath(path) {
-    this.engineTrashedPaths.delete(path);
-  }
   handleModify(file) {
-    if (this.noteRecreatedPath(file.path), this.syncBlocked) {
+    if (this.syncBlocked) {
       devLog().log("sync-blocked", "handleModify short-circuited \u2014 gate closed");
       return;
     }
@@ -20592,29 +20604,41 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     }, this.settings.debounceMs);
     this.debounceTimers.set(armedPath, timer), this.emitStatus();
   }
+  consumeEngineTrash(path) {
+    var _a;
+    let n = (_a = this.engineTrashedPaths.get(path)) != null ? _a : 0;
+    return n <= 0 ? !1 : (n === 1 ? this.engineTrashedPaths.delete(path) : this.engineTrashedPaths.set(path, n - 1), !0);
+  }
   /** Handle a vault delete event. */
   async handleDelete(file) {
-    var _a, _b, _c, _d, _e;
+    var _a, _b, _c, _d, _e, _f, _g;
     if (this.syncBlocked) {
       devLog().log("sync-blocked", "handleDelete short-circuited \u2014 gate closed");
       return;
     }
-    if (!this.ready || this.suppressDeletes || !this.isSyncable(file) || this.shouldIgnore(file.path)) return;
+    if (!this.ready || !this.isSyncable(file) || this.shouldIgnore(file.path)) return;
     let isBinary = this.isBinaryFile(file), existing = this.debounceTimers.get(file.path);
     existing && (this.time.clearTimeout(existing), this.debounceTimers.delete(file.path));
     let crdtNoteId = isBinary ? null : (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(file.path)) != null ? _b : null;
-    crdtNoteId && this.markRecentlyDeleted(crdtNoteId), isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path);
+    isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path);
     let hadSyncEvidence = this.syncState.has((0, import_obsidian24.normalizePath)(file.path));
-    if (this.dropPath((0, import_obsidian24.normalizePath)(file.path), { dropBase: !1 }), this.files.has(file.path, "remotelyDeleted") || this.engineTrashedPaths.has(file.path)) {
-      this.files.clearMarker(file.path, "remotelyDeleted"), this.engineTrashedPaths.delete(file.path), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
+    this.dropPath((0, import_obsidian24.normalizePath)(file.path), { dropBase: !1 });
+    let wasEngineTrash = this.consumeEngineTrash(file.path);
+    if (this.files.has(file.path, "remotelyDeleted") || wasEngineTrash) {
+      this.files.clearMarker(file.path, "remotelyDeleted"), crdtNoteId && this.markRecentlyDeleted(crdtNoteId), rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
       return;
     }
     if (!hadSyncEvidence) {
+      if (crdtNoteId && ((_d = this.crdtHasPendingOp) != null && _d.call(this, crdtNoteId))) {
+        this.markRecentlyDeleted(crdtNoteId), (_e = this.crdtEnqueue) == null || _e.call(this, { kind: "delete", docId: crdtNoteId, path: file.path }), this.isCrdtEligible(file) && await this.teardownCrdtDoc(crdtNoteId), rlog().info("push", `Delete superseded pending create: ${file.path}`);
+        return;
+      }
       rlog().warn("push", `Delete push REFUSED (no sync evidence): ${file.path}`), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
       return;
     }
+    crdtNoteId && this.markRecentlyDeleted(crdtNoteId);
     try {
-      isBinary ? (await this.api.deleteAttachment(file.path), this.goOnline()) : this.isCrdtEligible(file) ? crdtNoteId && ((_d = this.crdtEnqueue) == null || _d.call(this, { kind: "delete", docId: crdtNoteId, path: file.path })) : (await this.api.deleteNote(file.path), this.goOnline()), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
+      isBinary ? (await this.api.deleteAttachment(file.path), this.goOnline()) : this.isCrdtEligible(file) ? crdtNoteId && ((_f = this.crdtEnqueue) == null || _f.call(this, { kind: "delete", docId: crdtNoteId, path: file.path })) : (await this.api.deleteNote(file.path), this.goOnline()), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
     } catch (e) {
       if (isHttpStatus(e, 404)) {
         this.goOnline(), this.isCrdtEligible(file) && crdtNoteId && await this.teardownCrdtDoc(crdtNoteId);
@@ -20625,7 +20649,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         action: "delete",
         kind: isBinary ? "attachment" : "note",
         timestamp: Date.now(),
-        vaultId: (_e = this.settings.vaultId) != null ? _e : void 0
+        vaultId: (_g = this.settings.vaultId) != null ? _g : void 0,
+        // This branch is only reachable past the evidence rule — stamp it
+        // so the queue drain can tell fenced deletes from legacy/pre-fence
+        // entries it must drop (#416 review finding 0).
+        evidenced: !0
       }), this.maybeGoOffline(e);
     }
   }
@@ -20638,9 +20666,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     }
     if (!this.ready || !this.isSyncable(file)) return;
     let isBinary = this.isBinaryFile(file), armed = this.debounceTimers.get(oldPath);
-    if (armed && (this.time.clearTimeout(armed), this.debounceTimers.delete(oldPath), this.emitStatus()), isBinary || (_a = this.noteIdMap) == null || _a.rename(oldPath, file.path), !this.shouldIgnore(oldPath))
+    armed && (this.time.clearTimeout(armed), this.debounceTimers.delete(oldPath), this.emitStatus()), isBinary || (_a = this.noteIdMap) == null || _a.rename(oldPath, file.path);
+    let hadOldEvidence = this.syncState.has((0, import_obsidian24.normalizePath)(oldPath));
+    if (!this.shouldIgnore(oldPath))
       try {
-        isBinary ? (await this.api.deleteAttachment(oldPath), this.goOnline()) : this.isCrdtEligible(file) || (await this.api.deleteNote(oldPath), this.goOnline());
+        isBinary ? hadOldEvidence ? (await this.api.deleteAttachment(oldPath), this.goOnline()) : rlog().warn(
+          "push",
+          `Rename old-leg delete REFUSED (no sync evidence): ${oldPath}`
+        ) : this.isCrdtEligible(file) || (hadOldEvidence ? (await this.api.deleteNote(oldPath), this.goOnline()) : rlog().warn(
+          "push",
+          `Rename old-leg delete REFUSED (no sync evidence): ${oldPath}`
+        ));
       } catch (e) {
         isHttpStatus(e, 404) ? this.goOnline() : (console.error("Engram Sync: failed to delete old path %s", oldPath, e), rlog().error(
           "push",
@@ -20650,7 +20686,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           action: "delete",
           kind: isBinary ? "attachment" : "note",
           timestamp: Date.now(),
-          vaultId: (_b = this.settings.vaultId) != null ? _b : void 0
+          vaultId: (_b = this.settings.vaultId) != null ? _b : void 0,
+          evidenced: hadOldEvidence
         }), this.maybeGoOffline(e));
       }
     isBinary || ((_c = this.baseStore) == null || _c.rename((0, import_obsidian24.normalizePath)(oldPath), (0, import_obsidian24.normalizePath)(file.path)), this.dropPath((0, import_obsidian24.normalizePath)(oldPath), { dropBase: !1 }), this.unconfirmNoteId((_e = (_d = this.noteIdMap) == null ? void 0 : _d.get(file.path)) != null ? _e : null)), this.shouldIgnore(file.path) || await this.pushFile(file);
@@ -21063,7 +21100,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  handleDelete — every sync-applied deletion must route through here, or
    *  its echo-push can tombstone a note recreated at the path since. */
   async trashRemotelyDeleted(file) {
-    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), this.engineTrashedPaths.add(file.path), await this.app.fileManager.trashFile(file);
+    var _a;
+    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), this.engineTrashedPaths.set(file.path, ((_a = this.engineTrashedPaths.get(file.path)) != null ? _a : 0) + 1), await this.app.fileManager.trashFile(file);
   }
   /** Suppress WebSocket echoes for a path for ECHO_COOLDOWN_MS after push. */
   markRecentlyPushed(path) {
@@ -23136,11 +23174,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       if (this.syncBlocked) break;
       try {
         if (entry.action === "delete")
-          try {
-            entry.kind === "attachment" ? await this.api.deleteAttachment(entry.path) : await this.api.deleteNote(entry.path);
-          } catch (e) {
-            if (!isHttpStatus(e, 404)) throw e;
-          }
+          if (!entry.evidenced)
+            rlog().warn(
+              "queue",
+              `Queued delete DROPPED (no evidence stamp): ${entry.path}`
+            );
+          else
+            try {
+              entry.kind === "attachment" ? await this.api.deleteAttachment(entry.path) : await this.api.deleteNote(entry.path);
+            } catch (e) {
+              if (!isHttpStatus(e, 404)) throw e;
+            }
         else if (entry.kind === "attachment") {
           let base64 = entry.contentBase64, mimeType = entry.mimeType, mtime = entry.mtime;
           if (!base64) {
@@ -23152,7 +23196,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             let buffer = await this.app.vault.readBinary(file);
             base64 = arrayBufferToBase64(buffer), mimeType = this.getMimeType(file), mtime = file.stat.mtime / 1e3;
           }
-          await this.api.pushAttachment(entry.path, base64, mimeType, mtime);
+          await this.api.pushAttachment(entry.path, base64, mimeType, mtime), this.stampSyncedRow((0, import_obsidian24.normalizePath)(entry.path), { hash: fnv1a(base64) });
         } else {
           if (entry.crdt && entry.noteId) {
             this.crdt && ((_b = (_a = this.crdtLive) == null ? void 0 : _a.call(this)) != null && _b) && (this.pendingQueueDeliveries.set(entry.noteId, {
@@ -23591,7 +23635,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     }), this.registerInterval(window.setInterval(() => {
       var _a2;
       (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.tick();
-    }, 5e3)), this.syncEngine.setCrdtPorts({
+    }, 5e3)), this.syncEngine.setCrdtHasPendingOp(
+      (docId) => {
+        var _a2, _b2;
+        return (_b2 = (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.all().some((op) => op.docId === docId)) != null ? _b2 : !1;
+      }
+    ), this.syncEngine.setCrdtPorts({
       enqueue: (op) => {
         var _a2, _b2;
         return (_b2 = this.crdtOpQueue) == null ? void 0 : _b2.enqueue({

--- a/main.js
+++ b/main.js
@@ -20621,13 +20621,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       return;
     }
     if (!this.ready || !this.isSyncable(file) || this.shouldIgnore(file.path)) return;
-    let isBinary = this.isBinaryFile(file);
-    if (this.app.vault.getFileByPath(file.path)) {
-      this.consumeEngineTrash(file.path), this.files.clearMarker(file.path, "remotelyDeleted"), rlog().info("vault", `Delete echo for replaced path \u2014 skipped: ${file.path}`);
+    let isBinary = this.isBinaryFile(file), existing = this.debounceTimers.get(file.path);
+    if (existing && (this.time.clearTimeout(existing), this.debounceTimers.delete(file.path)), this.app.vault.getFileByPath(file.path)) {
+      let wasEcho = this.consumeEngineTrash(file.path) || this.files.has(file.path, "remotelyDeleted");
+      this.files.clearMarker(file.path, "remotelyDeleted"), wasEcho ? rlog().info("vault", `Delete echo for replaced path \u2014 skipped: ${file.path}`) : rlog().warn(
+        "vault",
+        `Delete event for reoccupied path SKIPPED (no echo evidence): ${file.path}`
+      );
       return;
     }
-    let existing = this.debounceTimers.get(file.path);
-    existing && (this.time.clearTimeout(existing), this.debounceTimers.delete(file.path));
     let crdtNoteId = isBinary ? null : (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(file.path)) != null ? _b : null;
     isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path);
     let hadSyncEvidence = this.syncState.has((0, import_obsidian24.normalizePath)(file.path));
@@ -20696,9 +20698,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           kind: isBinary ? "attachment" : "note",
           timestamp: Date.now(),
           vaultId: (_b = this.settings.vaultId) != null ? _b : void 0,
-          // The catch is reachable only after an evidenced API call ran
-          // (refused legs never call out), so this is always true.
-          evidenced: !0
+          // Provably equal to `true` today (refused legs never call out),
+          // but kept code-derived so a future throwing edit inside the
+          // refusal legs cannot silently stamp evidence (round-3 review).
+          evidenced: hadOldEvidence
         }), this.maybeGoOffline(e));
       }
     isBinary || ((_c = this.baseStore) == null || _c.rename((0, import_obsidian24.normalizePath)(oldPath), (0, import_obsidian24.normalizePath)(file.path)), this.dropPath((0, import_obsidian24.normalizePath)(oldPath), { dropBase: !1 }), this.unconfirmNoteId((_e = (_d = this.noteIdMap) == null ? void 0 : _d.get(file.path)) != null ? _e : null)), this.shouldIgnore(file.path) || await this.pushFile(file);
@@ -21111,12 +21114,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  handleDelete — every sync-applied deletion must route through here, or
    *  its echo-push can tombstone a note recreated at the path since. */
   async trashRemotelyDeleted(file) {
-    var _a;
-    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), this.engineTrashedPaths.set(file.path, ((_a = this.engineTrashedPaths.get(file.path)) != null ? _a : 0) + 1);
+    var _a, _b;
+    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS);
+    let before = (_a = this.engineTrashedPaths.get(file.path)) != null ? _a : 0;
+    this.engineTrashedPaths.set(file.path, before + 1);
     try {
       await this.app.fileManager.trashFile(file);
     } catch (e) {
-      throw this.consumeEngineTrash(file.path), e;
+      throw ((_b = this.engineTrashedPaths.get(file.path)) != null ? _b : 0) > before && this.consumeEngineTrash(file.path), this.files.clearMarker(file.path, "remotelyDeleted"), e;
     }
   }
   /** Suppress WebSocket echoes for a path for ECHO_COOLDOWN_MS after push. */
@@ -21463,7 +21468,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     var _a;
     if (!this.crdt || !this.crdtCatchupSince || this.isSyncBlocked()) return;
     let normalized = (0, import_obsidian24.normalizePath)(path);
-    if (!this.shouldIgnore(normalized) && !this.isLiveBound(normalized) && !(this.app.vault.getAbstractFileByPath(normalized) instanceof import_obsidian24.TFile) && !this.recentlyDeleted.has(noteId) && !this.queue.hasPendingDelete(normalized, (_a = this.settings.vaultId) != null ? _a : void 0))
+    if (!this.shouldIgnore(normalized) && !this.isLiveBound(normalized) && !(this.app.vault.getAbstractFileByPath(normalized) instanceof import_obsidian24.TFile) && !this.recentlyDeleted.has(noteId) && !this.queue.hasPendingEvidencedDelete(normalized, (_a = this.settings.vaultId) != null ? _a : void 0))
       try {
         this.noteIdMap && this.noteIdMap.pathForId(noteId) !== normalized && (this.noteIdMap.set(normalized, noteId), await this.saveData({ noteIds: this.noteIdMap.toJSON() })), this.confirmNoteId(noteId), await this.catchupViaSeqReplay();
       } catch (e) {
@@ -22085,7 +22090,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   async applyOp(op) {
     var _a, _b, _c, _d, _e, _f;
     if (!op.path) return !1;
-    if (op.kind === "upsert" && (this.recentlyDeleted.has(op.id) || this.queue.hasPendingDelete(
+    if (op.kind === "upsert" && (this.recentlyDeleted.has(op.id) || this.queue.hasPendingEvidencedDelete(
       (0, import_obsidian24.normalizePath)(op.path),
       (_a = this.settings.vaultId) != null ? _a : void 0
     )))
@@ -23654,12 +23659,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     }, 5e3)), this.syncEngine.setCrdtHasPendingOp(
       (docId) => {
         var _a2, _b2;
-        return (_b2 = (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.all().some(
-          (op) => {
-            var _a3;
-            return op.docId === docId && op.kind === "create" && op.vaultId === ((_a3 = this.settings.vaultId) != null ? _a3 : null);
-          }
-        )) != null ? _b2 : !1;
+        return (_b2 = (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.all().some((op) => {
+          var _a3, _b3;
+          if (op.docId !== docId || op.kind !== "create") return !1;
+          let owner = (_a3 = op.vaultId) != null ? _a3 : null;
+          return owner === null || owner === ((_b3 = this.settings.vaultId) != null ? _b3 : null);
+        })) != null ? _b2 : !1;
       }
     ), this.syncEngine.setCrdtPorts({
       enqueue: (op) => {

--- a/main.js
+++ b/main.js
@@ -15881,10 +15881,6 @@ var ExplicitFolders = class {
   async add(path) {
     this.set.add(path), await this.persist();
   }
-  /** Drop every marker (vault switch — the set is vault-scoped). */
-  async clear() {
-    this.set.clear(), await this.persist();
-  }
   async delete(path) {
     this.set.delete(path), await this.persist();
   }
@@ -18883,6 +18879,14 @@ var OfflineQueue = class {
     var _a;
     return ((_a = this.entries.get(dedupKey(path, vaultId))) == null ? void 0 : _a.action) === "delete";
   }
+  /** Like hasPendingDelete, but only for entries the drain will actually
+   *  PUSH. Unevidenced deletes are predestined to be dropped by the #416
+   *  drain gate — letting them suppress catch-up recreation would hide a
+   *  note behind a delete that never happens. */
+  hasPendingEvidencedDelete(path, vaultId) {
+    let entry = this.entries.get(dedupKey(path, vaultId));
+    return (entry == null ? void 0 : entry.action) === "delete" && entry.evidenced === !0;
+  }
   /** Remove a path's queued work immediately, without waiting on a persist
    *  round trip. `dequeue` awaits persistence, which is right after a
    *  successful sync but wrong for a rename or a vault switch: the caller needs
@@ -20231,7 +20235,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       rlog().info("crdt", `empty-materialize skip (recent local delete): ${normalized}`);
       return;
     }
-    if (this.queue.hasPendingDelete(normalized, (_a = this.settings.vaultId) != null ? _a : void 0)) {
+    if (this.queue.hasPendingEvidencedDelete(normalized, (_a = this.settings.vaultId) != null ? _a : void 0)) {
       rlog().info("crdt", `empty-materialize skip (delete queued): ${normalized}`);
       return;
     }
@@ -20372,7 +20376,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  point; a wipe that exists on only one path re-opens #200. */
   async wipePerVaultState() {
     var _a, _b, _c;
-    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), (_b = this.crdtResetOutbox) == null || _b.call(this), this.lastRelocationTs.clear(), await ((_c = this.explicitFolders) == null ? void 0 : _c.clear()), await this.saveData({ lastSync: "" });
+    this.syncState.clear(), this.lastSync = "", this.catchupSeq = 0, this.catchupId = null, this.manifestSeq = 0, this.lastValidatorRewind = null, (_a = this.noteIdMap) == null || _a.clear(), this.clearConfirmedNoteIds(), (_b = this.crdtResetOutbox) == null || _b.call(this), this.lastRelocationTs.clear(), this.engineTrashedPaths.clear(), await ((_c = this.explicitFolders) == null ? void 0 : _c.replaceAll([])), await this.saveData({ lastSync: "" });
   }
   /** Reset all per-vault sync bookkeeping. Used when the user switches the
    *  active server vault inside the SyncPreviewModal so the next sync starts
@@ -20617,7 +20621,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       return;
     }
     if (!this.ready || !this.isSyncable(file) || this.shouldIgnore(file.path)) return;
-    let isBinary = this.isBinaryFile(file), existing = this.debounceTimers.get(file.path);
+    let isBinary = this.isBinaryFile(file);
+    if (this.app.vault.getFileByPath(file.path)) {
+      this.consumeEngineTrash(file.path), this.files.clearMarker(file.path, "remotelyDeleted"), rlog().info("vault", `Delete echo for replaced path \u2014 skipped: ${file.path}`);
+      return;
+    }
+    let existing = this.debounceTimers.get(file.path);
     existing && (this.time.clearTimeout(existing), this.debounceTimers.delete(file.path));
     let crdtNoteId = isBinary ? null : (_b = (_a = this.noteIdMap) == null ? void 0 : _a.get(file.path)) != null ? _b : null;
     isBinary || (_c = this.noteIdMap) == null || _c.delete(file.path);
@@ -20687,7 +20696,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           kind: isBinary ? "attachment" : "note",
           timestamp: Date.now(),
           vaultId: (_b = this.settings.vaultId) != null ? _b : void 0,
-          evidenced: hadOldEvidence
+          // The catch is reachable only after an evidenced API call ran
+          // (refused legs never call out), so this is always true.
+          evidenced: !0
         }), this.maybeGoOffline(e));
       }
     isBinary || ((_c = this.baseStore) == null || _c.rename((0, import_obsidian24.normalizePath)(oldPath), (0, import_obsidian24.normalizePath)(file.path)), this.dropPath((0, import_obsidian24.normalizePath)(oldPath), { dropBase: !1 }), this.unconfirmNoteId((_e = (_d = this.noteIdMap) == null ? void 0 : _d.get(file.path)) != null ? _e : null)), this.shouldIgnore(file.path) || await this.pushFile(file);
@@ -21101,7 +21112,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  its echo-push can tombstone a note recreated at the path since. */
   async trashRemotelyDeleted(file) {
     var _a;
-    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), this.engineTrashedPaths.set(file.path, ((_a = this.engineTrashedPaths.get(file.path)) != null ? _a : 0) + 1), await this.app.fileManager.trashFile(file);
+    this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS), this.engineTrashedPaths.set(file.path, ((_a = this.engineTrashedPaths.get(file.path)) != null ? _a : 0) + 1);
+    try {
+      await this.app.fileManager.trashFile(file);
+    } catch (e) {
+      throw this.consumeEngineTrash(file.path), e;
+    }
   }
   /** Suppress WebSocket echoes for a path for ECHO_COOLDOWN_MS after push. */
   markRecentlyPushed(path) {
@@ -23638,7 +23654,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     }, 5e3)), this.syncEngine.setCrdtHasPendingOp(
       (docId) => {
         var _a2, _b2;
-        return (_b2 = (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.all().some((op) => op.docId === docId)) != null ? _b2 : !1;
+        return (_b2 = (_a2 = this.crdtOpQueue) == null ? void 0 : _a2.all().some(
+          (op) => {
+            var _a3;
+            return op.docId === docId && op.kind === "create" && op.vaultId === ((_a3 = this.settings.vaultId) != null ? _a3 : null);
+          }
+        )) != null ? _b2 : !1;
       }
     ), this.syncEngine.setCrdtPorts({
       enqueue: (op) => {

--- a/src/explicit-folders.ts
+++ b/src/explicit-folders.ts
@@ -46,12 +46,6 @@ export class ExplicitFolders {
 		await this.persist();
 	}
 
-	/** Drop every marker (vault switch — the set is vault-scoped). */
-	async clear(): Promise<void> {
-		this.set.clear();
-		await this.persist();
-	}
-
 	async delete(path: string): Promise<void> {
 		this.set.delete(path);
 		await this.persist();

--- a/src/explicit-folders.ts
+++ b/src/explicit-folders.ts
@@ -46,6 +46,12 @@ export class ExplicitFolders {
 		await this.persist();
 	}
 
+	/** Drop every marker (vault switch — the set is vault-scoped). */
+	async clear(): Promise<void> {
+		this.set.clear();
+		await this.persist();
+	}
+
 	async delete(path: string): Promise<void> {
 		this.set.delete(path);
 		await this.persist();

--- a/src/main.ts
+++ b/src/main.ts
@@ -583,8 +583,21 @@ export default class EngramSyncPlugin extends Plugin {
 		// Wire the SyncEngine's durable create/delete enqueue hook to the queue.
 		// The pending-op probe feeds the evidence rule's supersede exception: a
 		// create-then-delete must coalesce in-queue, not resurrect (#416 review).
+		// CREATE-only and CURRENT-vault-only (pre-merge review of #419): the
+		// supersede branch's safety argument — "the delete either supersedes the
+		// queued create or no-ops server-side" — collapses for a pending EDIT or
+		// a foreign-vault op, where the enqueued delete could reach a note the
+		// server genuinely owns despite this device having no sync evidence.
 		this.syncEngine.setCrdtHasPendingOp(
-			(docId) => this.crdtOpQueue?.all().some((op) => op.docId === docId) ?? false,
+			(docId) =>
+				this.crdtOpQueue
+					?.all()
+					.some(
+						(op) =>
+							op.docId === docId &&
+							op.kind === "create" &&
+							op.vaultId === (this.settings.vaultId ?? null),
+					) ?? false,
 		);
 		this.syncEngine.setCrdtPorts({
 			enqueue: (op) =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -581,6 +581,11 @@ export default class EngramSyncPlugin extends Plugin {
 		// until joined). registerInterval auto-clears on unload.
 		this.registerInterval(window.setInterval(() => void this.crdtOpQueue?.tick(), 5000));
 		// Wire the SyncEngine's durable create/delete enqueue hook to the queue.
+		// The pending-op probe feeds the evidence rule's supersede exception: a
+		// create-then-delete must coalesce in-queue, not resurrect (#416 review).
+		this.syncEngine.setCrdtHasPendingOp(
+			(docId) => this.crdtOpQueue?.all().some((op) => op.docId === docId) ?? false,
+		);
 		this.syncEngine.setCrdtPorts({
 			enqueue: (op) =>
 				this.crdtOpQueue?.enqueue({

--- a/src/main.ts
+++ b/src/main.ts
@@ -590,14 +590,16 @@ export default class EngramSyncPlugin extends Plugin {
 		// server genuinely owns despite this device having no sync evidence.
 		this.syncEngine.setCrdtHasPendingOp(
 			(docId) =>
-				this.crdtOpQueue
-					?.all()
-					.some(
-						(op) =>
-							op.docId === docId &&
-							op.kind === "create" &&
-							op.vaultId === (this.settings.vaultId ?? null),
-					) ?? false,
+				this.crdtOpQueue?.all().some((op) => {
+					if (op.docId !== docId || op.kind !== "create") return false;
+					// Mirror the queue's OWN delivery semantics (dropIfForeignVault):
+					// an unstamped/null owner means "current vault" and WILL be
+					// delivered — the probe must count it, or a delete for such a
+					// doc is refused while its queued create still fires (round-3
+					// review finding 1).
+					const owner = op.vaultId ?? null;
+					return owner === null || owner === (this.settings.vaultId ?? null);
+				}) ?? false,
 		);
 		this.syncEngine.setCrdtPorts({
 			enqueue: (op) =>

--- a/src/offline-queue.ts
+++ b/src/offline-queue.ts
@@ -116,6 +116,15 @@ export class OfflineQueue {
 		return this.entries.get(dedupKey(path, vaultId))?.action === "delete";
 	}
 
+	/** Like hasPendingDelete, but only for entries the drain will actually
+	 *  PUSH. Unevidenced deletes are predestined to be dropped by the #416
+	 *  drain gate — letting them suppress catch-up recreation would hide a
+	 *  note behind a delete that never happens. */
+	hasPendingEvidencedDelete(path: string, vaultId?: string): boolean {
+		const entry = this.entries.get(dedupKey(path, vaultId));
+		return entry?.action === "delete" && entry.evidenced === true;
+	}
+
 	/** Remove a path's queued work immediately, without waiting on a persist
 	 *  round trip. `dequeue` awaits persistence, which is right after a
 	 *  successful sync but wrong for a rename or a vault switch: the caller needs

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2398,23 +2398,40 @@ export class SyncEngine {
 
 		const isBinary = this.isBinaryFile(file);
 
-		// STALE-ECHO GUARD (#419 pre-merge review finding 5): a live file at
-		// this path right now means this delete event is for a REPLACED file
-		// (trash → recreate → late echo). Running the bookkeeping below would
-		// unmap, evidence-drop, and tombstone the FRESH note. Consume the trash
-		// record the event matches (if any) and stop.
-		if (this.app.vault.getFileByPath(file.path)) {
-			this.consumeEngineTrash(file.path);
-			this.files.clearMarker(file.path, "remotelyDeleted");
-			rlog().info("vault", `Delete echo for replaced path — skipped: ${file.path}`);
-			return;
-		}
-
-		// Cancel any pending push for this file
+		// Cancel any pending push for this path FIRST — even for echo events.
+		// A timer armed for the trashed file must die with it; surviving the
+		// early-return below, it would fire against whatever now occupies the
+		// path and push partial mid-materialize content (round-3 finding 3).
 		const existing = this.debounceTimers.get(file.path);
 		if (existing) {
 			this.time.clearTimeout(existing);
 			this.debounceTimers.delete(file.path);
+		}
+
+		// STALE-ECHO GUARD (#419 reviews, rounds 2+3): a live file at this path
+		// right now means this delete event is for a REPLACED file. Running the
+		// bookkeeping below would unmap, evidence-drop, and tombstone the FRESH
+		// note, so we stop here either way — but the two causes are logged
+		// apart: consuming an engine-trash record (or live echo marker) is the
+		// expected trash→recreate→late-echo shape; NO echo evidence means an
+		// external flow (git checkout, another sync tool) deleted-and-replaced
+		// the path, and skipping keeps the safe direction (the old server row
+		// survives and resurrects/conflicts on pull, vs. path/id-ambiguous
+		// bookkeeping that could delete the REPLACEMENT). The distinct warn is
+		// the tripwire if that class turns real in the field.
+		if (this.app.vault.getFileByPath(file.path)) {
+			const wasEcho =
+				this.consumeEngineTrash(file.path) || this.files.has(file.path, "remotelyDeleted");
+			this.files.clearMarker(file.path, "remotelyDeleted");
+			if (wasEcho) {
+				rlog().info("vault", `Delete echo for replaced path — skipped: ${file.path}`);
+			} else {
+				rlog().warn(
+					"vault",
+					`Delete event for reoccupied path SKIPPED (no echo evidence): ${file.path}`,
+				);
+			}
+			return;
 		}
 
 		// Resolve the note_id BEFORE clearing the map (removeDoc/reset below need
@@ -2657,9 +2674,10 @@ export class SyncEngine {
 						kind: isBinary ? "attachment" : "note",
 						timestamp: Date.now(),
 						vaultId: this.settings.vaultId ?? undefined,
-						// The catch is reachable only after an evidenced API call ran
-						// (refused legs never call out), so this is always true.
-						evidenced: true,
+						// Provably equal to `true` today (refused legs never call out),
+						// but kept code-derived so a future throwing edit inside the
+						// refusal legs cannot silently stamp evidence (round-3 review).
+						evidenced: hadOldEvidence,
 					});
 					this.maybeGoOffline(e);
 				}
@@ -3617,13 +3635,20 @@ export class SyncEngine {
 		this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS);
 		// Increment BEFORE the trash (Obsidian can dispatch the delete event
 		// during the await), but roll back on a throw: a trash that failed left
-		// the file in place, and a stranded counter would consume the user's
-		// NEXT genuine delete of it (#419 pre-merge review finding 2).
-		this.engineTrashedPaths.set(file.path, (this.engineTrashedPaths.get(file.path) ?? 0) + 1);
+		// the file in place, and stranded echo state (counter OR the 5s marker)
+		// would swallow the user's NEXT genuine delete of it (#419 reviews,
+		// rounds 2+3). The rollback is conditional on our own increment still
+		// being unconsumed — if the partial trash's delete event already fired
+		// during the await, decrementing again would steal a sibling counter.
+		const before = this.engineTrashedPaths.get(file.path) ?? 0;
+		this.engineTrashedPaths.set(file.path, before + 1);
 		try {
 			await this.app.fileManager.trashFile(file);
 		} catch (e) {
-			this.consumeEngineTrash(file.path);
+			if ((this.engineTrashedPaths.get(file.path) ?? 0) > before) {
+				this.consumeEngineTrash(file.path);
+			}
+			this.files.clearMarker(file.path, "remotelyDeleted");
 			throw e;
 		}
 	}
@@ -4290,7 +4315,8 @@ export class SyncEngine {
 		// offline queue. The seq replay's applyOp re-checks these per op, but the
 		// early return also avoids a pointless replay for a note we're deleting.
 		if (this.recentlyDeleted.has(noteId)) return;
-		if (this.queue.hasPendingDelete(normalized, this.settings.vaultId ?? undefined)) return;
+		if (this.queue.hasPendingEvidencedDelete(normalized, this.settings.vaultId ?? undefined))
+			return;
 		try {
 			// Learn + persist the id->path mapping (discovery source, like catchup).
 			if (this.noteIdMap && this.noteIdMap.pathForId(noteId) !== normalized) {
@@ -5578,7 +5604,7 @@ export class SyncEngine {
 		if (
 			op.kind === "upsert" &&
 			(this.recentlyDeleted.has(op.id) ||
-				this.queue.hasPendingDelete(
+				this.queue.hasPendingEvidencedDelete(
 					normalizePath(op.path),
 					this.settings.vaultId ?? undefined,
 				))

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1651,7 +1651,7 @@ export class SyncEngine {
 			rlog().info("crdt", `empty-materialize skip (recent local delete): ${normalized}`);
 			return;
 		}
-		if (this.queue.hasPendingDelete(normalized, this.settings.vaultId ?? undefined)) {
+		if (this.queue.hasPendingEvidencedDelete(normalized, this.settings.vaultId ?? undefined)) {
 			rlog().info("crdt", `empty-materialize skip (delete queued): ${normalized}`);
 			return;
 		}
@@ -1980,10 +1980,15 @@ export class SyncEngine {
 		// id in the new vault. Living here (not just resetForVaultChange) keeps
 		// BOTH vault-change paths in lockstep, per this method's contract.
 		this.lastRelocationTs.clear();
+		// Engine-trash counters are path-keyed and therefore vault-scoped: a
+		// counter stranded in the OLD vault (event eaten by a throw or a closed
+		// gate) must not consume a same-path delete in the NEW one (#419
+		// pre-merge review finding 4).
+		this.engineTrashedPaths.clear();
 		// Folder markers are vault-scoped too: a stale set after a switch lets
 		// handleFolderDelete push marker deletes against the NEW vault (post-
 		// merge review finding 8 — data-safe but cross-vault noise).
-		await this.explicitFolders?.clear();
+		await this.explicitFolders?.replaceAll([]);
 		await this.saveData({ lastSync: "" });
 	}
 
@@ -2393,6 +2398,18 @@ export class SyncEngine {
 
 		const isBinary = this.isBinaryFile(file);
 
+		// STALE-ECHO GUARD (#419 pre-merge review finding 5): a live file at
+		// this path right now means this delete event is for a REPLACED file
+		// (trash → recreate → late echo). Running the bookkeeping below would
+		// unmap, evidence-drop, and tombstone the FRESH note. Consume the trash
+		// record the event matches (if any) and stop.
+		if (this.app.vault.getFileByPath(file.path)) {
+			this.consumeEngineTrash(file.path);
+			this.files.clearMarker(file.path, "remotelyDeleted");
+			rlog().info("vault", `Delete echo for replaced path — skipped: ${file.path}`);
+			return;
+		}
+
 		// Cancel any pending push for this file
 		const existing = this.debounceTimers.get(file.path);
 		if (existing) {
@@ -2575,7 +2592,10 @@ export class SyncEngine {
 		// oldPath this device has no standing to issue it (the incident's
 		// lost-bookkeeping state re-enters through renames otherwise). A skipped
 		// old-leg delete costs a stale server copy that the next pull surfaces;
-		// a wrong one deletes another device's data.
+		// a wrong one deletes another device's data. Known accepted cost (#419
+		// pre-merge review): attachments synced before attachment stamping
+		// existed have no row, so their first rename leaves the old server path
+		// behind until a pull reconciles it — safe-direction, self-healing.
 		const hadOldEvidence = this.syncState.has(normalizePath(oldPath));
 		if (!this.shouldIgnore(oldPath)) {
 			try {
@@ -2637,7 +2657,9 @@ export class SyncEngine {
 						kind: isBinary ? "attachment" : "note",
 						timestamp: Date.now(),
 						vaultId: this.settings.vaultId ?? undefined,
-						evidenced: hadOldEvidence,
+						// The catch is reachable only after an evidenced API call ran
+						// (refused legs never call out), so this is always true.
+						evidenced: true,
 					});
 					this.maybeGoOffline(e);
 				}
@@ -3593,8 +3615,17 @@ export class SyncEngine {
 	 *  its echo-push can tombstone a note recreated at the path since. */
 	private async trashRemotelyDeleted(file: TAbstractFile): Promise<void> {
 		this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS);
+		// Increment BEFORE the trash (Obsidian can dispatch the delete event
+		// during the await), but roll back on a throw: a trash that failed left
+		// the file in place, and a stranded counter would consume the user's
+		// NEXT genuine delete of it (#419 pre-merge review finding 2).
 		this.engineTrashedPaths.set(file.path, (this.engineTrashedPaths.get(file.path) ?? 0) + 1);
-		await this.app.fileManager.trashFile(file);
+		try {
+			await this.app.fileManager.trashFile(file);
+		} catch (e) {
+			this.consumeEngineTrash(file.path);
+			throw e;
+		}
 	}
 
 	/** Suppress WebSocket echoes for a path for ECHO_COOLDOWN_MS after push. */
@@ -7718,6 +7749,15 @@ export class SyncEngine {
 					// evidence stamp; replaying them blind re-runs the incident
 					// around the handleDelete fence. Drop them loudly: the server
 					// copy survives and the next pull reconciles.
+					//
+					// DELIBERATE migration cost (#419 pre-merge review): a LEGIT
+					// delete queued by the one release that had the evidence rule
+					// but not this stamp is indistinguishable from a poisoned entry
+					// and gets dropped too — the deleted file resurrects once and
+					// the user deletes it again. Poisoned entries and legit ones
+					// cannot be told apart retroactively (both dropped their
+					// syncState at delete time); dropping is the side whose failure
+					// is recoverable.
 					if (!entry.evidenced) {
 						rlog().warn(
 							"queue",

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1063,6 +1063,15 @@ export class SyncEngine {
 	/** See CrdtPorts.resetOutbox. */
 	private crdtResetOutbox: (() => void) | null = null;
 
+	/** Wired by main.ts to the durable CrdtOpQueue: true when an op for this
+	 *  docId is still pending (unsent create/edit). Consulted by the evidence
+	 *  rule so a create-then-delete supersedes instead of resurrecting. */
+	private crdtHasPendingOp: ((docId: string) => boolean) | null = null;
+
+	setCrdtHasPendingOp(fn: ((docId: string) => boolean) | null): void {
+		this.crdtHasPendingOp = fn;
+	}
+
 	setCrdtEnqueue(
 		fn: ((op: { kind: "create" | "delete"; docId: string; path: string }) => void) | null,
 	): void {
@@ -1971,6 +1980,10 @@ export class SyncEngine {
 		// id in the new vault. Living here (not just resetForVaultChange) keeps
 		// BOTH vault-change paths in lockstep, per this method's contract.
 		this.lastRelocationTs.clear();
+		// Folder markers are vault-scoped too: a stale set after a switch lets
+		// handleFolderDelete push marker deletes against the NEW vault (post-
+		// merge review finding 8 — data-safe but cross-vault noise).
+		await this.explicitFolders?.clear();
 		await this.saveData({ lastSync: "" });
 	}
 
@@ -2257,14 +2270,7 @@ export class SyncEngine {
 	// --- Push: local → Engram ---
 
 	/** Handle a vault modify/create event with debounce. */
-	/** A file (re)appeared at `path` — any engine-trash record for it is
-	 *  stale and must not swallow a future genuine delete of the new file. */
-	noteRecreatedPath(path: string): void {
-		this.engineTrashedPaths.delete(path);
-	}
-
 	handleModify(file: TAbstractFile): void {
-		this.noteRecreatedPath(file.path);
 		if (this.syncBlocked) {
 			devLog().log("sync-blocked", "handleModify short-circuited — gate closed");
 			return;
@@ -2348,13 +2354,27 @@ export class SyncEngine {
 	/** When true, vault delete events are suppressed (used during local wipe). */
 	suppressDeletes = false;
 
-	/** Paths THIS ENGINE trashed (wipe pass, orphan sweep, remote-delete
-	 *  apply, recently_deleted convergence). Durable — consumed by
-	 *  handleDelete, cleared when the path is recreated — never expired by a
-	 *  timer. The 5s `remotelyDeleted` TTL was the 2026-08-12 data-loss seam
-	 *  (#416): a mass trash outlives the TTL, the late vault delete events
-	 *  look user-made, and the engine pushes them as real server deletions. */
-	private readonly engineTrashedPaths = new Set<string>();
+	/** Per-path count of trashes THIS ENGINE performed (wipe pass, orphan
+	 *  sweep, remote-delete apply, recently_deleted convergence). Durable —
+	 *  each trash increments, each vault delete event for the path consumes
+	 *  one — never expired by a timer and never cleared on recreate. The 5s
+	 *  `remotelyDeleted` TTL was the 2026-08-12 data-loss seam (#416): a mass
+	 *  trash outlives the TTL and the late delete events push as user deletes.
+	 *  Clear-on-recreate was the post-merge review's finding 1: it let the
+	 *  late echo of a trash land AFTER a pull recreated the path and push a
+	 *  delete against the FRESH note. Counters keep every trash matched 1:1
+	 *  with its own event regardless of interleaving; the only leak is a
+	 *  crash that eats the event, costing one echo-skipped (resurrectable)
+	 *  delete at that path later — the cheap failure. */
+	private readonly engineTrashedPaths = new Map<string, number>();
+
+	private consumeEngineTrash(path: string): boolean {
+		const n = this.engineTrashedPaths.get(path) ?? 0;
+		if (n <= 0) return false;
+		if (n === 1) this.engineTrashedPaths.delete(path);
+		else this.engineTrashedPaths.set(path, n - 1);
+		return true;
+	}
 
 	/** Handle a vault delete event. */
 	async handleDelete(file: TAbstractFile): Promise<void> {
@@ -2363,7 +2383,11 @@ export class SyncEngine {
 			return;
 		}
 		if (!this.ready) return;
-		if (this.suppressDeletes) return;
+		// NOTE: no suppressDeletes early-return here (post-merge review finding
+		// 4): every wipe-pass trash is in engineTrashedPaths, and consuming the
+		// record DURING the suppression window keeps the counter matched 1:1
+		// with its event. The early return stranded permanent entries that later
+		// swallowed genuine deletes at the same path.
 		if (!this.isSyncable(file)) return;
 		if (this.shouldIgnore(file.path)) return;
 
@@ -2379,14 +2403,6 @@ export class SyncEngine {
 		// Resolve the note_id BEFORE clearing the map (removeDoc/reset below need
 		// it to tear down the right CRDT doc, keyed by id not path).
 		const crdtNoteId = !isBinary ? (this.noteIdMap?.get(file.path) ?? null) : null;
-
-		// Tombstone the id BEFORE clearing the mapping and issuing the delete, so a
-		// racing catch-up head map (which still lists the not-yet-committed delete)
-		// or a late fan-out cannot resurrect it. Covers every exit path below
-		// (socket delete, REST delete, remote-echo skip, offline enqueue). Marked
-		// on any known id, regardless of which send path runs.
-
-		if (crdtNoteId) this.markRecentlyDeleted(crdtNoteId);
 
 		// Clear the file's note_id mapping — the vault file is genuinely gone,
 		// so a note later recreated at this path must mint a fresh id rather
@@ -2411,12 +2427,15 @@ export class SyncEngine {
 		// (replace-remote wipe→re-push, delete→recreate) and tombstones the
 		// FRESH note. Local bookkeeping above still ran; mirror the CRDT
 		// teardown the push path would have done and stop.
-		if (
-			this.files.has(file.path, "remotelyDeleted") ||
-			this.engineTrashedPaths.has(file.path)
-		) {
+		// Consume BEFORE the || — inside the 5s marker window the short-circuit
+		// would strand the counter entry, and a stranded entry later swallows a
+		// genuine delete at the path (the wipe-window leak, review finding 4).
+		const wasEngineTrash = this.consumeEngineTrash(file.path);
+		if (this.files.has(file.path, "remotelyDeleted") || wasEngineTrash) {
 			this.files.clearMarker(file.path, "remotelyDeleted");
-			this.engineTrashedPaths.delete(file.path);
+			// A converged REMOTE delete: tombstone the id so a racing catch-up or
+			// late fan-out cannot resurrect it (delete-wins, backend #970).
+			if (crdtNoteId) this.markRecentlyDeleted(crdtNoteId);
 			rlog().info("vault", `Delete echo skip (remote-applied): ${file.path}`);
 			if (this.isCrdtEligible(file) && crdtNoteId) {
 				await this.teardownCrdtDoc(crdtNoteId);
@@ -2432,12 +2451,33 @@ export class SyncEngine {
 		// false refusal is benign resurrection on the next pull; cost of a
 		// false push is data loss. Local bookkeeping above already ran.
 		if (!hadSyncEvidence) {
+			// Exception: a crdt_create for this id still PENDING in the durable op
+			// queue means the server may be about to learn the note — enqueue the
+			// delete so the queue's docId coalescing supersedes the create (the
+			// pre-fence test_10 semantics). Harmless even if the create already
+			// fired: a delete for a never-evidenced id either supersedes in-queue
+			// or terminally no-ops server-side. Without this, a create-then-delete
+			// note resurrects when the queued create fires (review finding 5).
+			if (crdtNoteId && this.crdtHasPendingOp?.(crdtNoteId)) {
+				this.markRecentlyDeleted(crdtNoteId);
+				this.crdtEnqueue?.({ kind: "delete", docId: crdtNoteId, path: file.path });
+				if (this.isCrdtEligible(file)) await this.teardownCrdtDoc(crdtNoteId);
+				rlog().info("push", `Delete superseded pending create: ${file.path}`);
+				return;
+			}
+			// Pure refusal: deliberately NO markRecentlyDeleted — the documented
+			// remedy for a wrong refusal is next-pull resurrection, and the
+			// delete-wins tombstone would block exactly that for 60s (finding 7).
 			rlog().warn("push", `Delete push REFUSED (no sync evidence): ${file.path}`);
 			if (this.isCrdtEligible(file) && crdtNoteId) {
 				await this.teardownCrdtDoc(crdtNoteId);
 			}
 			return;
 		}
+
+		// Tombstone the id BEFORE clearing the mapping and issuing the delete, so
+		// a racing catch-up head map or late fan-out cannot resurrect it.
+		if (crdtNoteId) this.markRecentlyDeleted(crdtNoteId);
 
 		try {
 			if (isBinary) {
@@ -2489,6 +2529,10 @@ export class SyncEngine {
 				kind: isBinary ? "attachment" : "note",
 				timestamp: Date.now(),
 				vaultId: this.settings.vaultId ?? undefined,
+				// This branch is only reachable past the evidence rule — stamp it
+				// so the queue drain can tell fenced deletes from legacy/pre-fence
+				// entries it must drop (#416 review finding 0).
+				evidenced: true,
 			});
 			this.maybeGoOffline(e);
 		}
@@ -2525,12 +2569,26 @@ export class SyncEngine {
 			this.noteIdMap?.rename(oldPath, file.path);
 		}
 
-		// Delete old path if it wasn't ignored
+		// Delete old path if it wasn't ignored.
+		// EVIDENCE RULE (#416, review finding 3): the old-leg delete is a real
+		// server deletion keyed by path — without recorded sync evidence for
+		// oldPath this device has no standing to issue it (the incident's
+		// lost-bookkeeping state re-enters through renames otherwise). A skipped
+		// old-leg delete costs a stale server copy that the next pull surfaces;
+		// a wrong one deletes another device's data.
+		const hadOldEvidence = this.syncState.has(normalizePath(oldPath));
 		if (!this.shouldIgnore(oldPath)) {
 			try {
 				if (isBinary) {
-					await this.api.deleteAttachment(oldPath);
-					this.goOnline();
+					if (hadOldEvidence) {
+						await this.api.deleteAttachment(oldPath);
+						this.goOnline();
+					} else {
+						rlog().warn(
+							"push",
+							`Rename old-leg delete REFUSED (no sync evidence): ${oldPath}`,
+						);
+					}
 				} else if (this.isCrdtEligible(file)) {
 					// Phase E2 (rename-as-move): NO tombstone (markdown AND canvas since
 					// #306 — a rename keeps the extension, so gating on the new file's
@@ -2544,11 +2602,16 @@ export class SyncEngine {
 					// carried: the #970 delete-wins window could eat a rename as a
 					// recreate-after-delete, and the delete+create pair could
 					// coalesce on the docId-keyed CrdtOpQueue (the test_10 class).
-				} else {
+				} else if (hadOldEvidence) {
 					// Defensive fallback (unreachable for current syncable text — md +
 					// canvas both rename-as-move above; kept for a future REST-only type).
 					await this.api.deleteNote(oldPath);
 					this.goOnline();
+				} else {
+					rlog().warn(
+						"push",
+						`Rename old-leg delete REFUSED (no sync evidence): ${oldPath}`,
+					);
 				}
 				// Task 6 (note_id-keyed CRDT): a rename must NOT tear down the CRDT
 				// doc. Its key is now the note's stable note_id (unchanged by a
@@ -2574,6 +2637,7 @@ export class SyncEngine {
 						kind: isBinary ? "attachment" : "note",
 						timestamp: Date.now(),
 						vaultId: this.settings.vaultId ?? undefined,
+						evidenced: hadOldEvidence,
 					});
 					this.maybeGoOffline(e);
 				}
@@ -3529,7 +3593,7 @@ export class SyncEngine {
 	 *  its echo-push can tombstone a note recreated at the path since. */
 	private async trashRemotelyDeleted(file: TAbstractFile): Promise<void> {
 		this.files.mark(file.path, "remotelyDeleted", ECHO_COOLDOWN_MS);
-		this.engineTrashedPaths.add(file.path);
+		this.engineTrashedPaths.set(file.path, (this.engineTrashedPaths.get(file.path) ?? 0) + 1);
 		await this.app.fileManager.trashFile(file);
 	}
 
@@ -7648,15 +7712,28 @@ export class SyncEngine {
 			if (this.syncBlocked) break;
 			try {
 				if (entry.action === "delete") {
-					try {
-						if (entry.kind === "attachment") {
-							await this.api.deleteAttachment(entry.path);
-						} else {
-							await this.api.deleteNote(entry.path);
+					// FENCE (#416 review finding 0): the drain is a delete-push path
+					// too. Entries persisted before the fence shipped (or by a
+					// pre-fence plugin — the incident's poisoned queues) carry no
+					// evidence stamp; replaying them blind re-runs the incident
+					// around the handleDelete fence. Drop them loudly: the server
+					// copy survives and the next pull reconciles.
+					if (!entry.evidenced) {
+						rlog().warn(
+							"queue",
+							`Queued delete DROPPED (no evidence stamp): ${entry.path}`,
+						);
+					} else {
+						try {
+							if (entry.kind === "attachment") {
+								await this.api.deleteAttachment(entry.path);
+							} else {
+								await this.api.deleteNote(entry.path);
+							}
+						} catch (e) {
+							// 404 means already deleted — dequeue and continue
+							if (!isHttpStatus(e, 404)) throw e;
 						}
-					} catch (e) {
-						// 404 means already deleted — dequeue and continue
-						if (!isHttpStatus(e, 404)) throw e;
 					}
 				} else if (entry.kind === "attachment") {
 					// Legacy entries may have content inline; new entries are content-free
@@ -7677,6 +7754,10 @@ export class SyncEngine {
 						mtime = file.stat.mtime / 1000;
 					}
 					await this.api.pushAttachment(entry.path, base64, mimeType!, mtime!);
+					// Mirror the live push path's stamp (review finding 6): without
+					// it an attachment whose only successful upload rode the queue
+					// has no sync evidence and its later delete is refused forever.
+					this.stampSyncedRow(normalizePath(entry.path), { hash: fnv1a(base64) });
 				} else {
 					// Durable CRDT delivery (Phase E3 — REST /updates deleted): the
 					// edit lives durably in the Y.Doc (IndexedDB, keyed by noteId);

--- a/src/types.ts
+++ b/src/types.ts
@@ -311,6 +311,11 @@ export interface QueueEntry {
 	kind?: "note" | "attachment";
 	/** Vault ID for dedup isolation. */
 	vaultId?: string;
+	/** Delete entries only: set when the enqueueing code path had passed the
+	 *  #416 evidence rule. The queue drain DROPS delete entries without it —
+	 *  pre-fence/legacy entries must not replay the incident around the
+	 *  handleDelete fence. */
+	evidenced?: boolean;
 	/** Set on a channel-down CRDT edit: deliver via /updates ops (encode the
 	 *  note's Y.Doc by noteId), falling back to the legacy push only when ops
 	 *  are unavailable. */

--- a/tests/sync-crdt-gate.test.ts
+++ b/tests/sync-crdt-gate.test.ts
@@ -1108,6 +1108,7 @@ describe("sign-out gate — flushQueue respects syncBlocked", () => {
 		).queue.enqueue({
 			path: "Notes/old.md",
 			action: "delete",
+			evidenced: true,
 			kind: "note",
 			timestamp: Date.now(),
 		});
@@ -1128,6 +1129,7 @@ describe("sign-out gate — flushQueue respects syncBlocked", () => {
 		).queue.enqueue({
 			path: "Notes/old.md",
 			action: "delete",
+			evidenced: true,
 			kind: "note",
 			timestamp: Date.now(),
 		});
@@ -1149,12 +1151,14 @@ describe("sign-out gate — flushQueue respects syncBlocked", () => {
 		await q.enqueue({
 			path: "Notes/a.md",
 			action: "delete",
+			evidenced: true,
 			kind: "note",
 			timestamp: Date.now(),
 		});
 		await q.enqueue({
 			path: "Notes/b.md",
 			action: "delete",
+			evidenced: true,
 			kind: "note",
 			timestamp: Date.now(),
 		});

--- a/tests/sync-delete-fence.test.ts
+++ b/tests/sync-delete-fence.test.ts
@@ -291,9 +291,11 @@ describe("pre-merge review hardening (#419 round 2)", () => {
 		(e as any).app.fileManager.trashFile = mock().mockRejectedValue(new Error("EBUSY"));
 
 		await expect((e as any).trashRemotelyDeleted(file)).rejects.toThrow("EBUSY");
-		(e as any).files.clearMarker(file.path, "remotelyDeleted");
 
-		// The file never left the vault; the user now deletes it for real.
+		// The file never left the vault; the user deletes it for real WITHIN the
+		// 5s marker window — the rollback must have cleared BOTH the counter and
+		// the remotelyDeleted marker (round-3 review: the marker half was missed
+		// and the old version of this test masked it with a manual clearMarker).
 		await e.handleDelete(file);
 		expect(deleteAttachment).toHaveBeenCalledTimes(1);
 	});
@@ -345,5 +347,36 @@ describe("pre-merge review hardening (#419 round 2)", () => {
 		]);
 		expect(e.queue.hasPendingEvidencedDelete("doomed/a.md", undefined)).toBe(false);
 		expect(e.queue.hasPendingEvidencedDelete("real/b.md", undefined)).toBe(true);
+	});
+});
+
+describe("round-3 hardening", () => {
+	test("a stale echo for a reoccupied path still cancels the pending push timer", async () => {
+		const { e } = makeEngine();
+		const file = makeAttachmentFile("reoccupied/x.png");
+		await (e as any).trashRemotelyDeleted(file);
+		// A push timer armed for the old file...
+		const timer = setTimeout(() => {}, 60_000);
+		(e as any).debounceTimers.set(file.path, timer);
+		// ...and a fresh file already at the path when the late echo lands.
+		(e as any).app.vault.getFileByPath = mock().mockReturnValue(makeAttachmentFile(file.path));
+
+		await e.handleDelete(file);
+
+		expect((e as any).debounceTimers.has(file.path)).toBe(false);
+		clearTimeout(timer);
+	});
+
+	test("probe semantics: an unstamped queued create still counts as pending", async () => {
+		const { e, crdtDeletes } = makeEngine();
+		const file = makeNoteFile("fresh/unstamped.md");
+		(e as any).noteIdMap.set(file.path, "id-unstamped");
+		// Simulate main.ts's owner semantics: unstamped op (vaultId undefined)
+		// is delivered to the current vault, so the probe reports it pending.
+		e.setCrdtHasPendingOp((id: string) => id === "id-unstamped");
+
+		await e.handleDelete(file);
+
+		expect(crdtDeletes).toEqual([file.path]);
 	});
 });

--- a/tests/sync-delete-fence.test.ts
+++ b/tests/sync-delete-fence.test.ts
@@ -282,3 +282,68 @@ describe("rename old-leg delete (review finding 2)", () => {
 		expect(deleteAttachment).toHaveBeenCalledWith("img/pic.png");
 	});
 });
+
+describe("pre-merge review hardening (#419 round 2)", () => {
+	test("a failed trashFile rolls the counter back — the next genuine delete pushes", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("locked/file.png");
+		recordSyncEvidence(e, file.path);
+		(e as any).app.fileManager.trashFile = mock().mockRejectedValue(new Error("EBUSY"));
+
+		await expect((e as any).trashRemotelyDeleted(file)).rejects.toThrow("EBUSY");
+		(e as any).files.clearMarker(file.path, "remotelyDeleted");
+
+		// The file never left the vault; the user now deletes it for real.
+		await e.handleDelete(file);
+		expect(deleteAttachment).toHaveBeenCalledTimes(1);
+	});
+
+	test("a vault switch clears stranded trash counters", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("Inbox.png");
+		recordSyncEvidence(e, file.path);
+		await (e as any).trashRemotelyDeleted(file);
+		(e as any).files.clearMarker(file.path, "remotelyDeleted");
+
+		await e.resetForVaultChange();
+
+		// New vault, same path: the old counter must not consume this delete.
+		recordSyncEvidence(e, file.path);
+		await e.handleDelete(file);
+		expect(deleteAttachment).toHaveBeenCalledTimes(1);
+	});
+
+	test("a late delete event for a REPLACED path leaves the fresh note's state intact", async () => {
+		const { e, crdtDeletes } = makeEngine();
+		const file = makeNoteFile("replaced/note.md");
+		await (e as any).trashRemotelyDeleted(file);
+		(e as any).files.clearMarker(file.path, "remotelyDeleted");
+
+		// A fresh file now lives at the path (pull recreated it) with new state.
+		(e as any).app.vault.getFileByPath = mock().mockReturnValue(makeNoteFile(file.path));
+		(e as any).noteIdMap.set(file.path, "id-fresh");
+		recordSyncEvidence(e, file.path);
+
+		await e.handleDelete(file);
+
+		// The stale echo must not unmap/tombstone/push against the fresh note.
+		expect(crdtDeletes).toHaveLength(0);
+		expect((e as any).noteIdMap.get(file.path)).toBe("id-fresh");
+		expect((e as any).syncState.has(file.path)).toBe(true);
+		expect((e as any).recentlyDeleted.has("id-fresh")).toBe(false);
+		// ...and the counter was consumed, so a real later delete pushes.
+		(e as any).app.vault.getFileByPath = mock().mockReturnValue(null);
+		await e.handleDelete(file);
+		expect(crdtDeletes).toEqual([file.path]);
+	});
+
+	test("an unevidenced queued delete does not suppress catch-up recreation", () => {
+		const { e } = makeEngine();
+		e.queue.load([
+			{ path: "doomed/a.md", action: "delete", timestamp: 1 },
+			{ path: "real/b.md", action: "delete", evidenced: true, timestamp: 2 },
+		]);
+		expect(e.queue.hasPendingEvidencedDelete("doomed/a.md", undefined)).toBe(false);
+		expect(e.queue.hasPendingEvidencedDelete("real/b.md", undefined)).toBe(true);
+	});
+});

--- a/tests/sync-delete-fence.test.ts
+++ b/tests/sync-delete-fence.test.ts
@@ -83,7 +83,11 @@ describe("engine-trashed paths never push their delete", () => {
 		expect(deleteAttachment).not.toHaveBeenCalled();
 	});
 
-	test("a recreate clears the record, so a later REAL user delete pushes", async () => {
+	test("the record is CONSUMED by the trash's own delete event, so a later REAL user delete pushes", async () => {
+		// Consumption-based, not clear-on-recreate (post-merge review finding 1:
+		// clearing on recreate let the late trash echo through as a push against
+		// the FRESH note). Sequence: trash → recreate → late trash echo (consumes)
+		// → genuine user delete (pushes).
 		const { e, deleteAttachment } = makeEngine();
 		const file = makeAttachmentFile("a/pic.png");
 		recordSyncEvidence(e, file.path);
@@ -91,13 +95,36 @@ describe("engine-trashed paths never push their delete", () => {
 		await (e as any).trashRemotelyDeleted(file);
 		(e as any).files.clearMarker(file.path, "remotelyDeleted");
 
-		// File comes back (pull or user recreate) — the trash record must not
-		// outlive it and swallow the next genuine delete.
-		e.noteRecreatedPath(file.path);
+		// Recreate at the path (pull) — must NOT clear the pending record.
 		recordSyncEvidence(e, file.path);
 
+		// Late delete event for the OLD trashed file: consumed as an echo, no push.
 		await e.handleDelete(file);
+		expect(deleteAttachment).not.toHaveBeenCalled();
 
+		// Genuine user delete of the recreated file: pushes.
+		recordSyncEvidence(e, file.path);
+		await e.handleDelete(file);
+		expect(deleteAttachment).toHaveBeenCalledTimes(1);
+	});
+
+	test("a wipe-pass delete event landing DURING suppressDeletes still consumes the record", async () => {
+		// Review finding 4: the suppressDeletes early-return ran before the echo
+		// consume, stranding a permanent record that would swallow a future
+		// genuine delete at the path.
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("wipe/extra.png");
+		recordSyncEvidence(e, file.path);
+
+		await (e as any).trashRemotelyDeleted(file);
+		(e as any).suppressDeletes = true;
+		await e.handleDelete(file); // in-window echo: consumed, no push
+		(e as any).suppressDeletes = false;
+		expect(deleteAttachment).not.toHaveBeenCalled();
+
+		// Path is later reused and genuinely deleted — must push.
+		recordSyncEvidence(e, file.path);
+		await e.handleDelete(file);
 		expect(deleteAttachment).toHaveBeenCalledTimes(1);
 	});
 });
@@ -147,5 +174,111 @@ describe("evidence rule: no syncState entry → no delete push", () => {
 		await e.handleDelete(file);
 
 		expect(crdtDeletes).toEqual([file.path]);
+	});
+});
+
+describe("refusal side effects (review findings 5+7)", () => {
+	test("refusal with a PENDING crdt create enqueues the superseding delete", async () => {
+		const { e, crdtDeletes } = makeEngine();
+		const file = makeNoteFile("fresh/unacked.md");
+		(e as any).noteIdMap.set(file.path, "id-pending");
+		e.setCrdtHasPendingOp((id: string) => id === "id-pending");
+
+		await e.handleDelete(file);
+
+		// Queue coalesces by docId: the delete supersedes the pending create,
+		// restoring the pre-fence create/delete coalesce semantics.
+		expect(crdtDeletes).toEqual([file.path]);
+	});
+
+	test("pure refusal (no pending op) does not tombstone the id for delete-wins", async () => {
+		const { e, crdtDeletes } = makeEngine();
+		const file = makeNoteFile("never/synced.md");
+		(e as any).noteIdMap.set(file.path, "id-x");
+		e.setCrdtHasPendingOp(() => false);
+
+		await e.handleDelete(file);
+
+		expect(crdtDeletes).toHaveLength(0);
+		// The promised remedy for a wrong refusal is next-pull resurrection —
+		// a recentlyDeleted tombstone would block it for the delete-wins window.
+		expect((e as any).recentlyDeleted.has("id-x")).toBe(false);
+	});
+});
+
+describe("offline-queue delete drain (review finding 0)", () => {
+	test("a persisted delete entry WITHOUT an evidence stamp is dropped, not pushed", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		e.queue.load([
+			{ path: "poison/old.png", action: "delete", kind: "attachment", timestamp: 1 },
+		]);
+
+		await e.flushQueue();
+
+		expect(deleteAttachment).not.toHaveBeenCalled();
+		expect(e.queue.size).toBe(0);
+	});
+
+	test("an evidenced delete entry still pushes", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		e.queue.load([
+			{
+				path: "known/gone.png",
+				action: "delete",
+				kind: "attachment",
+				timestamp: 1,
+				evidenced: true,
+			},
+		]);
+
+		await e.flushQueue();
+
+		expect(deleteAttachment).toHaveBeenCalledTimes(1);
+		expect(e.queue.size).toBe(0);
+	});
+});
+
+describe("queue-replayed attachment gains evidence (review finding 6)", () => {
+	test("an attachment uploaded only via the queue drain can later be deleted", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		(e as any).api.pushAttachment = mock().mockResolvedValue({ attachment: {} });
+		e.queue.load([
+			{
+				path: "flaky/photo.png",
+				action: "upsert",
+				contentBase64: "AQID",
+				mimeType: "image/png",
+				mtime: 100,
+				kind: "attachment",
+				timestamp: 1,
+			},
+		]);
+
+		await e.flushQueue();
+
+		// The replay must stamp sync evidence, or this delete is refused forever.
+		await e.handleDelete(makeAttachmentFile("flaky/photo.png"));
+		expect(deleteAttachment).toHaveBeenCalledWith("flaky/photo.png");
+	});
+});
+
+describe("rename old-leg delete (review finding 2)", () => {
+	test("rename of a never-synced attachment does not push the old-path delete", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("img/pic2.png");
+
+		await e.handleRename(file, "img/pic.png");
+
+		expect(deleteAttachment).not.toHaveBeenCalled();
+	});
+
+	test("rename of a synced attachment still deletes the old path", async () => {
+		const { e, deleteAttachment } = makeEngine();
+		const file = makeAttachmentFile("img/pic2.png");
+		recordSyncEvidence(e, "img/pic.png");
+
+		await e.handleRename(file, "img/pic.png");
+
+		expect(deleteAttachment).toHaveBeenCalledWith("img/pic.png");
 	});
 });

--- a/tests/sync-deleted-note-empty-materialize.test.ts
+++ b/tests/sync-deleted-note-empty-materialize.test.ts
@@ -114,6 +114,10 @@ describe("deleted note must not re-materialize empty", () => {
 			action: "delete",
 			kind: "note",
 			timestamp: Date.now(),
+			// A legit offline delete always carries the #416 evidence stamp;
+			// only evidenced entries suppress re-materialization (unevidenced
+			// ones are predestined to be dropped by the drain gate).
+			evidenced: true,
 		});
 
 		await e.materializeEmptyDiscovered("gone.md", "id-gone");

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -111,6 +111,10 @@ describe("discoverAnnouncedNote (e2e test_27 — announce-driven immediate empty
 			action: "delete",
 			kind: "note",
 			timestamp: Date.now(),
+			// Legit queued deletes carry the #416 evidence stamp; only those
+			// suppress announce-driven discovery (unevidenced ones are doomed
+			// to be dropped by the drain gate and must not hide live notes).
+			evidenced: true,
 		});
 		mockApp.vault.create.mockClear();
 		let replayed = false;

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -1445,7 +1445,12 @@ describe("OfflineQueue", () => {
 			mtime: 100,
 			timestamp: 1,
 		});
-		await queue.enqueue({ path: "Notes/B.md", action: "delete", timestamp: 2 });
+		await queue.enqueue({
+			path: "Notes/B.md",
+			action: "delete",
+			evidenced: true,
+			timestamp: 2,
+		});
 
 		const entries = queue.all();
 		expect(entries.map((e: any) => e.path)).toEqual(["Notes/A.md", "Notes/B.md", "Notes/C.md"]);
@@ -1455,7 +1460,7 @@ describe("OfflineQueue", () => {
 		const queue = new OfflineQueue();
 		queue.load([
 			{ path: "Notes/X.md", action: "upsert", content: "X", mtime: 100, timestamp: 1 },
-			{ path: "Notes/Y.md", action: "delete", timestamp: 2 },
+			{ path: "Notes/Y.md", action: "delete", evidenced: true, timestamp: 2 },
 		]);
 
 		expect(queue.size).toBe(2);
@@ -1498,7 +1503,12 @@ describe("OfflineQueue", () => {
 		expect(persisted.length).toBe(2);
 		expect(persisted[1]).toEqual([]);
 
-		await queue.enqueue({ path: "Notes/B.md", action: "delete", timestamp: 2 });
+		await queue.enqueue({
+			path: "Notes/B.md",
+			action: "delete",
+			evidenced: true,
+			timestamp: 2,
+		});
 		// clear persists immediately (cancels pending enqueue debounce)
 		await queue.clear();
 		expect(persisted.length).toBe(3);
@@ -1664,7 +1674,7 @@ describe("SyncEngine offline queue integration", () => {
 		// Pre-load queue
 		engine.queue.load([
 			{ path: "Notes/A.md", action: "upsert", content: "A", mtime: 100, timestamp: 1 },
-			{ path: "Notes/B.md", action: "delete", timestamp: 2 },
+			{ path: "Notes/B.md", action: "delete", evidenced: true, timestamp: 2 },
 			{ path: "Notes/C.md", action: "upsert", content: "C", mtime: 300, timestamp: 3 },
 		]);
 
@@ -1791,7 +1801,13 @@ describe("SyncEngine offline queue integration", () => {
 				kind: "attachment",
 				timestamp: 1,
 			},
-			{ path: "Assets/old.pdf", action: "delete", kind: "attachment", timestamp: 2 },
+			{
+				path: "Assets/old.pdf",
+				action: "delete",
+				evidenced: true,
+				kind: "attachment",
+				timestamp: 2,
+			},
 		]);
 
 		(mockApi.pushAttachment as jest.Mock).mockResolvedValue({ attachment: {} });


### PR DESCRIPTION
## Why

The post-merge adversarial review of #417 (requested after it merged early) confirmed the fence only guarded the `handleDelete` front door. Six bypasses were verified, two of them full re-entries of the #416 data-loss class.

## What each finding got

| Finding | Fix |
|---|---|
| Offline-queue drain replays deletes unchecked (incl. pre-fence poisoned queues) | delete entries need an `evidenced` stamp; unstamped entries are dropped with a Loki-visible warn |
| Rename old-leg deletes push without evidence | same evidence rule as handleDelete, refusal logged |
| Clear-on-recreate let the late trash echo delete the FRESH note | `engineTrashedPaths` is a counter consumed 1:1 by events; recreate never clears |
| suppressDeletes early-return stranded permanent entries that ate future real deletes | early-return removed; wipe-window events consume their records |
| Refusal left a pending `crdt_create` queued → guaranteed resurrection | refusal with a pending op enqueues the superseding delete (docId coalescing) |
| Refusal tombstoned the id, blocking its own promised next-pull resurrection | pure refusal no longer marks recentlyDeleted |
| Queue-replayed attachments gained no evidence → later deletes refused forever | replay stamps syncState like the live path |
| Stale `explicitFolders` pushes cross-vault marker deletes (data-safe) | wiped in `wipePerVaultState` |

## Tests

8 new fence tests (TDD, each watched red), covering every bypass: queue drain drop/keep, rename old-leg refuse/allow, recreate-then-late-echo, wipe-window consume, supersede-pending-create, no-tombstone-on-refusal, queue-replay evidence. Existing queue tests gained the `evidenced` arrange their scenarios implied. Full suite: 2509 pass; biome/tsc/eslint/stylelint/build green.

**Do not merge without Todd's explicit go.**

Refs #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC