### PR TITLE
fix: honest failure UX + accurate first-sync progress

### DIFF
--- a/main.js
+++ b/main.js
@@ -17800,7 +17800,7 @@ var SyncPreviewState = class {
   }
 };
 function planLoadErrorMessage(hasAuth) {
-  return hasAuth ? "Could not compare with the cloud. Check your connection." : "Your login expired \u2014 sign in again in Engram settings to continue.";
+  return hasAuth ? "Could not compare with the cloud. Check your connection." : "Your login expired. Sign in again in Engram settings to continue.";
 }
 function describeCreateVaultError(e) {
   return e instanceof LimitExceededError ? toastFor(e.reason) : statusOf(e) === 422 ? "Couldn't create vault \u2014 the name may be invalid or already in use." : "Could not create the vault \u2014 check your connection and try again.";
@@ -18369,8 +18369,13 @@ function renderActions(parent, plugin, refresh) {
         showChangeVault: !1,
         context: "review"
       });
-      plugin.syncEngine.computeSyncPlan("full").then((p) => modal.setPlan(p)).catch(() => modal.setPlanError(planLoadErrorMessage(plugin.hasAuthConfigured())));
-      let choice = await modal.awaitChoice();
+      plugin.syncEngine.computeSyncPlan("full").then((p) => modal.setPlan(p)).catch(() => modal.setPlanError(planLoadErrorMessage(plugin.hasAuthConfigured()))), plugin.trackPreviewModal(modal);
+      let choice;
+      try {
+        choice = await modal.awaitChoice();
+      } finally {
+        plugin.untrackPreviewModal(modal);
+      }
       if (choice === "change-vault")
         throw new Error("Sync Center received change-vault choice, caller missing");
       await plugin.runSyncWithProgress(choice, { plan: modal.getPlan() });
@@ -21318,7 +21323,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     var _a, _b, _c, _d, _e;
     let serverIds = /* @__PURE__ */ new Set(), serverAttachmentPaths = /* @__PURE__ */ new Set();
     if (this.seqReplayRunning) {
-      this.seqReplayAgain = !0;
+      if (this.seqReplayAgain = !0, !opts.awaitCoalesced)
+        return {
+          applied: 0,
+          files: 0,
+          failed: 0,
+          deletes: 0,
+          serverIds,
+          serverAttachmentPaths,
+          ran: !1,
+          complete: !1
+        };
       let running = await ((_a = this.seqReplayResult) == null ? void 0 : _a.catch(() => null));
       return {
         applied: (_b = running == null ? void 0 : running.applied) != null ? _b : 0,
@@ -21369,7 +21384,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     try {
       return await session;
     } finally {
-      this.seqReplayResult = null;
+      this.seqReplayResult === session && (this.seqReplayResult = null);
     }
   }
   /** Run `catchupViaSeqReplay` for a DESTRUCTIVE delete decision (pull-all wipe,
@@ -21437,12 +21452,16 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       if (manifest != null && manifest.unchanged) {
         await this.seedEmptyFolders();
         let { files: files2, failed: failed2, deletes: deletes2 } = await this.catchupViaSeqReplay({
-          onFileApplied
+          onFileApplied,
+          awaitCoalesced: opts.reportProgress
         });
         return { files: files2, failed: failed2, deletes: deletes2 };
       }
       await this.reconcileFromManifest(manifest, authGenAtFetch);
-      let behind = this.validateFromManifest(manifest), { files, failed, deletes } = await this.catchupViaSeqReplay({ onFileApplied }), poked = await this.healDivergedLiveBoundNotes(manifest);
+      let behind = this.validateFromManifest(manifest), { files, failed, deletes } = await this.catchupViaSeqReplay({
+        onFileApplied,
+        awaitCoalesced: opts.reportProgress
+      }), poked = await this.healDivergedLiveBoundNotes(manifest);
       try {
         await this.syncExplicitFolders();
       } catch (e) {
@@ -21482,7 +21501,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             try {
               let changed = await this.applySyncChange(c);
               if (applied += 1, !c.deleted && changed) {
-                let key = c.type === "attachment" ? `a:${c.path}` : `n:${(_a2 = c.id) != null ? _a2 : c.path}`;
+                let key = `${c.type === "attachment" ? "a" : "n"}:${(_a2 = c.id) != null ? _a2 : c.path}`;
                 tickedKeys.has(key) || (tickedKeys.add(key), files += 1, onFileApplied == null || onFileApplied(c.path));
               } else c.deleted && changed && (deletes += 1);
             } catch (e) {
@@ -21828,14 +21847,26 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           serverIds,
           serverAttachmentPaths
         } = replay);
-      } else
+      } else {
+        let replay = null;
+        for (let attempt = 0; attempt < 10; attempt++) {
+          let res = await this.catchupViaSeqReplay({ fromZero: !0, onFileApplied });
+          if (res.ran) {
+            replay = res;
+            break;
+          }
+          await this.sleep(50);
+        }
+        if (!replay)
+          return this.lastError = "Pull all aborted: another sync is running (replay contention). Try again when it finishes.", rlog().warn("pull", `${label} ABORTED: replay never ran exclusively`), 0;
         ({
           applied,
           files: pulledFileCount,
           failed: replayFailed,
           serverIds,
           serverAttachmentPaths
-        } = await this.catchupViaSeqReplay({ fromZero: !0, onFileApplied }));
+        } = replay);
+      }
       devLog().log(
         "pull",
         `${label}: replay applied=${applied}, serverIds=${serverIds.size}, serverAttachmentPaths=${serverAttachmentPaths.size}`
@@ -24750,7 +24781,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           firstSync: context === "first-time"
         });
       } catch (e) {
-        console.error("Engram Sync: sync failed", e), new import_obsidian26.Notice("Engram: sync failed \u2014 open the sync log for details"), rlog().error("lifecycle", `Sync (preview or run) failed: ${errMsg(e)}`);
+        console.error("Engram Sync: sync failed", e), new import_obsidian26.Notice("Engram: sync failed. Open the sync log for details."), rlog().error("lifecycle", `Sync (preview or run) failed: ${errMsg(e)}`);
       }
     });
   }
@@ -24761,6 +24792,16 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     await this.savePluginData(this.syncEngine.getLastSync());
   }
   /** Open the plugin settings on the Sync Center tab. */
+  /** Register/unregister the preview modal that auth invalidation should poke
+   *  with the sign-in error. Public so BOTH entry points (first-sync command
+   *  and Sync Center) share the seam — the Sync Center modal missing it left
+   *  the incident's 8s-spin-then-blame-connection limbo alive there. */
+  trackPreviewModal(modal) {
+    this.openPreviewModal = modal;
+  }
+  untrackPreviewModal(modal) {
+    this.openPreviewModal === modal && (this.openPreviewModal = null);
+  }
   openConnectionSettings() {
     var _a;
     (_a = this.settingTab) == null || _a.setInitialTab("connection");
@@ -24778,9 +24819,9 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     var _a, _b, _c, _d, _e;
     if (!this.statusBarEl) return;
     let blocked = (_b = (_a = this.syncEngine) == null ? void 0 : _a.isSyncBlocked()) != null ? _b : !1, text2, tooltip;
-    this.hasAuthConfigured() ? blocked && status.state !== "syncing" ? (text2 = status.pending > 0 ? `Engram: sync paused (${status.pending} queued)` : "Engram: sync paused", tooltip = "Sync paused \u2014 click to choose a sync direction") : status.state === "offline" ? (text2 = status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline", tooltip = "Server unreachable \u2014 changes will sync when connected") : status.state === "error" ? (text2 = "Engram: error", tooltip = status.error || "Unknown error") : status.state === "syncing" ? (text2 = status.pending > 0 ? `Engram: syncing (${status.pending})` : "Engram: syncing", tooltip = "Sync in progress...") : status.pending > 0 ? (text2 = `Engram: pending (${status.pending})`, tooltip = `${status.pending} file(s) queued`) : this.liveConnected ? (text2 = "Engram: live", tooltip = "WebSocket connected \u2014 live sync active") : (text2 = "Engram: ready", tooltip = "Click to sync") : (text2 = "Engram: signed out", tooltip = "Not signed in \u2014 click to open settings and reconnect");
+    this.hasAuthConfigured() ? blocked && status.state !== "syncing" ? (text2 = status.pending > 0 ? `Engram: sync paused (${status.pending} queued)` : "Engram: sync paused", tooltip = "Sync paused \u2014 click to choose a sync direction") : status.state === "offline" ? (text2 = status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline", tooltip = "Server unreachable \u2014 changes will sync when connected") : status.state === "error" ? (text2 = "Engram: error", tooltip = status.error || "Unknown error") : status.state === "syncing" ? (text2 = status.pending > 0 ? `Engram: syncing (${status.pending})` : "Engram: syncing", tooltip = "Sync in progress...") : status.pending > 0 ? (text2 = `Engram: pending (${status.pending})`, tooltip = `${status.pending} file(s) queued`) : this.liveConnected ? (text2 = "Engram: live", tooltip = "WebSocket connected \u2014 live sync active") : (text2 = "Engram: ready", tooltip = "Click to sync") : (text2 = "Engram: signed out", tooltip = "Not signed in. Click to open settings and reconnect.");
     let errorCount = (_d = (_c = this.syncLog) == null ? void 0 : _c.errorCount()) != null ? _d : 0;
-    if (errorCount > 0 && status.state === "idle" && !blocked && (text2 = `Engram: \u26A0 ${errorCount} sync errors`), status.lastSync) {
+    if (errorCount > 0 && status.state === "idle" && !blocked && this.hasAuthConfigured() && (text2 = `Engram: \u26A0 ${errorCount} sync errors`), status.lastSync) {
       let date = new Date(status.lastSync);
       tooltip += `
 Last sync: ${date.toLocaleString()}`;

--- a/main.js
+++ b/main.js
@@ -17799,6 +17799,9 @@ var SyncPreviewState = class {
     this.resolved || (this.resolved = !0, this.view = "done", this.onResolve(choice));
   }
 };
+function planLoadErrorMessage(hasAuth) {
+  return hasAuth ? "Could not compare with the cloud. Check your connection." : "Your login expired \u2014 sign in again in Engram settings to continue.";
+}
 function describeCreateVaultError(e) {
   return e instanceof LimitExceededError ? toastFor(e.reason) : statusOf(e) === 422 ? "Couldn't create vault \u2014 the name may be invalid or already in use." : "Could not create the vault \u2014 check your connection and try again.";
 }
@@ -18366,9 +18369,7 @@ function renderActions(parent, plugin, refresh) {
         showChangeVault: !1,
         context: "review"
       });
-      plugin.syncEngine.computeSyncPlan("full").then((p) => modal.setPlan(p)).catch(
-        () => modal.setPlanError("Could not compare with the cloud. Check your connection.")
-      );
+      plugin.syncEngine.computeSyncPlan("full").then((p) => modal.setPlan(p)).catch(() => modal.setPlanError(planLoadErrorMessage(plugin.hasAuthConfigured())));
       let choice = await modal.awaitChoice();
       if (choice === "change-vault")
         throw new Error("Sync Center received change-vault choice, caller missing");
@@ -19581,6 +19582,9 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
      *  committed during the replay is never missed. */
     this.seqReplayRunning = !1;
     this.seqReplayAgain = !1;
+    /** Resolves with the running replay session's counts — what a coalescing
+     *  caller awaits so it can report real work instead of zeros. */
+    this.seqReplayResult = null;
     this.seqHealLastAt = 0;
     this.seqHealTimer = null;
     /** Ceiling on how long an edit may sit in pendingPostPullPushes while a
@@ -21311,46 +21315,62 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     return { notes, attachments };
   }
   async catchupViaSeqReplay(opts = {}) {
-    var _a, _b, _c;
+    var _a, _b, _c, _d, _e;
     let serverIds = /* @__PURE__ */ new Set(), serverAttachmentPaths = /* @__PURE__ */ new Set();
-    if (this.seqReplayRunning)
-      return this.seqReplayAgain = !0, {
-        applied: 0,
-        files: 0,
-        failed: 0,
-        deletes: 0,
+    if (this.seqReplayRunning) {
+      this.seqReplayAgain = !0;
+      let running = await ((_a = this.seqReplayResult) == null ? void 0 : _a.catch(() => null));
+      return {
+        applied: (_b = running == null ? void 0 : running.applied) != null ? _b : 0,
+        files: (_c = running == null ? void 0 : running.files) != null ? _c : 0,
+        failed: (_d = running == null ? void 0 : running.failed) != null ? _d : 0,
+        deletes: (_e = running == null ? void 0 : running.deletes) != null ? _e : 0,
+        // Still EMPTY sets + ran:false — the counts are honest but the
+        // sets belong to the other caller's walk; destructive decisions
+        // keep requiring ran && complete.
         serverIds,
         serverAttachmentPaths,
         ran: !1,
         complete: !1
       };
-    this.seqReplayRunning = !0;
-    let applied = 0, files = 0, failed = 0, deletes = 0, complete = !0;
-    try {
-      do {
-        this.seqReplayAgain = !1;
-        let pass = await this.runSeqReplayOnce(
-          ((_a = opts.fromZero) != null ? _a : !1) || ((_b = opts.enumerateOnly) != null ? _b : !1),
-          serverIds,
-          serverAttachmentPaths,
-          (_c = opts.enumerateOnly) != null ? _c : !1,
-          opts.onFileApplied
-        );
-        applied += pass.applied, files += pass.files, failed += pass.failed, deletes += pass.deletes, pass.complete || (complete = !1);
-      } while (this.seqReplayAgain);
-    } finally {
-      this.seqReplayRunning = !1;
     }
-    return {
-      applied,
-      files,
-      failed,
-      deletes,
-      serverIds,
-      serverAttachmentPaths,
-      ran: !0,
-      complete
-    };
+    this.seqReplayRunning = !0;
+    let session = (async () => {
+      var _a2, _b2, _c2;
+      let applied = 0, files = 0, failed = 0, deletes = 0, complete = !0, tickedKeys = /* @__PURE__ */ new Set();
+      try {
+        do {
+          this.seqReplayAgain = !1;
+          let pass = await this.runSeqReplayOnce(
+            ((_a2 = opts.fromZero) != null ? _a2 : !1) || ((_b2 = opts.enumerateOnly) != null ? _b2 : !1),
+            serverIds,
+            serverAttachmentPaths,
+            tickedKeys,
+            (_c2 = opts.enumerateOnly) != null ? _c2 : !1,
+            opts.onFileApplied
+          );
+          applied += pass.applied, files += pass.files, failed += pass.failed, deletes += pass.deletes, pass.complete || (complete = !1);
+        } while (this.seqReplayAgain);
+      } finally {
+        this.seqReplayRunning = !1;
+      }
+      return {
+        applied,
+        files,
+        failed,
+        deletes,
+        serverIds,
+        serverAttachmentPaths,
+        ran: !0,
+        complete
+      };
+    })();
+    this.seqReplayResult = session;
+    try {
+      return await session;
+    } finally {
+      this.seqReplayResult = null;
+    }
   }
   /** Run `catchupViaSeqReplay` for a DESTRUCTIVE delete decision (pull-all wipe,
    *  push-all replace-remote). Retries until THIS call executes the replay
@@ -21438,10 +21458,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         "pull",
         `Catch-up failed: ${errMsg(e)}`,
         e instanceof Error ? e.stack : void 0
-      ), (_a = this.onVaultScopedError) == null || _a.call(this, e), { files: 0, failed: 0, deletes: 0 };
+      ), (_a = this.onVaultScopedError) == null || _a.call(this, e), { files: 0, failed: 1, deletes: 0 };
     }
   }
-  async runSeqReplayOnce(fromZero, serverIds, serverAttachmentPaths, enumerateOnly = !1, onFileApplied) {
+  async runSeqReplayOnce(fromZero, serverIds, serverAttachmentPaths, tickedKeys, enumerateOnly = !1, onFileApplied) {
     var _a;
     if (!this.crdtCatchupSince || !this.crdt)
       return { applied: 0, files: 0, failed: 0, deletes: 0, complete: !1 };
@@ -21457,10 +21477,14 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         seq: cursor,
         id: cursorId,
         onRow: async (c) => {
+          var _a2;
           if (!enumerateOnly)
             try {
               let changed = await this.applySyncChange(c);
-              applied += 1, !c.deleted && changed ? (files += 1, onFileApplied == null || onFileApplied(c.path)) : c.deleted && changed && (deletes += 1);
+              if (applied += 1, !c.deleted && changed) {
+                let key = c.type === "attachment" ? `a:${c.path}` : `n:${(_a2 = c.id) != null ? _a2 : c.path}`;
+                tickedKeys.has(key) || (tickedKeys.add(key), files += 1, onFileApplied == null || onFileApplied(c.path));
+              } else c.deleted && changed && (deletes += 1);
             } catch (e) {
               failed += 1, rlog().error("crdt", `seq-replay: skipped ${c.path} \u2014 ${errMsg(e)}`);
             }
@@ -23866,15 +23890,17 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         this.openSyncCenterSettings();
       }
     }), this.startSyncInterval(), this.statusBarEl = this.addStatusBarItem(), this.statusBarEl.setText("Engram: ready"), this.statusBarEl.addClass("engram-status-bar-clickable"), this.registerDomEvent(this.statusBarEl, "click", () => {
-      if (this.hasAuthConfigured()) {
-        if (this.syncEngine.isSyncBlocked()) {
-          this.doSyncWithFirstSyncCheck();
-          return;
-        }
-        new import_obsidian26.Notice("Engram sync: syncing..."), this.syncEngine.fullSync().then(({ pulled, pushed }) => {
-          new import_obsidian26.Notice(`Engram Sync: pulled ${pulled}, pushed ${pushed}`);
-        }).catch((e) => this.handleSyncError("Manual sync", e, { notice: !0 }));
+      if (!this.hasAuthConfigured()) {
+        this.openConnectionSettings();
+        return;
       }
+      if (this.syncEngine.isSyncBlocked()) {
+        this.doSyncWithFirstSyncCheck();
+        return;
+      }
+      new import_obsidian26.Notice("Engram sync: syncing..."), this.syncEngine.fullSync().then(({ pulled, pushed }) => {
+        new import_obsidian26.Notice(`Engram Sync: pulled ${pulled}, pushed ${pushed}`);
+      }).catch((e) => this.handleSyncError("Manual sync", e, { notice: !0 }));
     }), this.registerEditorExtension([liveBindingPlugin]), this.registerEvent(this.app.workspace.on("file-open", (file) => this.handleFileOpen(file))), this.registerEvent(
       this.app.workspace.on("active-leaf-change", () => {
         var _a2;
@@ -24204,8 +24230,8 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
    * Idempotent — a no-op once auth is already cleared.
    */
   async clearAuthAndPromptRelink(reason, notify) {
-    var _a;
-    !this.settings.refreshToken && !this.settings.apiKey || (rlog().info("auth", `Clearing auth + prompting re-link (${reason})`), Object.assign(this.settings, withClearedAuth(this.settings)), this.api.setAuthProvider(null), this.replaceAuthProvider(null), (_a = this.noteStream) == null || _a.disconnect(), this.noteStream = null, this.liveConnected = !1, this.everConnected = !1, await this.savePluginData(this.syncEngine.getLastSync()), this.updateStatusBar(this.syncEngine.getStatus()), notify && new import_obsidian26.Notice("Engram: your login expired \u2014 open Engram settings to reconnect."));
+    var _a, _b;
+    !this.settings.refreshToken && !this.settings.apiKey || (rlog().info("auth", `Clearing auth + prompting re-link (${reason})`), Object.assign(this.settings, withClearedAuth(this.settings)), this.api.setAuthProvider(null), this.replaceAuthProvider(null), (_a = this.noteStream) == null || _a.disconnect(), this.noteStream = null, this.liveConnected = !1, this.everConnected = !1, (_b = this.openPreviewModal) == null || _b.setPlanError(planLoadErrorMessage(!1)), await this.savePluginData(this.syncEngine.getLastSync()), this.updateStatusBar(this.syncEngine.getStatus()), notify && new import_obsidian26.Notice("Engram: your login expired \u2014 open Engram settings to reconnect."));
   }
   /**
    * Fired by OAuthAuth when the server DEFINITIVELY rejects the stored refresh
@@ -24716,9 +24742,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           }
         });
         this.syncEngine.computeSyncPlan("full").then((plan) => modal.setPlan(plan)).catch((e) => {
-          modal.setPlanError(
-            "Could not compare with the cloud. Check your connection."
-          ), rlog().error("lifecycle", `Sync plan compute failed: ${errMsg(e)}`);
+          modal.setPlanError(planLoadErrorMessage(this.hasAuthConfigured())), rlog().error("lifecycle", `Sync plan compute failed: ${errMsg(e)}`);
         }), this.openPreviewModal = modal;
         let choice = await modal.awaitChoice();
         this.openPreviewModal = null, await this.runSyncWithProgress(choice, {
@@ -24726,7 +24750,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           firstSync: context === "first-time"
         });
       } catch (e) {
-        console.error("Engram Sync: sync preview failed", e), new import_obsidian26.Notice("Engram sync: preview failed \u2014 check connection"), rlog().error("lifecycle", `Sync preview failed: ${errMsg(e)}`);
+        console.error("Engram Sync: sync failed", e), new import_obsidian26.Notice("Engram: sync failed \u2014 open the sync log for details"), rlog().error("lifecycle", `Sync (preview or run) failed: ${errMsg(e)}`);
       }
     });
   }
@@ -24737,6 +24761,12 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     await this.savePluginData(this.syncEngine.getLastSync());
   }
   /** Open the plugin settings on the Sync Center tab. */
+  openConnectionSettings() {
+    var _a;
+    (_a = this.settingTab) == null || _a.setInitialTab("connection");
+    let setting = this.app.setting;
+    setting.open(), setting.openTabById(this.manifest.id);
+  }
   openSyncCenterSettings() {
     var _a;
     (_a = this.settingTab) == null || _a.setInitialTab("sync-center");
@@ -24748,7 +24778,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
     var _a, _b, _c, _d, _e;
     if (!this.statusBarEl) return;
     let blocked = (_b = (_a = this.syncEngine) == null ? void 0 : _a.isSyncBlocked()) != null ? _b : !1, text2, tooltip;
-    blocked && status.state !== "syncing" ? (text2 = status.pending > 0 ? `Engram: sync paused (${status.pending} queued)` : "Engram: sync paused", tooltip = "Sync paused \u2014 click to choose a sync direction") : status.state === "offline" ? (text2 = status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline", tooltip = "Server unreachable \u2014 changes will sync when connected") : status.state === "error" ? (text2 = "Engram: error", tooltip = status.error || "Unknown error") : status.state === "syncing" ? (text2 = status.pending > 0 ? `Engram: syncing (${status.pending})` : "Engram: syncing", tooltip = "Sync in progress...") : status.pending > 0 ? (text2 = `Engram: pending (${status.pending})`, tooltip = `${status.pending} file(s) queued`) : this.liveConnected ? (text2 = "Engram: live", tooltip = "WebSocket connected \u2014 live sync active") : (text2 = "Engram: ready", tooltip = "Click to sync");
+    this.hasAuthConfigured() ? blocked && status.state !== "syncing" ? (text2 = status.pending > 0 ? `Engram: sync paused (${status.pending} queued)` : "Engram: sync paused", tooltip = "Sync paused \u2014 click to choose a sync direction") : status.state === "offline" ? (text2 = status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline", tooltip = "Server unreachable \u2014 changes will sync when connected") : status.state === "error" ? (text2 = "Engram: error", tooltip = status.error || "Unknown error") : status.state === "syncing" ? (text2 = status.pending > 0 ? `Engram: syncing (${status.pending})` : "Engram: syncing", tooltip = "Sync in progress...") : status.pending > 0 ? (text2 = `Engram: pending (${status.pending})`, tooltip = `${status.pending} file(s) queued`) : this.liveConnected ? (text2 = "Engram: live", tooltip = "WebSocket connected \u2014 live sync active") : (text2 = "Engram: ready", tooltip = "Click to sync") : (text2 = "Engram: signed out", tooltip = "Not signed in \u2014 click to open settings and reconnect");
     let errorCount = (_d = (_c = this.syncLog) == null ? void 0 : _c.errorCount()) != null ? _d : 0;
     if (errorCount > 0 && status.state === "idle" && !blocked && (text2 = `Engram: \u26A0 ${errorCount} sync errors`), status.lastSync) {
       let date = new Date(status.lastSync);

--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ import { reconcileColdStart, SyncEngine } from "./sync";
 import { channelConnectionKey, computeSyncFingerprint } from "./sync-fingerprint";
 import { SyncLog } from "./sync-log";
 import { SyncLogModal } from "./sync-log-modal";
-import { SyncPreviewModal } from "./sync-preview-modal";
+import { planLoadErrorMessage, SyncPreviewModal } from "./sync-preview-modal";
 import {
 	describePlannedWork,
 	type PlannedPhase,
@@ -309,7 +309,7 @@ export default class EngramSyncPlugin extends Plugin {
 	/** The live SyncPreviewModal, if one is open. Held so healDeadVault can
 	 *  close a preview that sits on a just-nulled vault before reopening the
 	 *  picker (the syncPreviewGuard makes a reopen a no-op while it lives). */
-	private openPreviewModal: { close(): void } | null = null;
+	private openPreviewModal: { close(): void; setPlanError(msg: string): void } | null = null;
 
 	/** Timestamp (ms) of the last noteIdMap manifest-reconcile attempt.
 	 *  Reconciling on EVERY reconnect (not just the first) is required so a
@@ -906,7 +906,12 @@ export default class EngramSyncPlugin extends Plugin {
 		this.statusBarEl.addClass("engram-status-bar-clickable");
 
 		this.registerDomEvent(this.statusBarEl, "click", () => {
-			if (!this.hasAuthConfigured()) return;
+			if (!this.hasAuthConfigured()) {
+				// Signed out: a silent dead click here was the incident's limbo —
+				// route to settings where the re-link lives.
+				this.openConnectionSettings();
+				return;
+			}
 
 			if (this.syncEngine.isSyncBlocked()) {
 				// Gate is closed — open SyncPreviewModal so the user can pick
@@ -1568,6 +1573,10 @@ export default class EngramSyncPlugin extends Plugin {
 		this.noteStream = null;
 		this.liveConnected = false;
 		this.everConnected = false;
+		// An open preview modal is now waiting on an enumeration that can never
+		// succeed — flip it to the sign-in error instead of letting it spin out
+		// the 8s enumerate budget and blame the connection.
+		this.openPreviewModal?.setPlanError(planLoadErrorMessage(false));
 		await this.savePluginData(this.syncEngine.getLastSync());
 		this.updateStatusBar(this.syncEngine.getStatus());
 		if (notify) {
@@ -2530,7 +2539,7 @@ export default class EngramSyncPlugin extends Plugin {
 	 *  startup sync, post-saveSettings sync, the status-bar click handler, and
 	 *  the periodic sync interval — all of which need to fire for OAuth users
 	 *  too, not just static-key users. */
-	private hasAuthConfigured(): boolean {
+	hasAuthConfigured(): boolean {
 		return (
 			Boolean(this.settings.apiUrl) &&
 			Boolean(this.settings.apiKey || this.settings.refreshToken)
@@ -2660,9 +2669,7 @@ export default class EngramSyncPlugin extends Plugin {
 					.computeSyncPlan("full")
 					.then((plan) => modal.setPlan(plan))
 					.catch((e) => {
-						modal.setPlanError(
-							"Could not compare with the cloud. Check your connection.",
-						);
+						modal.setPlanError(planLoadErrorMessage(this.hasAuthConfigured()));
 						rlog().error("lifecycle", `Sync plan compute failed: ${errMsg(e)}`);
 					});
 
@@ -2676,9 +2683,11 @@ export default class EngramSyncPlugin extends Plugin {
 				});
 			} catch (e) {
 				// biome-ignore lint/suspicious/noConsole: error boundary
-				console.error("Engram Sync: sync preview failed", e);
-				new Notice("Engram sync: preview failed — check connection");
-				rlog().error("lifecycle", `Sync preview failed: ${errMsg(e)}`);
+				console.error("Engram Sync: sync failed", e);
+				// This boundary wraps BOTH the preview and the sync run it
+				// dispatches — "preview failed" here mislabeled real sync failures.
+				new Notice("Engram: sync failed — open the sync log for details");
+				rlog().error("lifecycle", `Sync (preview or run) failed: ${errMsg(e)}`);
 			}
 		});
 	}
@@ -2691,6 +2700,15 @@ export default class EngramSyncPlugin extends Plugin {
 	}
 
 	/** Open the plugin settings on the Sync Center tab. */
+	openConnectionSettings(): void {
+		this.settingTab?.setInitialTab("connection");
+		const setting = (
+			this.app as unknown as { setting: { open(): void; openTabById(id: string): void } }
+		).setting;
+		setting.open();
+		setting.openTabById(this.manifest.id);
+	}
+
 	openSyncCenterSettings(): void {
 		this.settingTab?.setInitialTab("sync-center");
 		const setting = (
@@ -2709,7 +2727,13 @@ export default class EngramSyncPlugin extends Plugin {
 		let text: string;
 		let tooltip: string;
 
-		if (blocked && status.state !== "syncing") {
+		if (!this.hasAuthConfigured()) {
+			// Signed out (or never linked): "ready" here was a lie the 2026-08-12
+			// incident shipped — after a forced sign-out the bar claimed ready
+			// while every sync path was dead.
+			text = "Engram: signed out";
+			tooltip = "Not signed in — click to open settings and reconnect";
+		} else if (blocked && status.state !== "syncing") {
 			// Sync gate closed — user has not picked a direction in SyncPreviewModal
 			// for the current auth+vault fingerprint. Show a click-to-resolve nag.
 			text =

--- a/src/main.ts
+++ b/src/main.ts
@@ -2686,7 +2686,7 @@ export default class EngramSyncPlugin extends Plugin {
 				console.error("Engram Sync: sync failed", e);
 				// This boundary wraps BOTH the preview and the sync run it
 				// dispatches — "preview failed" here mislabeled real sync failures.
-				new Notice("Engram: sync failed — open the sync log for details");
+				new Notice("Engram: sync failed. Open the sync log for details.");
 				rlog().error("lifecycle", `Sync (preview or run) failed: ${errMsg(e)}`);
 			}
 		});
@@ -2700,6 +2700,18 @@ export default class EngramSyncPlugin extends Plugin {
 	}
 
 	/** Open the plugin settings on the Sync Center tab. */
+	/** Register/unregister the preview modal that auth invalidation should poke
+	 *  with the sign-in error. Public so BOTH entry points (first-sync command
+	 *  and Sync Center) share the seam — the Sync Center modal missing it left
+	 *  the incident's 8s-spin-then-blame-connection limbo alive there. */
+	trackPreviewModal(modal: { close(): void; setPlanError(msg: string): void }): void {
+		this.openPreviewModal = modal;
+	}
+
+	untrackPreviewModal(modal: { close(): void; setPlanError(msg: string): void }): void {
+		if (this.openPreviewModal === modal) this.openPreviewModal = null;
+	}
+
 	openConnectionSettings(): void {
 		this.settingTab?.setInitialTab("connection");
 		const setting = (
@@ -2732,7 +2744,7 @@ export default class EngramSyncPlugin extends Plugin {
 			// incident shipped — after a forced sign-out the bar claimed ready
 			// while every sync path was dead.
 			text = "Engram: signed out";
-			tooltip = "Not signed in — click to open settings and reconnect";
+			tooltip = "Not signed in. Click to open settings and reconnect.";
 		} else if (blocked && status.state !== "syncing") {
 			// Sync gate closed — user has not picked a direction in SyncPreviewModal
 			// for the current auth+vault fingerprint. Show a click-to-resolve nag.
@@ -2763,7 +2775,10 @@ export default class EngramSyncPlugin extends Plugin {
 		}
 
 		const errorCount = this.syncLog?.errorCount() ?? 0;
-		if (errorCount > 0 && status.state === "idle" && !blocked) {
+		// hasAuthConfigured guard: dead auth PRODUCES logged sync errors, so
+		// without it the error badge overwrites "signed out" in exactly the
+		// forced-sign-out state the branch above exists for.
+		if (errorCount > 0 && status.state === "idle" && !blocked && this.hasAuthConfigured()) {
 			text = `Engram: ⚠ ${errorCount} sync errors`;
 		}
 

--- a/src/sync-center-render.ts
+++ b/src/sync-center-render.ts
@@ -10,7 +10,7 @@ import type EngramSyncPlugin from "./main";
 import type { QueuedReason } from "./offline-queue";
 import { ACTION_ICONS } from "./sync-log-modal";
 import { plural } from "./sync-plan-format";
-import { SyncPreviewModal } from "./sync-preview-modal";
+import { planLoadErrorMessage, SyncPreviewModal } from "./sync-preview-modal";
 import { DEFAULT_UPGRADE_URL } from "./tabs/urls";
 import type { SyncIssue, SyncIssueCategory, SyncLogEntry } from "./types";
 
@@ -152,9 +152,7 @@ function renderActions(parent: HTMLElement, plugin: EngramSyncPlugin, refresh: (
 			void plugin.syncEngine
 				.computeSyncPlan("full")
 				.then((p) => modal.setPlan(p))
-				.catch(() =>
-					modal.setPlanError("Could not compare with the cloud. Check your connection."),
-				);
+				.catch(() => modal.setPlanError(planLoadErrorMessage(plugin.hasAuthConfigured())));
 			const choice = await modal.awaitChoice();
 			// change-vault is unreachable here (showChangeVault: false), but assert in
 			// case a future caller flips that flag without updating this dispatch site.

--- a/src/sync-center-render.ts
+++ b/src/sync-center-render.ts
@@ -153,7 +153,15 @@ function renderActions(parent: HTMLElement, plugin: EngramSyncPlugin, refresh: (
 				.computeSyncPlan("full")
 				.then((p) => modal.setPlan(p))
 				.catch(() => modal.setPlanError(planLoadErrorMessage(plugin.hasAuthConfigured())));
-			const choice = await modal.awaitChoice();
+			// Registered so auth invalidation can flip this modal to the sign-in
+			// error too, not just the first-sync command's modal.
+			plugin.trackPreviewModal(modal);
+			let choice: Awaited<ReturnType<typeof modal.awaitChoice>>;
+			try {
+				choice = await modal.awaitChoice();
+			} finally {
+				plugin.untrackPreviewModal(modal);
+			}
 			// change-vault is unreachable here (showChangeVault: false), but assert in
 			// case a future caller flips that flag without updating this dispatch site.
 			if (choice === "change-vault") {

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -146,6 +146,16 @@ export class SyncPreviewState {
 	}
 }
 
+/** Plan-load failure copy for the preview modal. Auth state decides the
+ *  message: blaming the connection when the real problem is a dead login sent
+ *  the 2026-08-12 incident user into a retry limbo — the signed-out copy must
+ *  say "sign in", never "check your connection". Pure for testing. */
+export function planLoadErrorMessage(hasAuth: boolean): string {
+	return hasAuth
+		? "Could not compare with the cloud. Check your connection."
+		: "Your login expired — sign in again in Engram settings to continue.";
+}
+
 /** Map a createVault rejection to a short human label. LimitExceededError =
  *  402 from the standardized backend body (spec §4.6), 422 = validation
  *  (e.g. duplicate/empty name), else a generic connection message. Pure

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -153,7 +153,7 @@ export class SyncPreviewState {
 export function planLoadErrorMessage(hasAuth: boolean): string {
 	return hasAuth
 		? "Could not compare with the cloud. Check your connection."
-		: "Your login expired — sign in again in Engram settings to continue.";
+		: "Your login expired. Sign in again in Engram settings to continue.";
 }
 
 /** Map a createVault rejection to a short human label. LimitExceededError =

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3939,6 +3939,12 @@ export class SyncEngine {
 			 *  FILE units (the plan's denominator), not op-log rows. Drives the
 			 *  per-file "pulling" progress the UI seeds from the plan. */
 			onFileApplied?: (path: string) => void;
+			/** When this call COALESCES behind an in-flight replay: true = wait
+			 *  for the running session and return its real counts (the sync
+			 *  modal's honest-recap path); false/absent = return zeros instantly
+			 *  (poll, join handler, exclusive retry loop — callers that must not
+			 *  block for a whole replay or claim another caller's work). */
+			awaitCoalesced?: boolean;
 		} = {},
 	): Promise<{
 		applied: number;
@@ -3968,14 +3974,31 @@ export class SyncEngine {
 		const serverIds = new Set<string>();
 		const serverAttachmentPaths = new Set<string>();
 		if (this.seqReplayRunning) {
-			// Ask the running replay for one more pass, then WAIT for it and
-			// report its real counts. Returning zeros here made a coalesced
-			// fullSync tell the progress modal "Already up to date" while the
-			// join-triggered replay was still downloading the vault behind it.
+			this.seqReplayAgain = true;
+			if (!opts.awaitCoalesced) {
+				// Fast-return zeros: the poll, the topic-join handler, and the
+				// exclusive destructive loop all depend on a coalesced call being
+				// near-instant (blocking the join handler defers the op-queue
+				// drain for the whole replay; real counts here fire spurious
+				// "pulled N changes" toasts for another caller's work).
+				return {
+					applied: 0,
+					files: 0,
+					failed: 0,
+					deletes: 0,
+					serverIds,
+					serverAttachmentPaths,
+					ran: false,
+					complete: false,
+				};
+			}
+			// Progress-reporting caller (the sync modal): WAIT for the running
+			// session and report its real counts. Returning zeros here made a
+			// coalesced fullSync tell the progress modal "Already up to date"
+			// while the join-triggered replay was still downloading the vault.
 			// Safe: seqReplayRunning=true means the running task is suspended at
 			// an await INSIDE its loop (the exit path from condition-check to
 			// finally has no await), so it always sees the flag we just set.
-			this.seqReplayAgain = true;
 			const running = await this.seqReplayResult?.catch(() => null);
 			return {
 				applied: running?.applied ?? 0,
@@ -4040,7 +4063,10 @@ export class SyncEngine {
 		try {
 			return await session;
 		} finally {
-			this.seqReplayResult = null;
+			// Guarded: a new owner can start in the microtask window between the
+			// IIFE clearing seqReplayRunning and this continuation running —
+			// nulling unconditionally would drop the NEW session's promise.
+			if (this.seqReplayResult === session) this.seqReplayResult = null;
 		}
 	}
 
@@ -4149,12 +4175,16 @@ export class SyncEngine {
 				await this.seedEmptyFolders();
 				const { files, failed, deletes } = await this.catchupViaSeqReplay({
 					onFileApplied,
+					awaitCoalesced: opts.reportProgress,
 				});
 				return { files, failed, deletes };
 			}
 			await this.reconcileFromManifest(manifest, authGenAtFetch);
 			const behind = this.validateFromManifest(manifest);
-			const { files, failed, deletes } = await this.catchupViaSeqReplay({ onFileApplied });
+			const { files, failed, deletes } = await this.catchupViaSeqReplay({
+				onFileApplied,
+				awaitCoalesced: opts.reportProgress,
+			});
 			const poked = await this.healDivergedLiveBoundNotes(manifest);
 			try {
 				await this.syncExplicitFolders();
@@ -4263,8 +4293,9 @@ export class SyncEngine {
 							if (!c.deleted && changed) {
 								// One row per op, but the plan (the progress denominator)
 								// counts folded FILES — dedupe so a note with N ops ticks once.
-								const key =
-									c.type === "attachment" ? `a:${c.path}` : `n:${c.id ?? c.path}`;
+								// Keyed by IDENTITY for both kinds: a rename mid-log changes
+								// the path but is still one planned file.
+								const key = `${c.type === "attachment" ? "a" : "n"}:${c.id ?? c.path}`;
 								if (!tickedKeys.has(key)) {
 									tickedKeys.add(key);
 									files += 1;
@@ -4885,13 +4916,41 @@ export class SyncEngine {
 					serverAttachmentPaths,
 				} = replay);
 			} else {
+				// Keep-branch needs the from-zero replay to ACTUALLY run too: a
+				// coalesced call rides an incremental session (fromZero silently
+				// dropped), so files behind the persisted cursor never re-download
+				// while the recap claims a completed restore. Bounded retry until
+				// this call runs the replay itself — but unlike the wipe, an
+				// INCOMPLETE walk is fine: pulled files are real and nothing is
+				// trashed off the partial sets.
+				let replay: {
+					applied: number;
+					files: number;
+					failed: number;
+					serverIds: Set<string>;
+					serverAttachmentPaths: Set<string>;
+				} | null = null;
+				for (let attempt = 0; attempt < 10; attempt++) {
+					const res = await this.catchupViaSeqReplay({ fromZero: true, onFileApplied });
+					if (res.ran) {
+						replay = res;
+						break;
+					}
+					await this.sleep(50);
+				}
+				if (!replay) {
+					this.lastError =
+						"Pull all aborted: another sync is running (replay contention). Try again when it finishes.";
+					rlog().warn("pull", `${label} ABORTED: replay never ran exclusively`);
+					return 0;
+				}
 				({
 					applied,
 					files: pulledFileCount,
 					failed: replayFailed,
 					serverIds,
 					serverAttachmentPaths,
-				} = await this.catchupViaSeqReplay({ fromZero: true, onFileApplied }));
+				} = replay);
 			}
 
 			devLog().log(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3754,6 +3754,14 @@ export class SyncEngine {
 	 *  committed during the replay is never missed. */
 	private seqReplayRunning = false;
 	private seqReplayAgain = false;
+	/** Resolves with the running replay session's counts — what a coalescing
+	 *  caller awaits so it can report real work instead of zeros. */
+	private seqReplayResult: Promise<{
+		applied: number;
+		files: number;
+		failed: number;
+		deletes: number;
+	}> | null = null;
 	private seqHealLastAt = 0;
 	private seqHealTimer: number | null = null;
 	private static readonly SEQ_HEAL_COOLDOWN_MS = 4_000;
@@ -3960,12 +3968,23 @@ export class SyncEngine {
 		const serverIds = new Set<string>();
 		const serverAttachmentPaths = new Set<string>();
 		if (this.seqReplayRunning) {
+			// Ask the running replay for one more pass, then WAIT for it and
+			// report its real counts. Returning zeros here made a coalesced
+			// fullSync tell the progress modal "Already up to date" while the
+			// join-triggered replay was still downloading the vault behind it.
+			// Safe: seqReplayRunning=true means the running task is suspended at
+			// an await INSIDE its loop (the exit path from condition-check to
+			// finally has no await), so it always sees the flag we just set.
 			this.seqReplayAgain = true;
+			const running = await this.seqReplayResult?.catch(() => null);
 			return {
-				applied: 0,
-				files: 0,
-				failed: 0,
-				deletes: 0,
+				applied: running?.applied ?? 0,
+				files: running?.files ?? 0,
+				failed: running?.failed ?? 0,
+				deletes: running?.deletes ?? 0,
+				// Still EMPTY sets + ran:false — the counts are honest but the
+				// sets belong to the other caller's walk; destructive decisions
+				// keep requiring ran && complete.
 				serverIds,
 				serverAttachmentPaths,
 				ran: false,
@@ -3973,42 +3992,56 @@ export class SyncEngine {
 			};
 		}
 		this.seqReplayRunning = true;
-		let applied = 0;
-		let files = 0;
-		let failed = 0;
-		let deletes = 0;
-		let complete = true;
+		const session = (async () => {
+			let applied = 0;
+			let files = 0;
+			let failed = 0;
+			let deletes = 0;
+			let complete = true;
+			// FILE-unit dedupe across every pass of this session: the op-log has
+			// one row per op, the plan counts folded files — a note with N ops
+			// must tick the progress feed once, or `current` outruns the plan's
+			// denominator and the bar pins at 100% while files keep arriving.
+			const tickedKeys = new Set<string>();
+			try {
+				do {
+					this.seqReplayAgain = false;
+					const pass = await this.runSeqReplayOnce(
+						(opts.fromZero ?? false) || (opts.enumerateOnly ?? false),
+						serverIds,
+						serverAttachmentPaths,
+						tickedKeys,
+						opts.enumerateOnly ?? false,
+						opts.onFileApplied,
+					);
+					applied += pass.applied;
+					files += pass.files;
+					failed += pass.failed;
+					deletes += pass.deletes;
+					// The sets accumulate across coalesced passes, so ONE short pass taints
+					// the whole result — never OR this back to true.
+					if (!pass.complete) complete = false;
+				} while (this.seqReplayAgain);
+			} finally {
+				this.seqReplayRunning = false;
+			}
+			return {
+				applied,
+				files,
+				failed,
+				deletes,
+				serverIds,
+				serverAttachmentPaths,
+				ran: true,
+				complete,
+			};
+		})();
+		this.seqReplayResult = session;
 		try {
-			do {
-				this.seqReplayAgain = false;
-				const pass = await this.runSeqReplayOnce(
-					(opts.fromZero ?? false) || (opts.enumerateOnly ?? false),
-					serverIds,
-					serverAttachmentPaths,
-					opts.enumerateOnly ?? false,
-					opts.onFileApplied,
-				);
-				applied += pass.applied;
-				files += pass.files;
-				failed += pass.failed;
-				deletes += pass.deletes;
-				// The sets accumulate across coalesced passes, so ONE short pass taints
-				// the whole result — never OR this back to true.
-				if (!pass.complete) complete = false;
-			} while (this.seqReplayAgain);
+			return await session;
 		} finally {
-			this.seqReplayRunning = false;
+			this.seqReplayResult = null;
 		}
-		return {
-			applied,
-			files,
-			failed,
-			deletes,
-			serverIds,
-			serverAttachmentPaths,
-			ran: true,
-			complete,
-		};
 	}
 
 	/** Run `catchupViaSeqReplay` for a DESTRUCTIVE delete decision (pull-all wipe,
@@ -4149,7 +4182,10 @@ export class SyncEngine {
 				e instanceof Error ? e.stack : undefined,
 			);
 			this.onVaultScopedError?.(e);
-			return { files: 0, failed: 0, deletes: 0 };
+			// failed:1 so a progress-reporting caller (the sync modal) renders a
+			// failure instead of "All synced" — a dead-auth or dead-manifest
+			// catch-up must never read as success. Background pollers ignore it.
+			return { files: 0, failed: 1, deletes: 0 };
 		}
 	}
 
@@ -4157,6 +4193,9 @@ export class SyncEngine {
 		fromZero: boolean,
 		serverIds: Set<string>,
 		serverAttachmentPaths: Set<string>,
+		/** Session-scoped: keys already counted as downloaded files. Multiple
+		 *  op-log rows for the same note/attachment tick the file counter once. */
+		tickedKeys: Set<string>,
 		enumerateOnly = false,
 		onFileApplied?: (path: string) => void,
 		/** `complete` is false when the walk did NOT reach the end of the feed, so
@@ -4222,8 +4261,15 @@ export class SyncEngine {
 							// Counting them made the recap disagree with the plan AND showed
 							// a Downloading bar on a sync with nothing to download.
 							if (!c.deleted && changed) {
-								files += 1;
-								onFileApplied?.(c.path);
+								// One row per op, but the plan (the progress denominator)
+								// counts folded FILES — dedupe so a note with N ops ticks once.
+								const key =
+									c.type === "attachment" ? `a:${c.path}` : `n:${c.id ?? c.path}`;
+								if (!tickedKeys.has(key)) {
+									tickedKeys.add(key);
+									files += 1;
+									onFileApplied?.(c.path);
+								}
 							} else if (c.deleted && changed) {
 								// A tombstone that actually trashed a local file — surfaced
 								// separately so a delete-only poll is still user-visible

--- a/tests/main-auth-ux.test.ts
+++ b/tests/main-auth-ux.test.ts
@@ -103,3 +103,90 @@ describe("clearAuthAndPromptRelink surfaces into an open preview modal", () => {
 		expect(planErrors).toEqual([planLoadErrorMessage(false)]);
 	});
 });
+
+describe("round-1 review fixes (#422)", () => {
+	test("signed-out status wins over the sync-error override", () => {
+		const texts: string[] = [];
+		const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
+			settings: {},
+			statusBarEl: {
+				setText(t: string) {
+					texts.push(t);
+				},
+				setAttribute(_k: string, _v: string) {},
+			},
+			syncEngine: {
+				isSyncBlocked() {
+					return false;
+				},
+			},
+			// Dead auth PRODUCES logged sync errors — the exact state the
+			// signed-out branch exists for must not be masked by the error badge.
+			syncLog: {
+				errorCount() {
+					return 3;
+				},
+			},
+			liveConnected: false,
+		});
+		(
+			EngramSyncPlugin.prototype as unknown as {
+				updateStatusBar(this: unknown, s: SyncStatus): void;
+			}
+		).updateStatusBar.call(fake, { state: "idle", pending: 0, queued: 0 } as SyncStatus);
+		expect(texts[0]).toMatch(/signed out/i);
+	});
+
+	test("trackPreviewModal registers a modal for the auth poke; untrack clears it", async () => {
+		const planErrors: string[] = [];
+		const modal = {
+			close() {},
+			setPlanError(msg: string) {
+				planErrors.push(msg);
+			},
+		};
+		const proto = EngramSyncPlugin.prototype as unknown as {
+			trackPreviewModal(this: unknown, m: unknown): void;
+			untrackPreviewModal(this: unknown, m: unknown): void;
+			clearAuthAndPromptRelink(this: unknown, reason: string, notify: boolean): Promise<void>;
+		};
+		const base = {
+			settings: { refreshToken: "rt" } as Record<string, unknown>,
+			api: { setAuthProvider(_p: unknown) {} },
+			authProvider: null,
+			noteStream: null,
+			liveConnected: false,
+			everConnected: false,
+			openPreviewModal: null as unknown,
+			async savePluginData(_ls: unknown) {},
+			syncEngine: {
+				getLastSync() {
+					return 0;
+				},
+				getStatus() {
+					return { state: "idle", pending: 0, queued: 0 };
+				},
+			},
+			updateStatusBar(_s: unknown) {},
+		};
+		const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), base);
+
+		proto.trackPreviewModal.call(fake, modal);
+		await proto.clearAuthAndPromptRelink.call(fake, "test", false);
+		expect(planErrors).toEqual([planLoadErrorMessage(false)]);
+
+		const fake2 = Object.assign(Object.create(EngramSyncPlugin.prototype), base, {
+			settings: { refreshToken: "rt" },
+		});
+		proto.trackPreviewModal.call(fake2, modal);
+		proto.untrackPreviewModal.call(fake2, modal);
+		planErrors.length = 0;
+		await proto.clearAuthAndPromptRelink.call(fake2, "test", false);
+		expect(planErrors).toEqual([]);
+	});
+
+	test("no em dashes in the new user-facing copy", () => {
+		expect(planLoadErrorMessage(true)).not.toContain("\u2014");
+		expect(planLoadErrorMessage(false)).not.toContain("\u2014");
+	});
+});

--- a/tests/main-auth-ux.test.ts
+++ b/tests/main-auth-ux.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests: auth-failure surfacing (#420 P2).
+ *
+ * Prod 2026-08-12: the token family was revoked mid-first-sync. The status bar
+ * kept saying "Engram: ready" with a click that silently did nothing, the open
+ * preview modal spun for 8s then blamed the connection, and nothing anywhere
+ * said "sign in again". These pin the honest states.
+ */
+import { describe, expect, test } from "bun:test";
+import EngramSyncPlugin from "../src/main";
+import { planLoadErrorMessage } from "../src/sync-preview-modal";
+import type { SyncStatus } from "../src/types";
+
+describe("planLoadErrorMessage", () => {
+	test("auth configured → connection copy; signed out → sign-in copy", () => {
+		expect(planLoadErrorMessage(true)).toMatch(/connection/i);
+		expect(planLoadErrorMessage(false)).toMatch(/sign in/i);
+		// The signed-out copy must never blame the network — that's the lie the
+		// incident shipped.
+		expect(planLoadErrorMessage(false)).not.toMatch(/connection/i);
+	});
+});
+
+describe("status bar when signed out", () => {
+	function fakeFor(settings: Record<string, unknown>) {
+		const texts: string[] = [];
+		const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
+			settings,
+			statusBarEl: {
+				setText(t: string) {
+					texts.push(t);
+				},
+				setAttribute(_k: string, _v: string) {},
+			},
+			syncEngine: {
+				isSyncBlocked() {
+					return false;
+				},
+			},
+			syncLog: null,
+			liveConnected: false,
+		});
+		return { fake, texts };
+	}
+	const idle: SyncStatus = { state: "idle", pending: 0, queued: 0 } as SyncStatus;
+
+	test("no auth configured → says signed out, not ready", () => {
+		const { fake, texts } = fakeFor({});
+		(
+			EngramSyncPlugin.prototype as unknown as {
+				updateStatusBar(this: unknown, s: SyncStatus): void;
+			}
+		).updateStatusBar.call(fake, idle);
+		expect(texts[0]).toMatch(/signed out/i);
+	});
+
+	test("auth configured → unchanged ready state", () => {
+		const { fake, texts } = fakeFor({ apiUrl: "https://api", refreshToken: "rt" });
+		(
+			EngramSyncPlugin.prototype as unknown as {
+				updateStatusBar(this: unknown, s: SyncStatus): void;
+			}
+		).updateStatusBar.call(fake, idle);
+		expect(texts[0]).toBe("Engram: ready");
+	});
+});
+
+describe("clearAuthAndPromptRelink surfaces into an open preview modal", () => {
+	test("sets the sign-in plan error on the open modal", async () => {
+		const planErrors: string[] = [];
+		const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
+			settings: { refreshToken: "rt" } as Record<string, unknown>,
+			api: { setAuthProvider(_p: unknown) {} },
+			authProvider: null,
+			noteStream: null,
+			liveConnected: false,
+			everConnected: false,
+			openPreviewModal: {
+				setPlanError(msg: string) {
+					planErrors.push(msg);
+				},
+			},
+			async savePluginData(_ls: unknown) {},
+			syncEngine: {
+				getLastSync() {
+					return 0;
+				},
+				getStatus() {
+					return { state: "idle", pending: 0, queued: 0 };
+				},
+			},
+			updateStatusBar(_s: unknown) {},
+		});
+
+		await (
+			EngramSyncPlugin.prototype as unknown as {
+				clearAuthAndPromptRelink(reason: string, notify: boolean): Promise<void>;
+			}
+		).clearAuthAndPromptRelink.call(fake, "test", false);
+
+		// The open modal must flip to the sign-in error instead of spinning
+		// until the enumerate budget expires and blaming the connection.
+		expect(planErrors).toEqual([planLoadErrorMessage(false)]);
+	});
+});

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -387,3 +387,67 @@ describe("review findings — rerun progress continuity + joiner marker", () => 
 		expect((b as { joined?: boolean }).joined).toBe(true);
 	});
 });
+
+describe("first-sync progress honesty (#420 P2)", () => {
+	test("multiple op-log rows for one note tick the file counter ONCE", async () => {
+		// The plan's denominator is folded per note; a note with N ops must not
+		// contribute N ticks or the bar pins at 100% while files keep arriving.
+		const feed = [
+			noteRow({ id: "id-a", seq: 1, path: "Notes/a.md", content: "v1" }),
+			noteRow({ id: "id-a", seq: 2, path: "Notes/a.md", content: "v2" }),
+			noteRow({ id: "id-b", seq: 3, path: "Notes/b.md" }),
+		];
+		const { engine, events } = makeEngine(feed);
+
+		const res = await engine.catchUp({ reportProgress: true });
+
+		expect(res.files).toBe(2);
+		const pulls = events.filter((e) => e.phase === "pulling");
+		expect(pulls.length).toBe(2);
+		expect(pulls.map((e) => e.current)).toEqual([1, 2]);
+	});
+
+	test("a catch-up coalescing behind an in-flight replay reports the REAL file count", async () => {
+		// Returning {files: 0} from the coalesced call made the one-click first
+		// sync report "Already up to date" while the join-triggered replay was
+		// still downloading the vault behind the modal.
+		const feed = [
+			noteRow({ id: "id-a", seq: 1, path: "Notes/a.md" }),
+			noteRow({ id: "id-b", seq: 2, path: "Notes/b.md" }),
+		];
+		const { engine } = makeEngine(feed);
+		let releaseFirstFetch!: () => void;
+		const gate = new Promise<void>((r) => (releaseFirstFetch = r));
+		let call = 0;
+		engine.setCrdtCatchupSince(async () => {
+			call += 1;
+			if (call === 1) await gate;
+			return { changes: call <= 2 ? feed : [], has_more: false, next_seq: null };
+		});
+
+		const first = engine.catchUp({ reportProgress: false });
+		// Let the first call reach the (gated) fetch before the second starts.
+		await new Promise((r) => setTimeout(r, 10));
+		const second = engine.catchUp({ reportProgress: true });
+		await new Promise((r) => setTimeout(r, 10));
+		releaseFirstFetch();
+
+		const [firstRes, secondRes] = await Promise.all([first, second]);
+		expect(firstRes.files).toBe(2);
+		// The coalesced caller waited for the running replay and reports what it
+		// actually downloaded — not a fabricated "nothing to do".
+		expect(secondRes.files).toBe(2);
+	});
+
+	test("a catch-up that dies at the boundary reports a failure, not success", async () => {
+		const { engine } = makeEngine([]);
+		(engine as unknown as { api: { getManifest: () => Promise<never> } }).api.getManifest =
+			mock().mockRejectedValue(new Error("HTTP 401"));
+
+		const res = await engine.catchUp({ reportProgress: true });
+
+		// files 0 + failed 0 renders as "All synced" in the completion modal —
+		// a dead-auth first sync must never claim success.
+		expect(res.failed).toBeGreaterThan(0);
+	});
+});

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -451,3 +451,81 @@ describe("first-sync progress honesty (#420 P2)", () => {
 		expect(res.failed).toBeGreaterThan(0);
 	});
 });
+
+describe("coalesce semantics are opt-in (#422 review round 1)", () => {
+	const gatedEngine = () => {
+		const feed = [
+			noteRow({ id: "id-a", seq: 1, path: "Notes/a.md" }),
+			noteRow({ id: "id-b", seq: 2, path: "Notes/b.md" }),
+		];
+		const { engine } = makeEngine(feed);
+		let release!: () => void;
+		const gate = new Promise<void>((r) => (release = r));
+		let call = 0;
+		engine.setCrdtCatchupSince(async () => {
+			call += 1;
+			if (call === 1) await gate;
+			return { changes: call <= 2 ? feed : [], has_more: false, next_seq: null };
+		});
+		return { engine, release };
+	};
+
+	test("a non-progress catch-up coalesces to zeros instantly (poll/join semantics)", async () => {
+		const { engine, release } = gatedEngine();
+		const owner = engine.catchUp({ reportProgress: true });
+		await new Promise((r) => setTimeout(r, 10));
+
+		// The 5-min poll and the topic-join handler depend on the old fast
+		// return: blocking them behind a long replay defers the op-queue drain,
+		// and real counts here fire a spurious "pulled N changes" toast.
+		const start = Date.now();
+		const polled = await engine.catchUp({ reportProgress: false });
+		expect(polled.files).toBe(0);
+		expect(Date.now() - start).toBeLessThan(200);
+
+		release();
+		await owner;
+	});
+
+	test("pull-all-keep refuses to fake success when the replay coalesces", async () => {
+		const { engine, release } = gatedEngine();
+		const owner = engine.catchUp({ reportProgress: true });
+		await new Promise((r) => setTimeout(r, 10));
+
+		// A coalesced pull-all never replays from zero — reporting the running
+		// incremental session's counts would claim a full-vault restore that
+		// did not happen.
+		const pulled = await engine.pullAll({ deleteLocalExtras: false });
+		expect(pulled).toBe(0);
+		expect(engine.getStatus().error ?? "").toMatch(/another sync|contention|aborted/i);
+
+		release();
+		await owner;
+	});
+
+	test("attachment rows dedupe by id across a rename, like notes", async () => {
+		const attRow = (over: Record<string, unknown>) =>
+			({
+				type: "attachment",
+				id: "att-1",
+				seq: 1,
+				path: "Files/x.png",
+				mime_type: "image/png",
+				size_bytes: 3,
+				mtime: 1,
+				updated_at: "2026-01-01T00:00:00Z",
+				deleted: false,
+				...over,
+			}) as unknown as SyncChange;
+		const feed = [
+			attRow({ seq: 1, path: "Files/x.png" }),
+			attRow({ seq: 2, path: "Files/renamed.png" }),
+		];
+		const { engine } = makeEngine(feed);
+
+		const res = await engine.catchUp({ reportProgress: true });
+		// One attachment renamed mid-log is ONE planned file — two path-keyed
+		// ticks would overrun the plan's denominator (the pinned-bar bug).
+		expect(res.files).toBe(1);
+	});
+});

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -190,8 +190,11 @@ describe("SyncEngine.pullAll — replay-from-0 (Task 5)", () => {
 				applied: 1,
 				files: 1,
 				failed: 0,
+				deletes: 0,
 				serverIds: new Set(["s1"]),
 				serverAttachmentPaths: new Set<string>(),
+				ran: true,
+				complete: true,
 			};
 		};
 


### PR DESCRIPTION
## Why

Prod 2026-08-12 (#420): mid-first-sync the token family was revoked. Beyond the auth bug itself (#421), the UX lied at every step: the progress bar was "100% wrong", the modal claimed success off a failed read, the status bar said "ready" with a dead click, and every error blamed the connection instead of the dead login.

## Progress accuracy — three engine fixes (src/sync.ts)

1. **File ticks dedupe per note/attachment** across all passes of a replay session. The op-log carries one row per op; the plan (the progress denominator) counts folded files. A note with N ops ticked N times, `current` outran the plan, and the bar pinned at 100% while files kept arriving.
2. **Coalesced catch-up awaits the running replay** and reports its real counts. Returning `{files: 0}` made a one-click first sync say "Already up to date" while the join-triggered replay downloaded the vault behind the modal. Destructive semantics unchanged: coalesced calls still return empty sets + `ran:false`.
3. **The `catchUp` boundary returns `failed:1`** so a dead-auth/dead-manifest pass renders as a failure, not "All synced".

## Auth-failure surfacing

- Status bar: **"Engram: signed out"** when no auth is configured (was "ready"), and the click opens the Connection settings tab (was a silent `return`).
- **Auth-aware plan-error copy** (`planLoadErrorMessage`): signed out → "sign in again in Engram settings", never "check your connection". Wired at both call sites (first-sync + Sync Center).
- `clearAuthAndPromptRelink` **flips an open preview modal** to the sign-in error immediately instead of letting it spin the 8s enumerate budget and blame the network.
- The `doSyncWithFirstSyncCheck` boundary no longer labels sync-run failures "preview failed".

## Tests

TDD (all watched red first): 3 engine tests in `tests/sync-progress-firstsync.test.ts` (dedupe, coalesce-reports-real-counts, boundary failure) + 4 in new `tests/main-auth-ux.test.ts` (copy, signed-out status bar both ways, modal poke). Full suite 2536 pass / 0 fail; biome + eslint + stylelint + tsc + build green.

Refs #420 (P2; P1 was #421, P3 resolved as already-shipped — see issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC