### PR TITLE
fix(sync): first-sync progress stream and server oracle

### DIFF
--- a/main.js
+++ b/main.js
@@ -20925,7 +20925,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         let mimeType = this.getMimeType(file);
         await this.api.pushAttachment(file.path, base64, mimeType, mtime), this.stampSyncedRow((0, import_obsidian24.normalizePath)(file.path), { hash });
       } else {
-        let content = noteContent, hash = noteHash, noteId = (_c = (_b = this.noteIdMap) == null ? void 0 : _b.get(file.path)) != null ? _c : null;
+        let content = await this.app.vault.cachedRead(file), hash = fnv1a(content), noteId = (_c = (_b = this.noteIdMap) == null ? void 0 : _b.get(file.path)) != null ? _c : null;
         if (!noteId && this.noteIdMap) {
           if (this.shouldDeferMint(file.path))
             return rlog().info(
@@ -22579,12 +22579,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               return rlog().warn(
                 "pull",
                 `CRDT catch-up: pull backfilling diverged note (no note_id) ${change.path}`
-              ), await this.flushFromCrdt(normalized, content), this.markServerKnown(normalized), this.stampSyncedRow(normalized, {
+              ), await this.flushFromCrdt(normalized, content) ? (this.markServerKnown(normalized), this.stampSyncedRow(normalized, {
                 hash: fnv1a(content),
                 version: change.version,
                 serverHash: change.content_hash,
                 seq: change.seq
-              }), !0;
+              }), !0) : !1;
           }
         else
           rlog().info("pull", `CRDT-managed: re-enroll for catch-up ${change.path}`);

--- a/main.js
+++ b/main.js
@@ -20114,7 +20114,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
    *  only the content hash is refreshed. `markCreated` additionally flips the
    *  `hasServerNote` oracle via the CRDT_HEAD_CREATED sentinel (genesis /
    *  create-ack adopt sites); the first convergence overwrites the sentinel
-   *  with the authoritative head. */
+   *  with the authoritative head.
+   *
+   *  Pulled-from-feed sites do NOT go through `markCreated` — they call
+   *  `markServerKnown` after the flush, which fills a missing head without
+   *  ever overwriting a real one. */
   recordCrdtBaseline(normalized, content, opts) {
     this.patchSyncedRow(normalized, {
       hash: fnv1a(content),
@@ -20495,6 +20499,18 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   }
   setCrdtHead(path, head) {
     this.patchSyncedRow((0, import_obsidian24.normalizePath)(path), { crdtHead: head });
+  }
+  /** Flip the `hasServerNote` oracle for a note the server demonstrably holds,
+   *  without ever DOWNGRADING an authoritative head to the placeholder.
+   *
+   *  `patchSyncedRow` merges, so writing CRDT_HEAD_CREATED over a real head
+   *  recorded by `applyPushedNoteUpdate` would invert the sentinel's contract
+   *  and permanently defeat the convergence cost gate (`getCrdtHead ===
+   *  serverHead` -> skip), re-firing STEP1 for that note forever. The sentinel
+   *  only ever fills a HOLE. */
+  markServerKnown(path) {
+    let normalized = (0, import_obsidian24.normalizePath)(path);
+    this.getCrdtHead(normalized) == null && this.setCrdtHead(normalized, CRDT_HEAD_CREATED);
   }
   /** Public: consumed as `CrdtManagerOptions.canSendLive` by the wiring in
    *  main.ts (`createCrdtWiring({ canSendLive: (id) => this.syncEngine.hasServerNote(id) })`)
@@ -21370,7 +21386,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
       let applied = 0, files = 0, failed = 0, deletes = 0, complete = !0, tickedKeys = /* @__PURE__ */ new Set();
       opts.onFileApplied && this.seqReplayFileListeners.add(opts.onFileApplied);
       let emitFileApplied = (path) => {
-        for (let listener of [...this.seqReplayFileListeners]) listener(path);
+        for (let listener of [...this.seqReplayFileListeners])
+          try {
+            listener(path);
+          } catch (e) {
+            devLog().log("sync", `progress subscriber threw for ${path}: ${errMsg(e)}`);
+          }
       };
       try {
         do {
@@ -21731,17 +21752,8 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         hash: localHash,
         serverHash: staged.serverHash,
         version: staged.version,
-        seq: staged.seq,
-        // #339: a STEP2 that delivered CONTENT is proof the server holds a
-        // row for this note — we just merged the server's own ops for it.
-        // Without flipping the oracle, `hasServerNote` stays false and the
-        // note's next push takes the genesis branch; on a first sync
-        // `splitGenesisVsKnown` then misroutes the entire freshly-pulled
-        // vault through crdtCreateBatch (prod 2026-08-13: "122 files to
-        // upload" from an empty local vault). An EMPTY converged doc is NOT
-        // proof — genesis stays the correct route there, so gate on content.
-        ...staged.content ? { crdtHead: CRDT_HEAD_CREATED } : {}
-      }), rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
+        seq: staged.seq
+      }), staged.content && this.markServerKnown(path), rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
     } catch (e) {
       rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
     }
@@ -22529,7 +22541,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
               return rlog().warn(
                 "pull",
                 `CRDT catch-up: pull backfilling diverged note (no note_id) ${change.path}`
-              ), await this.flushFromCrdt(normalized, content), this.stampSyncedRow(normalized, {
+              ), await this.flushFromCrdt(normalized, content), this.markServerKnown(normalized), this.stampSyncedRow(normalized, {
                 hash: fnv1a(content),
                 version: change.version,
                 serverHash: change.content_hash,
@@ -22539,7 +22551,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         else
           rlog().info("pull", `CRDT-managed: re-enroll for catch-up ${change.path}`);
       } else
-        return noteId && this.isLiveBound(normalized) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content), !0;
+        return noteId && this.isLiveBound(normalized) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content), this.markServerKnown(normalized), !0;
       return !1;
     }
     let existing = this.app.vault.getFileByPath(normalized);

--- a/main.js
+++ b/main.js
@@ -16734,7 +16734,7 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
         }),
         15e3
       );
-      if (resp.status === 428) return;
+      if (resp.status === 400 || resp.status === 428) return;
       if (resp.status >= 200 && resp.status < 300) {
         this.pollInterval && window.clearInterval(this.pollInterval);
         let result = resp.json;

--- a/main.js
+++ b/main.js
@@ -19590,6 +19590,15 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     /** Resolves with the running replay session's counts — what a coalescing
      *  caller awaits so it can report real work instead of zeros. */
     this.seqReplayResult = null;
+    /** Per-file tick subscribers for the RUNNING replay session. The counts a
+     *  coalescing caller awaits are only half the contract — its progress UI
+     *  also needs the STREAM, and the early return can't reach the exclusive
+     *  call site's `onFileApplied` hand-off. On a first sync the join handler
+     *  always owns the replay (it is one of many bare `catchupViaSeqReplay()`
+     *  callers), so the user's modal ALWAYS coalesces: without this it renders
+     *  a dead 0% bar with no filenames for the whole pull, then one final
+     *  number. Registration is scoped to each caller's own await. */
+    this.seqReplayFileListeners = /* @__PURE__ */ new Set();
     this.seqHealLastAt = 0;
     this.seqHealTimer = null;
     /** Ceiling on how long an edit may sit in pendingPostPullPushes while a
@@ -21320,7 +21329,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     return { notes, attachments };
   }
   async catchupViaSeqReplay(opts = {}) {
-    var _a, _b, _c, _d, _e;
+    var _a, _b, _c, _d, _e, _f;
     let serverIds = /* @__PURE__ */ new Set(), serverAttachmentPaths = /* @__PURE__ */ new Set();
     if (this.seqReplayRunning) {
       if (this.seqReplayAgain = !0, !opts.awaitCoalesced)
@@ -21334,12 +21343,18 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           ran: !1,
           complete: !1
         };
-      let running = await ((_a = this.seqReplayResult) == null ? void 0 : _a.catch(() => null));
+      opts.onFileApplied && this.seqReplayFileListeners.add(opts.onFileApplied);
+      let running;
+      try {
+        running = (_b = await ((_a = this.seqReplayResult) == null ? void 0 : _a.catch(() => null))) != null ? _b : null;
+      } finally {
+        opts.onFileApplied && this.seqReplayFileListeners.delete(opts.onFileApplied);
+      }
       return {
-        applied: (_b = running == null ? void 0 : running.applied) != null ? _b : 0,
-        files: (_c = running == null ? void 0 : running.files) != null ? _c : 0,
-        failed: (_d = running == null ? void 0 : running.failed) != null ? _d : 0,
-        deletes: (_e = running == null ? void 0 : running.deletes) != null ? _e : 0,
+        applied: (_c = running == null ? void 0 : running.applied) != null ? _c : 0,
+        files: (_d = running == null ? void 0 : running.files) != null ? _d : 0,
+        failed: (_e = running == null ? void 0 : running.failed) != null ? _e : 0,
+        deletes: (_f = running == null ? void 0 : running.deletes) != null ? _f : 0,
         // Still EMPTY sets + ran:false — the counts are honest but the
         // sets belong to the other caller's walk; destructive decisions
         // keep requiring ran && complete.
@@ -21353,6 +21368,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
     let session = (async () => {
       var _a2, _b2, _c2;
       let applied = 0, files = 0, failed = 0, deletes = 0, complete = !0, tickedKeys = /* @__PURE__ */ new Set();
+      opts.onFileApplied && this.seqReplayFileListeners.add(opts.onFileApplied);
+      let emitFileApplied = (path) => {
+        for (let listener of [...this.seqReplayFileListeners]) listener(path);
+      };
       try {
         do {
           this.seqReplayAgain = !1;
@@ -21362,12 +21381,12 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
             serverAttachmentPaths,
             tickedKeys,
             (_c2 = opts.enumerateOnly) != null ? _c2 : !1,
-            opts.onFileApplied
+            emitFileApplied
           );
           applied += pass.applied, files += pass.files, failed += pass.failed, deletes += pass.deletes, pass.complete || (complete = !1);
         } while (this.seqReplayAgain);
       } finally {
-        this.seqReplayRunning = !1;
+        opts.onFileApplied && this.seqReplayFileListeners.delete(opts.onFileApplied), this.seqReplayRunning = !1;
       }
       return {
         applied,
@@ -21712,7 +21731,16 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         hash: localHash,
         serverHash: staged.serverHash,
         version: staged.version,
-        seq: staged.seq
+        seq: staged.seq,
+        // #339: a STEP2 that delivered CONTENT is proof the server holds a
+        // row for this note — we just merged the server's own ops for it.
+        // Without flipping the oracle, `hasServerNote` stays false and the
+        // note's next push takes the genesis branch; on a first sync
+        // `splitGenesisVsKnown` then misroutes the entire freshly-pulled
+        // vault through crdtCreateBatch (prod 2026-08-13: "122 files to
+        // upload" from an empty local vault). An EMPTY converged doc is NOT
+        // proof — genesis stays the correct route there, so gate on content.
+        ...staged.content ? { crdtHead: CRDT_HEAD_CREATED } : {}
       }), rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
     } catch (e) {
       rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);

--- a/main.js
+++ b/main.js
@@ -20898,12 +20898,11 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         }), issueDisposition(gate.category) === "informational" ? this.attachmentLimitedThisBatch += 1 : (this.failuresThisBatch += 1, (_a = this.firstFailureMessageThisBatch) != null || (this.firstFailureMessageThisBatch = gate.message)), devLog().log("push", `skip (pre-gate ${gate.category}): ${file.path}`), !1;
       }
     }
-    let isBinary = this.isBinaryFile(file), noteContent = "", noteHash = 0;
+    let isBinary = this.isBinaryFile(file);
     if (!isBinary) {
-      noteContent = await this.app.vault.cachedRead(file), noteHash = fnv1a(noteContent);
-      let existing = this.syncState.get((0, import_obsidian24.normalizePath)(file.path));
-      if (!force && existing !== void 0 && noteHash === existing.hash)
-        return devLog().log("push", `skip (echo): ${file.path}`), rlog().info("push", `Echo skip: ${file.path} | hash=${noteHash}`), !1;
+      let echoHash = fnv1a(await this.app.vault.cachedRead(file)), existing = this.syncState.get((0, import_obsidian24.normalizePath)(file.path));
+      if (!force && existing !== void 0 && echoHash === existing.hash)
+        return devLog().log("push", `skip (echo): ${file.path}`), rlog().info("push", `Echo skip: ${file.path} | hash=${echoHash}`), !1;
     }
     await this.acquirePushSlot();
     let pushedPath = file.path;

--- a/main.js
+++ b/main.js
@@ -985,8 +985,25 @@ var LEVEL_SEVERITY = {
   async destroy() {
     this.stopTimer(), await this.flush(), this.buffer = [], this.pushFn = null;
   }
-  addEntry(level, category, message, stack, diagnostic) {
-    if (!this.enabled || !this.pushFn || LEVEL_SEVERITY[level] < LEVEL_SEVERITY[this.levelThreshold]) return;
+  /** A silent failure the user cannot see and we cannot debug. Ships at warn
+   *  EVEN WHEN DIAGNOSTICS ARE OFF, and bypasses the level threshold.
+   *
+   *  Why the bypass exists: `diagnosticsEnabled` defaults false, so every
+   *  rlog() call is a no-op on a fresh install — and a user's FIRST sync is
+   *  simultaneously the most likely thing to break and the least likely to
+   *  have telemetry enabled. Prod 2026-08-13: a first sync dropped 316 of 316
+   *  notes and produced exactly zero client log lines to look at.
+   *
+   *  CONTRACT — callers must honour it: counts and reasons ONLY. Never a
+   *  path, a title, or note content. The setting is protecting the user from
+   *  verbose per-note telemetry, and that protection stays intact; what it
+   *  must not do is hide the fact that sync silently did nothing. */
+  anomaly(category, message) {
+    this.addEntry("warn", category, message, void 0, !1, !0);
+  }
+  addEntry(level, category, message, stack, diagnostic, force) {
+    if (!this.pushFn || !force && (!this.enabled || LEVEL_SEVERITY[level] < LEVEL_SEVERITY[this.levelThreshold]))
+      return;
     let entry = {
       ts: (/* @__PURE__ */ new Date()).toISOString(),
       level,
@@ -1014,6 +1031,8 @@ var LEVEL_SEVERITY = {
   info() {
   },
   diag() {
+  },
+  anomaly() {
   },
   setConnId() {
   },
@@ -21406,6 +21425,10 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
           );
           applied += pass.applied, files += pass.files, failed += pass.failed, deletes += pass.deletes, pass.complete || (complete = !1);
         } while (this.seqReplayAgain);
+        applied > 0 && files === 0 && deletes === 0 && rlog().anomaly(
+          "sync",
+          `replay produced no files: applied=${applied} files=0 deletes=0 failed=${failed} complete=${complete}`
+        );
       } finally {
         opts.onFileApplied && this.seqReplayFileListeners.delete(opts.onFileApplied), this.seqReplayRunning = !1;
       }

--- a/main.js
+++ b/main.js
@@ -21366,6 +21366,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   async catchupViaSeqReplay(opts = {}) {
     var _a, _b, _c, _d, _e, _f;
     let serverIds = /* @__PURE__ */ new Set(), serverAttachmentPaths = /* @__PURE__ */ new Set();
+    if (this.syncBlocked)
+      return devLog().log("sync-blocked", "catchupViaSeqReplay skipped \u2014 gate closed"), rlog().anomaly("sync", "catch-up skipped \u2014 sync gate closed (blocked=true)"), {
+        applied: 0,
+        files: 0,
+        failed: 0,
+        deletes: 0,
+        serverIds,
+        serverAttachmentPaths,
+        ran: !1,
+        complete: !1
+      };
     if (this.seqReplayRunning) {
       if (this.seqReplayAgain = !0, !opts.awaitCoalesced)
         return {

--- a/main.js
+++ b/main.js
@@ -20071,7 +20071,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
   async flushFromCrdt(path, content) {
     var _a, _b;
     if (this.syncBlocked)
-      return devLog().log("sync-blocked", `flushFromCrdt short-circuited \u2014 gate closed: ${path}`), !0;
+      return devLog().log("sync-blocked", `flushFromCrdt short-circuited \u2014 gate closed: ${path}`), !1;
     let normalized = (0, import_obsidian24.normalizePath)(path), file = this.app.vault.getAbstractFileByPath(normalized);
     if (file instanceof import_obsidian24.TFile && await this.app.vault.cachedRead(file) === content)
       return this.recordCrdtBaseline(normalized, content), !0;
@@ -21427,7 +21427,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         } while (this.seqReplayAgain);
         applied > 0 && files === 0 && deletes === 0 && rlog().anomaly(
           "sync",
-          `replay produced no files: applied=${applied} files=0 deletes=0 failed=${failed} complete=${complete}`
+          `replay produced no files: applied=${applied} files=0 deletes=0 failed=${failed} complete=${complete} blocked=${this.syncBlocked}`
         );
       } finally {
         opts.onFileApplied && this.seqReplayFileListeners.delete(opts.onFileApplied), this.seqReplayRunning = !1;
@@ -22574,7 +22574,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         else
           rlog().info("pull", `CRDT-managed: re-enroll for catch-up ${change.path}`);
       } else
-        return noteId && this.isLiveBound(normalized) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content), this.markServerKnown(normalized), !0;
+        return noteId && this.isLiveBound(normalized) && ((_k = this.crdtEnrollment) == null || _k.enroll(noteId)), rlog().info("pull", `CRDT discovery: enrolling new note ${change.path}`), await this.flushFromCrdt(normalized, content) ? (this.markServerKnown(normalized), !0) : !1;
       return !1;
     }
     let existing = this.app.vault.getFileByPath(normalized);

--- a/main.js
+++ b/main.js
@@ -20898,10 +20898,17 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         }), issueDisposition(gate.category) === "informational" ? this.attachmentLimitedThisBatch += 1 : (this.failuresThisBatch += 1, (_a = this.firstFailureMessageThisBatch) != null || (this.firstFailureMessageThisBatch = gate.message)), devLog().log("push", `skip (pre-gate ${gate.category}): ${file.path}`), !1;
       }
     }
+    let isBinary = this.isBinaryFile(file), noteContent = "", noteHash = 0;
+    if (!isBinary) {
+      noteContent = await this.app.vault.cachedRead(file), noteHash = fnv1a(noteContent);
+      let existing = this.syncState.get((0, import_obsidian24.normalizePath)(file.path));
+      if (!force && existing !== void 0 && noteHash === existing.hash)
+        return devLog().log("push", `skip (echo): ${file.path}`), rlog().info("push", `Echo skip: ${file.path} | hash=${noteHash}`), !1;
+    }
     await this.acquirePushSlot();
     let pushedPath = file.path;
     this.pushing.add(pushedPath), this.lastError = "", this.emitStatus();
-    let isBinary = this.isBinaryFile(file), success = !1, pushedNoteParse;
+    let success = !1, pushedNoteParse;
     devLog().log(
       "push",
       `start ${isBinary ? "attachment" : "note"}: ${file.path} (active=${this.activePushCount})`
@@ -20918,10 +20925,7 @@ var BINARY_EXTENSIONS = /* @__PURE__ */ new Set([
         let mimeType = this.getMimeType(file);
         await this.api.pushAttachment(file.path, base64, mimeType, mtime), this.stampSyncedRow((0, import_obsidian24.normalizePath)(file.path), { hash });
       } else {
-        let content = await this.app.vault.cachedRead(file), hash = fnv1a(content), existing = this.syncState.get((0, import_obsidian24.normalizePath)(file.path));
-        if (!force && existing !== void 0 && hash === existing.hash)
-          return devLog().log("push", `skip (echo): ${file.path}`), rlog().info("push", `Echo skip: ${file.path} | hash=${hash}`), !1;
-        let noteId = (_c = (_b = this.noteIdMap) == null ? void 0 : _b.get(file.path)) != null ? _c : null;
+        let content = noteContent, hash = noteHash, noteId = (_c = (_b = this.noteIdMap) == null ? void 0 : _b.get(file.path)) != null ? _c : null;
         if (!noteId && this.noteIdMap) {
           if (this.shouldDeferMint(file.path))
             return rlog().info(
@@ -24817,7 +24821,9 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
       );
       return;
     }
-    this.syncGateAcceptedFor = fp, this.syncEngine.setSyncBlocked(!1), (_a = this.crdtEnrollment) == null || _a.resetAll(), await this.savePluginData(this.syncEngine.getLastSync()), this.updateStatusBar(this.syncEngine.getStatus());
+    this.syncGateAcceptedFor = fp, this.syncEngine.setSyncBlocked(!1), (_a = this.crdtEnrollment) == null || _a.resetAll(), this.syncEngine.catchupViaSeqReplay().catch((e) => {
+      rlog().warn("lifecycle", `gate-open catch-up failed: ${errMsg(e)}`);
+    }), await this.savePluginData(this.syncEngine.getLastSync()), this.updateStatusBar(this.syncEngine.getStatus());
   }
   /** Decide which header copy the SyncPreviewModal should use based on the
    *  saved gate fingerprint. Never accepted before = first-time onboarding;

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -180,7 +180,13 @@ export class DeviceFlowModal extends Modal {
 				15_000,
 			);
 
-			if (resp.status === 428) return;
+			// Still waiting for the human to approve. 400 is the RFC 8628 §3.5
+			// status (engram#device-auth); 428 is what this endpoint returned
+			// before 2026-08 and is kept so an older backend still links.
+			// Unrecognised statuses also fall through to "keep polling" below —
+			// that is what made the server-side flip safe for already-installed
+			// builds, but it is implicit, so name the pending statuses here.
+			if (resp.status === 400 || resp.status === 428) return;
 
 			if (resp.status >= 200 && resp.status < 300) {
 				if (this.pollInterval) window.clearInterval(this.pollInterval);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2575,6 +2575,16 @@ export default class EngramSyncPlugin extends Plugin {
 		// Active-leaf-change enrollment was skipped while the gate was closed;
 		// resetAll clears the once-per-session guards so the next enroll re-issues STEP1.
 		this.crdtEnrollment?.resetAll();
+		// Pull what the gate held back (#425). A blocked replay now bails before
+		// walking, which preserves the catch-up cursor — so those feed rows are
+		// still waiting, and until now nothing asked for them on unblock. The
+		// pull only happened if the user separately triggered a FullSync, which
+		// is exactly the path that left a vault empty in prod on 2026-08-13.
+		// After setSyncBlocked(false), never before, or this bails on the gate
+		// it is meant to be draining.
+		void this.syncEngine.catchupViaSeqReplay().catch((e) => {
+			rlog().warn("lifecycle", `gate-open catch-up failed: ${errMsg(e)}`);
+		});
 		await this.savePluginData(this.syncEngine.getLastSync());
 		this.updateStatusBar(this.syncEngine.getStatus());
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2582,6 +2582,14 @@ export default class EngramSyncPlugin extends Plugin {
 		// is exactly the path that left a vault empty in prod on 2026-08-13.
 		// After setSyncBlocked(false), never before, or this bails on the gate
 		// it is meant to be draining.
+		//
+		// Deliberately fire-and-forget and WITHOUT an onFileApplied: this call is
+		// the safety net, not the UI. When the user came through the preview modal
+		// the follow-on sync owns the progress surface, and the replay's tick
+		// fan-out means whichever of the two starts first still feeds that
+		// surface. Awaiting here would instead stall the modal's own dismissal
+		// behind a full vault pull. The trade is that an accept with no follow-on
+		// sync pulls silently — correct, just quiet.
 		void this.syncEngine.catchupViaSeqReplay().catch((e) => {
 			rlog().warn("lifecycle", `gate-open catch-up failed: ${errMsg(e)}`);
 		});

--- a/src/remote-log.ts
+++ b/src/remote-log.ts
@@ -128,15 +128,36 @@ export class RemoteLogger {
 		this.pushFn = null;
 	}
 
+	/** A silent failure the user cannot see and we cannot debug. Ships at warn
+	 *  EVEN WHEN DIAGNOSTICS ARE OFF, and bypasses the level threshold.
+	 *
+	 *  Why the bypass exists: `diagnosticsEnabled` defaults false, so every
+	 *  rlog() call is a no-op on a fresh install — and a user's FIRST sync is
+	 *  simultaneously the most likely thing to break and the least likely to
+	 *  have telemetry enabled. Prod 2026-08-13: a first sync dropped 316 of 316
+	 *  notes and produced exactly zero client log lines to look at.
+	 *
+	 *  CONTRACT — callers must honour it: counts and reasons ONLY. Never a
+	 *  path, a title, or note content. The setting is protecting the user from
+	 *  verbose per-note telemetry, and that protection stays intact; what it
+	 *  must not do is hide the fact that sync silently did nothing. */
+	anomaly(category: string, message: string): void {
+		this.addEntry("warn", category, message, undefined, false, true);
+	}
+
 	private addEntry(
 		level: "error" | "warn" | "info",
 		category: string,
 		message: string,
 		stack?: string,
 		diagnostic?: boolean,
+		force?: boolean,
 	): void {
-		if (!this.enabled || !this.pushFn) return;
-		if (LEVEL_SEVERITY[level] < LEVEL_SEVERITY[this.levelThreshold]) return;
+		if (!this.pushFn) return;
+		if (!force) {
+			if (!this.enabled) return;
+			if (LEVEL_SEVERITY[level] < LEVEL_SEVERITY[this.levelThreshold]) return;
+		}
 
 		const entry: RemoteLogEntry = {
 			ts: new Date().toISOString(),
@@ -198,6 +219,7 @@ interface NoopLogger {
 	warn(category: string, message: string): void;
 	info(category: string, message: string): void;
 	diag(category: string, message: string): void;
+	anomaly(category: string, message: string): void;
 	setConnId(id: string | null): void;
 	setClientContext(deviceId: string | null, vaultId: string | null): void;
 	setLevelThreshold(level: RemoteLogLevel): void;
@@ -212,6 +234,7 @@ const _noop: NoopLogger = {
 	warn() {},
 	info() {},
 	diag() {},
+	anomaly() {},
 	setConnId() {},
 	setClientContext() {},
 	setLevelThreshold() {},

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1387,7 +1387,11 @@ export class SyncEngine {
 	 *  only the content hash is refreshed. `markCreated` additionally flips the
 	 *  `hasServerNote` oracle via the CRDT_HEAD_CREATED sentinel (genesis /
 	 *  create-ack adopt sites); the first convergence overwrites the sentinel
-	 *  with the authoritative head. */
+	 *  with the authoritative head.
+	 *
+	 *  Pulled-from-feed sites do NOT go through `markCreated` — they call
+	 *  `markServerKnown` after the flush, which fills a missing head without
+	 *  ever overwriting a real one. */
 	private recordCrdtBaseline(
 		normalized: string,
 		content: string,
@@ -2073,6 +2077,21 @@ export class SyncEngine {
 
 	private setCrdtHead(path: string, head: string): void {
 		this.patchSyncedRow(normalizePath(path), { crdtHead: head });
+	}
+
+	/** Flip the `hasServerNote` oracle for a note the server demonstrably holds,
+	 *  without ever DOWNGRADING an authoritative head to the placeholder.
+	 *
+	 *  `patchSyncedRow` merges, so writing CRDT_HEAD_CREATED over a real head
+	 *  recorded by `applyPushedNoteUpdate` would invert the sentinel's contract
+	 *  and permanently defeat the convergence cost gate (`getCrdtHead ===
+	 *  serverHead` -> skip), re-firing STEP1 for that note forever. The sentinel
+	 *  only ever fills a HOLE. */
+	private markServerKnown(path: string): void {
+		const normalized = normalizePath(path);
+		if (this.getCrdtHead(normalized) == null) {
+			this.setCrdtHead(normalized, CRDT_HEAD_CREATED);
+		}
 	}
 
 	/** Public: consumed as `CrdtManagerOptions.canSendLive` by the wiring in
@@ -4050,8 +4069,20 @@ export class SyncEngine {
 			// This session owns the tick fan-out: its own caller's callback and
 			// every coalescer that registers while it runs see the same stream.
 			if (opts.onFileApplied) this.seqReplayFileListeners.add(opts.onFileApplied);
+			// One bad subscriber must not take down the stream. This runs INSIDE
+			// the per-row try that increments `failed`, so an unguarded throw
+			// would both mis-count a successfully applied row as failed AND
+			// starve every later subscriber — including the exclusive owner's own
+			// progress. Pre-fan-out that blast radius was one caller; now it is
+			// all of them, so the guard is load-bearing, not defensive noise.
 			const emitFileApplied = (path: string): void => {
-				for (const listener of [...this.seqReplayFileListeners]) listener(path);
+				for (const listener of [...this.seqReplayFileListeners]) {
+					try {
+						listener(path);
+					} catch (e) {
+						devLog().log("sync", `progress subscriber threw for ${path}: ${errMsg(e)}`);
+					}
+				}
 			};
 			try {
 				do {
@@ -4744,16 +4775,15 @@ export class SyncEngine {
 				serverHash: staged.serverHash,
 				version: staged.version,
 				seq: staged.seq,
-				// #339: a STEP2 that delivered CONTENT is proof the server holds a
-				// row for this note — we just merged the server's own ops for it.
-				// Without flipping the oracle, `hasServerNote` stays false and the
-				// note's next push takes the genesis branch; on a first sync
-				// `splitGenesisVsKnown` then misroutes the entire freshly-pulled
-				// vault through crdtCreateBatch (prod 2026-08-13: "122 files to
-				// upload" from an empty local vault). An EMPTY converged doc is NOT
-				// proof — genesis stays the correct route there, so gate on content.
-				...(staged.content ? { crdtHead: CRDT_HEAD_CREATED } : {}),
 			});
+
+			// #339: a STEP2 that delivered CONTENT is proof the server holds a row
+			// for this note — we just merged the server's own ops for it. An EMPTY
+			// converged doc is NOT proof; genesis stays the correct route there.
+			//
+			// Via markServerKnown so the placeholder can only fill a hole, never
+			// overwrite an authoritative head this note already has.
+			if (staged.content) this.markServerKnown(path);
 			rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
 		} catch (e) {
 			rlog().warn("crdt", `socket converge: commit failed for ${path}: ${errMsg(e)}`);
@@ -6275,6 +6305,15 @@ export class SyncEngine {
 				// edits; its later STEP2 (identical content) is a harmless idempotent
 				// re-flush suppressed by markRecentlyFlushed.
 				await this.flushFromCrdt(normalized, content);
+				// This row came off the server's own op-log feed, so the server
+				// demonstrably holds it (#339). Without a head `hasServerNote` says
+				// otherwise, and pushFile's write routing takes the genesis branch
+				// (the `!hasServerNote` arm) instead of the live-CRDT arm — on a
+				// first sync that re-uploads the WHOLE freshly-pulled vault (prod
+				// 2026-08-13: "122 files to upload" from an empty local vault).
+				// This is the branch a fresh vault actually takes;
+				// commitCrdtConvergence never runs here.
+				this.markServerKnown(normalized);
 				return true;
 			} else {
 				// The note exists locally and CRDT owns its body for LIVE edits — but
@@ -6573,6 +6612,9 @@ export class SyncEngine {
 								`CRDT catch-up: pull backfilling diverged note (no note_id) ${change.path}`,
 							);
 							await this.flushFromCrdt(normalized, content);
+							// Same feed, same proof (#339): a backfilled row is still the
+							// server telling us it holds this note.
+							this.markServerKnown(normalized);
 							this.stampSyncedRow(normalized, {
 								hash: fnv1a(content),
 								version: change.version,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2902,37 +2902,30 @@ export class SyncEngine {
 			}
 		}
 
-		// Echo suppression for notes, ABOVE the push slot (#426). Materialising a
-		// pulled note fires a vault modify event, so a first sync of N notes
-		// queues N pushes that all turn out to be echoes — and each one used to
-		// burn a bounded push slot, a status repaint and a "Push start" log line
-		// before bailing (~800 of the ~1,200 client log lines on the 315-note
-		// first sync of 2026-08-13). Identical predicate to the one this replaces,
-		// so no push that would have gone out is dropped; it now costs a cached
-		// read instead of a slot.
+		// Echo FILTER for notes, ABOVE the push slot (#426). Materialising a pulled
+		// note fires a vault modify event, so a first sync of N notes queues N
+		// pushes that all turn out to be echoes — and each one used to burn a
+		// bounded push slot, a status repaint and a "Push start" log line before
+		// bailing (~800 of the ~1,200 client log lines on the 315-note first sync
+		// of 2026-08-13). Same predicate the note branch used to apply inside the
+		// slot, so nothing that would have been pushed is dropped.
 		//
-		// It must also stay AHEAD of the CRDT routing branch below, not just the
-		// legacy REST path: a disk write this engine itself just made
-		// (materializeRelocated -> flushFromCrdt -> recordCrdtBaseline records this
-		// exact hash) fires create/modify same as a real edit. Routing that echo
-		// into routeModify/applyLocalEdit diffs `content` against the Y.Doc's
-		// CURRENT state — if the doc has meanwhile advanced (a concurrent remote
-		// update landed in the room), the diff is a genuine-looking but stale
-		// delta that DELETES the just-arrived remote content, not a harmless no-op
-		// (e2e test_37 content-loss: first append vanishes).
+		// A filter, and ONLY a filter: nothing read here is transmitted. The body
+		// that gets pushed is re-read below, after the slot, because the wait can
+		// be long and a pre-wait snapshot diffed into the Y.Doc's CURRENT state is
+		// the stale delta that DELETES just-arrived remote content (e2e test_37).
+		// Deciding "is this an echo" on a slightly older body is safe — the answer
+		// only gets more conservative. Deciding WHAT TO SEND on one is not.
 		//
 		// Attachments keep their check inside the slot: theirs needs the base64
 		// body, which is the expensive part — hoisting it would not avoid it.
 		const isBinary = this.isBinaryFile(file);
-		let noteContent = "";
-		let noteHash = 0;
 		if (!isBinary) {
-			noteContent = await this.app.vault.cachedRead(file);
-			noteHash = fnv1a(noteContent);
+			const echoHash = fnv1a(await this.app.vault.cachedRead(file));
 			const existing = this.syncState.get(normalizePath(file.path));
-			if (!force && existing !== undefined && noteHash === existing.hash) {
+			if (!force && existing !== undefined && echoHash === existing.hash) {
 				devLog().log("push", `skip (echo): ${file.path}`);
-				rlog().info("push", `Echo skip: ${file.path} | hash=${noteHash}`);
+				rlog().info("push", `Echo skip: ${file.path} | hash=${echoHash}`);
 				return false;
 			}
 		}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2983,11 +2983,20 @@ export class SyncEngine {
 				await this.api.pushAttachment(file.path, base64, mimeType, mtime);
 				this.stampSyncedRow(normalizePath(file.path), { hash });
 			} else {
-				// Read + echo-checked above the push slot (#426). Reused here rather
-				// than re-read: cachedRead is cheap but not free, and a second read
-				// could observe a DIFFERENT body than the one we hash-checked.
-				const content = noteContent;
-				const hash = noteHash;
+				// RE-READ after the slot. The pre-slot read (#426) exists only to
+				// bail on echoes cheaply; it must not be the body we transmit.
+				// acquirePushSlot can block for as long as the queue ahead of us
+				// takes, and `content` is diffed into the Y.Doc's CURRENT state
+				// below — a snapshot taken before that wait is exactly the "stale
+				// delta that DELETES the just-arrived remote content" failure the
+				// echo guard above is written to prevent (e2e test_37). Observing a
+				// newer body here is the correct outcome, not a hazard: the newest
+				// content is what should be pushed.
+				//
+				// Costs one extra cachedRead, and only on the non-echo path — every
+				// echo already returned above without taking a slot.
+				const content = await this.app.vault.cachedRead(file);
+				const hash = fnv1a(content);
 
 				// note_id-keyed CRDT rework (Task 5): resolve (or mint) this note's
 				// stable id BEFORE routing, so both the CRDT path (Task 6) and the
@@ -6704,7 +6713,18 @@ export class SyncEngine {
 								"pull",
 								`CRDT catch-up: pull backfilling diverged note (no note_id) ${change.path}`,
 							);
-							await this.flushFromCrdt(normalized, content);
+							// Gate the bookkeeping on the write, same as the discovery
+							// branch. Stamping a hash for content that never reached disk
+							// tells the engine disk matches the server, so the resulting
+							// divergence is invisible and never repaired — a quieter
+							// version of the 2026-08-13 failure. Unreachable today (the
+							// replay bails before this when the gate is shut), which is
+							// precisely why it must not depend on that staying true.
+							// `false` is the honest answer under this function's contract
+							// ("true when a file was actually created/modified") — the
+							// same reason flushFromCrdt itself stopped returning true
+							// for a gate-blocked no-op.
+							if (!(await this.flushFromCrdt(normalized, content))) return false;
 							// Same feed, same proof (#339): a backfilled row is still the
 							// server telling us it holds this note.
 							this.markServerKnown(normalized);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4103,6 +4103,25 @@ export class SyncEngine {
 					// the whole result — never OR this back to true.
 					if (!pass.complete) complete = false;
 				} while (this.seqReplayAgain);
+				// Outcome check. `applied` counts every row the feed handed us;
+				// `files` and `deletes` count what actually reached disk. All three
+				// passes done and applied > 0 with NOTHING materialised or trashed
+				// means the feed did work and the vault got none of it — the shape
+				// of the 2026-08-13 prod failure, where 316 note rows arrived, 73
+				// folders landed, and not one note did.
+				//
+				// Shipped via rlog().anomaly so it survives `diagnosticsEnabled:
+				// false` (the default). That failure produced ZERO client log lines
+				// precisely because a fresh install has telemetry off, which is the
+				// same install most likely to hit a first-sync bug. Counts only —
+				// no paths — so the setting still protects what it is meant to.
+				if (applied > 0 && files === 0 && deletes === 0) {
+					rlog().anomaly(
+						"sync",
+						`replay produced no files: applied=${applied} files=0 deletes=0 ` +
+							`failed=${failed} complete=${complete}`,
+					);
+				}
 			} finally {
 				if (opts.onFileApplied) this.seqReplayFileListeners.delete(opts.onFileApplied);
 				this.seqReplayRunning = false;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4011,6 +4011,46 @@ export class SyncEngine {
 	}> {
 		const serverIds = new Set<string>();
 		const serverAttachmentPaths = new Set<string>();
+
+		// Gate closed: walk NOTHING. The block used to live per-file inside
+		// flushFromCrdt, so a blocked replay still fetched every page, and the
+		// server still decrypted and serialised every row, for a pass whose
+		// every write was discarded — then the real pass did it all again. That
+		// doubling is the prod pull CPU spike.
+		//
+		// The correctness half is worse. `onPage` persists the catch-up cursor
+		// after each page and exempts only `enumerateOnly`, whose comment
+		// reasons it exactly right — "a later genuine catch-up needs to still
+		// see every op this enumeration walked past, since none of them were
+		// applied" — and then misses this case, where equally none of them were
+		// applied. So a blocked walk advanced the cursor PAST notes it never
+		// wrote, and the next replay resumed after them. They came back only if
+		// the manifest validator happened to rewind; that repair machinery is
+		// largely compensating for this.
+		//
+		// `complete: false` is load-bearing: we walked nothing, so the empty
+		// server sets are not evidence, and no destructive delete decision may
+		// trust them (they require ran && complete).
+		if (this.syncBlocked) {
+			devLog().log("sync-blocked", "catchupViaSeqReplay skipped — gate closed");
+			// Ships even with diagnostics off. Skipping the walk is correct, but a
+			// pull that returns nothing because a gate is shut must still be
+			// visible — silently doing nothing and reporting success is the bug
+			// this whole series came from. One line per blocked attempt, not one
+			// per note. Counts only, no paths.
+			rlog().anomaly("sync", "catch-up skipped — sync gate closed (blocked=true)");
+			return {
+				applied: 0,
+				files: 0,
+				failed: 0,
+				deletes: 0,
+				serverIds,
+				serverAttachmentPaths,
+				ran: false,
+				complete: false,
+			};
+		}
+
 		if (this.seqReplayRunning) {
 			this.seqReplayAgain = true;
 			if (!opts.awaitCoalesced) {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2902,6 +2902,41 @@ export class SyncEngine {
 			}
 		}
 
+		// Echo suppression for notes, ABOVE the push slot (#426). Materialising a
+		// pulled note fires a vault modify event, so a first sync of N notes
+		// queues N pushes that all turn out to be echoes — and each one used to
+		// burn a bounded push slot, a status repaint and a "Push start" log line
+		// before bailing (~800 of the ~1,200 client log lines on the 315-note
+		// first sync of 2026-08-13). Identical predicate to the one this replaces,
+		// so no push that would have gone out is dropped; it now costs a cached
+		// read instead of a slot.
+		//
+		// It must also stay AHEAD of the CRDT routing branch below, not just the
+		// legacy REST path: a disk write this engine itself just made
+		// (materializeRelocated -> flushFromCrdt -> recordCrdtBaseline records this
+		// exact hash) fires create/modify same as a real edit. Routing that echo
+		// into routeModify/applyLocalEdit diffs `content` against the Y.Doc's
+		// CURRENT state — if the doc has meanwhile advanced (a concurrent remote
+		// update landed in the room), the diff is a genuine-looking but stale
+		// delta that DELETES the just-arrived remote content, not a harmless no-op
+		// (e2e test_37 content-loss: first append vanishes).
+		//
+		// Attachments keep their check inside the slot: theirs needs the base64
+		// body, which is the expensive part — hoisting it would not avoid it.
+		const isBinary = this.isBinaryFile(file);
+		let noteContent = "";
+		let noteHash = 0;
+		if (!isBinary) {
+			noteContent = await this.app.vault.cachedRead(file);
+			noteHash = fnv1a(noteContent);
+			const existing = this.syncState.get(normalizePath(file.path));
+			if (!force && existing !== undefined && noteHash === existing.hash) {
+				devLog().log("push", `skip (echo): ${file.path}`);
+				rlog().info("push", `Echo skip: ${file.path} | hash=${noteHash}`);
+				return false;
+			}
+		}
+
 		await this.acquirePushSlot();
 		// Snapshot the path for the lifetime of this push. TFile.path is LIVE —
 		// a user rename landing while the request is in flight mutates it, and
@@ -2913,7 +2948,6 @@ export class SyncEngine {
 		this.lastError = "";
 		this.emitStatus();
 
-		const isBinary = this.isBinaryFile(file);
 		let success = false;
 		// Set in the note branch below so recordParseStatus can run AFTER the
 		// shared issues.clear(file.path) — resp (and thus parse_status) is only
@@ -2949,29 +2983,11 @@ export class SyncEngine {
 				await this.api.pushAttachment(file.path, base64, mimeType, mtime);
 				this.stampSyncedRow(normalizePath(file.path), { hash });
 			} else {
-				const content = await this.app.vault.cachedRead(file);
-
-				// Echo suppression — skip pushing if content matches what the sync
-				// engine last wrote (pull/WebSocket/flushFromCrdt). Must run BEFORE
-				// the CRDT routing branch below, not just the legacy REST path: a
-				// disk write this engine itself just made (e.g. materializeRelocated
-				// discovering a note and calling flushFromCrdt, which records this
-				// exact hash via recordCrdtBaseline) fires vault's create/modify
-				// event same as a real edit. Routing that echo into
-				// routeModify/applyLocalEdit unconditionally diffs "content" against
-				// the Y.Doc's CURRENT state — if the Y.Doc has meanwhile advanced
-				// (e.g. a concurrent remote update just landed in the room), the
-				// diff is a genuine-looking but stale delta that DELETES the
-				// just-arrived remote content, not a harmless no-op (e2e test_37
-				// content-loss: first append vanishes). Hoisting this hash check
-				// above the CRDT branch closes that hole for both paths.
-				const hash = fnv1a(content);
-				const existing = this.syncState.get(normalizePath(file.path));
-				if (!force && existing !== undefined && hash === existing.hash) {
-					devLog().log("push", `skip (echo): ${file.path}`);
-					rlog().info("push", `Echo skip: ${file.path} | hash=${hash}`);
-					return false;
-				}
+				// Read + echo-checked above the push slot (#426). Reused here rather
+				// than re-read: cachedRead is cheap but not free, and a second read
+				// could observe a DIFFERENT body than the one we hash-checked.
+				const content = noteContent;
+				const hash = noteHash;
 
 				// note_id-keyed CRDT rework (Task 5): resolve (or mint) this note's
 				// stable id BEFORE routing, so both the CRDT path (Task 6) and the

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1270,8 +1270,18 @@ export class SyncEngine {
 	 *  CRDT frames cannot overwrite local files before the user picks a direction. */
 	async flushFromCrdt(path: string, content: string): Promise<boolean> {
 		if (this.syncBlocked) {
+			// FALSE, not true. This wrote nothing, and claiming otherwise is what
+			// made the 2026-08-13 prod failure invisible: the `true` propagated
+			// into `changed`, counted the note as a downloaded file, drove the bar
+			// to 100%, made the recap claim success, and suppressed the
+			// no-files-produced anomaly — all while the vault stayed empty.
+			// Folders bypass this gate entirely (direct vault.createFolder), which
+			// is why the user saw every folder arrive and not one note.
+			//
+			// A no-op must never report as work. The caller decides what to do
+			// about a closed gate; it cannot decide anything if we lie to it.
 			devLog().log("sync-blocked", `flushFromCrdt short-circuited — gate closed: ${path}`);
-			return true;
+			return false;
 		}
 		const normalized = normalizePath(path);
 		const file = this.app.vault.getAbstractFileByPath(normalized);
@@ -4116,10 +4126,14 @@ export class SyncEngine {
 				// same install most likely to hit a first-sync bug. Counts only —
 				// no paths — so the setting still protects what it is meant to.
 				if (applied > 0 && files === 0 && deletes === 0) {
+					// `blocked` is the first thing to look at: a closed first-sync
+					// gate silently no-ops every note write while folders (which
+					// bypass it) still land. That combination — folders arrive,
+					// notes do not — is the 2026-08-13 signature.
 					rlog().anomaly(
 						"sync",
 						`replay produced no files: applied=${applied} files=0 deletes=0 ` +
-							`failed=${failed} complete=${complete}`,
+							`failed=${failed} complete=${complete} blocked=${this.syncBlocked}`,
 					);
 				}
 			} finally {
@@ -6323,7 +6337,11 @@ export class SyncEngine {
 				// hold the body here, so write it. CRDT stays the single writer for LIVE
 				// edits; its later STEP2 (identical content) is a harmless idempotent
 				// re-flush suppressed by markRecentlyFlushed.
-				await this.flushFromCrdt(normalized, content);
+				// Propagate the write result instead of hardcoding `return true`.
+				// The old unconditional true meant a gate-blocked no-op still
+				// counted as a materialised file (2026-08-13).
+				const wrote = await this.flushFromCrdt(normalized, content);
+				if (!wrote) return false;
 				// This row came off the server's own op-log feed, so the server
 				// demonstrably holds it (#339). Without a head `hasServerNote` says
 				// otherwise, and pushFile's write routing takes the genesis branch

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3762,6 +3762,15 @@ export class SyncEngine {
 		failed: number;
 		deletes: number;
 	}> | null = null;
+	/** Per-file tick subscribers for the RUNNING replay session. The counts a
+	 *  coalescing caller awaits are only half the contract — its progress UI
+	 *  also needs the STREAM, and the early return can't reach the exclusive
+	 *  call site's `onFileApplied` hand-off. On a first sync the join handler
+	 *  always owns the replay (it is one of many bare `catchupViaSeqReplay()`
+	 *  callers), so the user's modal ALWAYS coalesces: without this it renders
+	 *  a dead 0% bar with no filenames for the whole pull, then one final
+	 *  number. Registration is scoped to each caller's own await. */
+	private seqReplayFileListeners = new Set<(path: string) => void>();
 	private seqHealLastAt = 0;
 	private seqHealTimer: number | null = null;
 	private static readonly SEQ_HEAL_COOLDOWN_MS = 4_000;
@@ -3999,7 +4008,19 @@ export class SyncEngine {
 			// Safe: seqReplayRunning=true means the running task is suspended at
 			// an await INSIDE its loop (the exit path from condition-check to
 			// finally has no await), so it always sees the flag we just set.
-			const running = await this.seqReplayResult?.catch(() => null);
+			//
+			// Subscribe to the running session's per-file ticks for the duration
+			// of this await, so a progress-reporting coalescer renders the live
+			// "Downloading <name>" stream instead of a frozen bar. Ticks already
+			// applied before we registered are lost by construction — the counts
+			// below still report the session's true totals.
+			if (opts.onFileApplied) this.seqReplayFileListeners.add(opts.onFileApplied);
+			let running: { applied: number; files: number; failed: number; deletes: number } | null;
+			try {
+				running = (await this.seqReplayResult?.catch(() => null)) ?? null;
+			} finally {
+				if (opts.onFileApplied) this.seqReplayFileListeners.delete(opts.onFileApplied);
+			}
 			return {
 				applied: running?.applied ?? 0,
 				files: running?.files ?? 0,
@@ -4026,6 +4047,12 @@ export class SyncEngine {
 			// must tick the progress feed once, or `current` outruns the plan's
 			// denominator and the bar pins at 100% while files keep arriving.
 			const tickedKeys = new Set<string>();
+			// This session owns the tick fan-out: its own caller's callback and
+			// every coalescer that registers while it runs see the same stream.
+			if (opts.onFileApplied) this.seqReplayFileListeners.add(opts.onFileApplied);
+			const emitFileApplied = (path: string): void => {
+				for (const listener of [...this.seqReplayFileListeners]) listener(path);
+			};
 			try {
 				do {
 					this.seqReplayAgain = false;
@@ -4035,7 +4062,7 @@ export class SyncEngine {
 						serverAttachmentPaths,
 						tickedKeys,
 						opts.enumerateOnly ?? false,
-						opts.onFileApplied,
+						emitFileApplied,
 					);
 					applied += pass.applied;
 					files += pass.files;
@@ -4046,6 +4073,7 @@ export class SyncEngine {
 					if (!pass.complete) complete = false;
 				} while (this.seqReplayAgain);
 			} finally {
+				if (opts.onFileApplied) this.seqReplayFileListeners.delete(opts.onFileApplied);
 				this.seqReplayRunning = false;
 			}
 			return {
@@ -4716,6 +4744,15 @@ export class SyncEngine {
 				serverHash: staged.serverHash,
 				version: staged.version,
 				seq: staged.seq,
+				// #339: a STEP2 that delivered CONTENT is proof the server holds a
+				// row for this note — we just merged the server's own ops for it.
+				// Without flipping the oracle, `hasServerNote` stays false and the
+				// note's next push takes the genesis branch; on a first sync
+				// `splitGenesisVsKnown` then misroutes the entire freshly-pulled
+				// vault through crdtCreateBatch (prod 2026-08-13: "122 files to
+				// upload" from an empty local vault). An EMPTY converged doc is NOT
+				// proof — genesis stays the correct route there, so gate on content.
+				...(staged.content ? { crdtHead: CRDT_HEAD_CREATED } : {}),
 			});
 			rlog().info("crdt", `socket converge: STEP2 committed ${path}`);
 		} catch (e) {

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -128,3 +128,67 @@ describe("DeviceFlowModal.startDeviceFlow", () => {
 		await expect((modal as any).startDeviceFlow()).rejects.toThrow("HTTP 500");
 	});
 });
+
+describe("DeviceFlowModal poll — pending statuses", () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+	});
+
+	/** Drive one poll with a mocked response, reporting whether the loop kept
+	 *  going (no resolve, no clearInterval) or terminated. */
+	const pollOnceWith = async (
+		status: number,
+		json: unknown,
+	): Promise<{ resolved: boolean; stopped: boolean }> => {
+		mockRequestUrl.mockResolvedValue({ status, json });
+		const modal = new DeviceFlowModal(
+			makeApp("V"),
+			makePlugin("https://example.test", "cid-1"),
+		) as any;
+		let resolved = false;
+		modal.resolve = () => {
+			resolved = true;
+		};
+		modal.pollInterval = 999;
+		modal.close = () => {};
+		const cleared: number[] = [];
+		const realClear = window.clearInterval;
+		window.clearInterval = ((id: number) => {
+			cleared.push(id);
+		}) as unknown as typeof window.clearInterval;
+		try {
+			await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
+		} finally {
+			window.clearInterval = realClear;
+		}
+		return { resolved, stopped: cleared.length > 0 };
+	};
+
+	// Characterization, not red-first: the pre-existing fall-through already
+	// kept polling on an unrecognised status, which is exactly why flipping the
+	// server 428 -> 400 did not strand already-installed builds. These pin that
+	// behaviour so a future `else { abort }` cannot silently break device login.
+	test("400 authorization_pending keeps polling", async () => {
+		const { resolved, stopped } = await pollOnceWith(400, { error: "authorization_pending" });
+		expect(resolved).toBe(false);
+		expect(stopped).toBe(false);
+	});
+
+	test("428 authorization_pending still keeps polling (older backend)", async () => {
+		const { resolved, stopped } = await pollOnceWith(428, { error: "authorization_pending" });
+		expect(resolved).toBe(false);
+		expect(stopped).toBe(false);
+	});
+
+	test("410 expired stops the loop", async () => {
+		const { resolved, stopped } = await pollOnceWith(410, { error: "expired_or_invalid" });
+		expect(resolved).toBe(false);
+		expect(stopped).toBe(true);
+	});
+
+	test("200 resolves with the token payload and stops the loop", async () => {
+		const { resolved, stopped } = await pollOnceWith(200, { access_token: "at" });
+		expect(resolved).toBe(true);
+		expect(stopped).toBe(true);
+	});
+});

--- a/tests/main-auth-ux.test.ts
+++ b/tests/main-auth-ux.test.ts
@@ -190,3 +190,65 @@ describe("round-1 review fixes (#422)", () => {
 		expect(planLoadErrorMessage(false)).not.toContain("\u2014");
 	});
 });
+
+describe("opening the sync gate re-runs the catch-up (#425)", () => {
+	// While the gate is shut, catchupViaSeqReplay now bails before walking, so
+	// no feed rows are consumed and the cursor is preserved. That is correct —
+	// but it means the rows are still WAITING when the gate opens, and nothing
+	// was asking for them: markSyncGateAccepted re-fired STEP1 enrollment and
+	// then stopped. The pull only happened if the user separately triggered a
+	// FullSync, which is precisely the path that failed in prod on 2026-08-13.
+	const fakePlugin = () => {
+		const calls: string[] = [];
+		const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
+			settings: {
+				refreshToken: "rt",
+				userEmail: "a@b.test",
+				vaultId: "v1",
+				apiKey: "",
+			},
+			syncGateAcceptedFor: null,
+			syncEngine: {
+				setSyncBlocked(v: boolean) {
+					calls.push(`setSyncBlocked(${v})`);
+				},
+				getLastSync: () => 0,
+				getStatus: () => ({ state: "idle", pending: 0, queued: 0 }),
+				catchupViaSeqReplay: async () => {
+					calls.push("catchupViaSeqReplay");
+					return {};
+				},
+			},
+			crdtEnrollment: {
+				resetAll() {
+					calls.push("resetAll");
+				},
+			},
+			async savePluginData() {},
+			updateStatusBar() {},
+		});
+		return { fake, calls };
+	};
+
+	test("markSyncGateAccepted unblocks AND pulls what the gate held back", async () => {
+		const { fake, calls } = fakePlugin();
+
+		await fake.markSyncGateAccepted();
+
+		expect(calls).toContain("setSyncBlocked(false)");
+		expect(calls).toContain("catchupViaSeqReplay");
+		// Order matters: pulling before the unblock would bail on the closed gate.
+		expect(calls.indexOf("setSyncBlocked(false)")).toBeLessThan(
+			calls.indexOf("catchupViaSeqReplay"),
+		);
+	});
+
+	test("an empty fingerprint neither unblocks nor pulls", async () => {
+		const { fake, calls } = fakePlugin();
+		fake.settings = { refreshToken: "", userEmail: "", vaultId: "", apiKey: "" };
+
+		await fake.markSyncGateAccepted();
+
+		expect(calls).toEqual([]);
+	});
+});

--- a/tests/remote-log.test.ts
+++ b/tests/remote-log.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for remote-log.ts — RemoteLogger buffer, flush, threshold, ring buffer.
  */
-import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, jest, mock, test } from "bun:test";
 import {
 	destroyRemoteLog,
 	initRemoteLog,
@@ -403,5 +403,54 @@ describe("verbose remote logging reaches Loki", () => {
 		// warn/error ship regardless (Category.loki_ship? passes them); flagging
 		// them would only add noise to the payload.
 		expect(sent[0]?.[0]?.diagnostic).toBeUndefined();
+	});
+});
+
+describe("anomaly() bypasses the diagnostics gate", () => {
+	// Same global-singleton teardown as the rest of this file.
+	afterEach(async () => {
+		await destroyRemoteLog();
+	});
+
+	// Prod 2026-08-13: a first sync silently dropped 316 of 316 notes and we had
+	// NOTHING to look at — `diagnosticsEnabled` defaults false, so every
+	// rlog() call on the pull path was a no-op. The one moment we most need
+	// telemetry is a user's first sync, which is exactly when nobody has opted
+	// into diagnostics yet. anomaly() is the narrow escape hatch: COUNTS AND
+	// REASONS ONLY, never paths or content, so it respects what the setting is
+	// actually protecting (verbose per-note telemetry) while making a silent
+	// failure visible.
+	const makeLogger = () => {
+		const sent: any[] = [];
+		const logger = initRemoteLog();
+		logger.configure(
+			async (batch: any[]) => {
+				sent.push(...batch);
+			},
+			"1.0.0-test",
+			"test",
+		);
+		logger.setEnabled(false);
+		return { logger, sent };
+	};
+
+	test("an anomaly ships even with diagnostics OFF", async () => {
+		const { logger, sent } = makeLogger();
+
+		logger.anomaly("sync", "replay consumed 316 rows and produced 0 files");
+		await logger.flush();
+
+		expect(sent.length).toBe(1);
+		expect(sent[0].message).toContain("316");
+		expect(sent[0].level).toBe("warn");
+	});
+
+	test("an ordinary info line stays suppressed with diagnostics OFF", async () => {
+		const { logger, sent } = makeLogger();
+
+		logger.info("sync", "routine chatter");
+		await logger.flush();
+
+		expect(sent.length).toBe(0);
 	});
 });

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -529,3 +529,103 @@ describe("coalesce semantics are opt-in (#422 review round 1)", () => {
 		expect(res.files).toBe(1);
 	});
 });
+
+describe("coalesced callers still receive the per-file stream", () => {
+	test("a progress-reporting catch-up that coalesces still gets per-file pulling events", async () => {
+		// Prod 2026-08-13: on a first sync the topic-join handler always starts
+		// the replay first (it is one of 11 bare `catchupViaSeqReplay()` call
+		// sites), so the user's sync modal ALWAYS coalesces behind it. #422 made
+		// the coalesced return report honest counts, but the early return never
+		// reaches the `opts.onFileApplied` hand-off at the exclusive call site —
+		// the callback is silently discarded. The modal therefore blocks for the
+		// whole replay with a dead 0% bar and no filenames, then prints one
+		// final number. Counts alone are not the contract; the STREAM is.
+		const feed = [
+			noteRow({ id: "id-a", seq: 1, path: "Notes/a.md" }),
+			noteRow({ id: "id-b", seq: 2, path: "Notes/b.md" }),
+		];
+		const { engine, events } = makeEngine(feed);
+		let releaseFirstFetch!: () => void;
+		const gate = new Promise<void>((r) => (releaseFirstFetch = r));
+		let call = 0;
+		engine.setCrdtCatchupSince(async () => {
+			call += 1;
+			if (call === 1) await gate;
+			return { changes: call <= 2 ? feed : [], has_more: false, next_seq: null };
+		});
+
+		// The background caller (join handler) wins the race and runs exclusively.
+		const background = engine.catchUp({ reportProgress: false });
+		await new Promise((r) => setTimeout(r, 10));
+		// The user's modal arrives second and coalesces.
+		const modal = engine.catchUp({ reportProgress: true });
+		await new Promise((r) => setTimeout(r, 10));
+		releaseFirstFetch();
+		await Promise.all([background, modal]);
+
+		const pulls = events.filter((e) => e.phase === "pulling");
+		expect(pulls.map((e) => e.current)).toEqual([1, 2]);
+		// The filenames the "Downloading <name>" row renders.
+		expect(pulls.map((e) => e.currentPath)).toEqual(["Notes/a.md", "Notes/b.md"]);
+	});
+});
+
+describe("hasServerNote after a handshake heal (#339)", () => {
+	type Staged = {
+		path: string;
+		serverHash: string;
+		content: string | null;
+		version?: number;
+		seq?: number;
+	};
+	const stage = (engine: SyncEngine, noteId: string, staged: Staged): void => {
+		(engine as unknown as { pendingConvergence: Map<string, Staged> }).pendingConvergence.set(
+			noteId,
+			staged,
+		);
+	};
+
+	test("a note that converged via STEP2 is known to exist on the server", async () => {
+		// The server just handed us this note's full state, so it demonstrably
+		// holds a row for it. Without a crdtHead the oracle says false and the
+		// note's next push takes the genesis path — on a first sync that
+		// misroutes the WHOLE pulled vault through crdtCreateBatch, which is
+		// what surfaced as "122 files to upload" from an empty local vault.
+		const { engine } = makeEngine([]);
+		const map = new NoteIdMap();
+		map.set("Notes/a.md", "id-a");
+		engine.setNoteIdMap(map);
+		stage(engine, "id-a", {
+			path: "Notes/a.md",
+			serverHash: "h1",
+			content: "server body",
+			version: 3,
+			seq: 7,
+		});
+
+		await engine.commitCrdtConvergence("id-a");
+
+		expect(engine.hasServerNote("id-a")).toBe(true);
+	});
+
+	test("an EMPTY converged doc does NOT claim the server has the note", async () => {
+		// Boundary guard: a handshake that returns nothing is not proof of a
+		// server row, and genesis is the correct route for it. Setting the
+		// sentinel here would strand a genuinely-new note with no create.
+		const { engine } = makeEngine([]);
+		const map = new NoteIdMap();
+		map.set("Notes/empty.md", "id-empty");
+		engine.setNoteIdMap(map);
+		stage(engine, "id-empty", {
+			path: "Notes/empty.md",
+			serverHash: "h0",
+			content: "",
+			version: 1,
+			seq: 1,
+		});
+
+		await engine.commitCrdtConvergence("id-empty");
+
+		expect(engine.hasServerNote("id-empty")).toBe(false);
+	});
+});

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -764,7 +764,10 @@ describe("the sync gate must not fake success (prod 2026-08-13 root cause)", () 
 		await flush();
 
 		expect(res.files).toBe(0);
-		const anomaly = sent.find((e) => e.message.includes("produced no files"));
+		// The signal is the gate-skip line, not "produced no files": we now bail
+		// before walking, so there are no rows to have produced nothing from.
+		// Either way the user's pull must not silently claim success.
+		const anomaly = sent.find((e) => e.message.includes("sync gate closed"));
 		expect(anomaly).toBeDefined();
 		expect(anomaly?.level).toBe("warn");
 	});
@@ -779,5 +782,73 @@ describe("the sync gate must not fake success (prod 2026-08-13 root cause)", () 
 
 		expect(res.files).toBe(2);
 		expect(sent.filter((e) => e.message.includes("produced no files")).length).toBe(0);
+	});
+});
+
+describe("a gate-blocked replay must not walk the feed at all", () => {
+	afterEach(async () => {
+		await destroyRemoteLog();
+	});
+
+	test("blocked: no fetch, and the catch-up cursor does NOT advance", async () => {
+		// DATA LOSS, not just wasted work. onPage persists the cursor after each
+		// page and exempts only `enumerateOnly` — whose comment reasons exactly
+		// the right way ("a later genuine catch-up needs to still see every op
+		// this enumeration walked past, since none of them were applied") and
+		// then misses the gate case, where equally none of them were applied.
+		//
+		// So a blocked walk advanced the cursor past 316 notes it never wrote,
+		// and the next replay resumed AFTER them. They were only ever recovered
+		// by the manifest validator's rewind — machinery that exists to paper
+		// over this.
+		//
+		// It is also the prod CPU spike: the server decrypts and serialises the
+		// whole feed for a pass whose every row is discarded, and then does it
+		// again for the real pass.
+		const { engine } = makeEngine(threeRowFeed());
+		let fetches = 0;
+		engine.setCrdtCatchupSince(async () => {
+			fetches += 1;
+			return { changes: threeRowFeed(), has_more: false, next_seq: null };
+		});
+		engine.setCatchupSeq(0);
+		engine.setSyncBlocked(true);
+
+		const res = await engine.catchUp({ reportProgress: true });
+
+		expect(fetches).toBe(0);
+		expect(engine.getCatchupSeq()).toBe(0);
+		expect(res.files).toBe(0);
+	});
+
+	test("blocked: the replay reports ran=false AND complete=false", async () => {
+		// Load-bearing: we walked nothing, so the empty server sets are not
+		// evidence. Destructive delete decisions require ran && complete, and
+		// trusting an empty set here would read as "the server has nothing" and
+		// trash the vault.
+		const { engine } = makeEngine(threeRowFeed());
+		engine.setSyncBlocked(true);
+
+		const res = await engine.catchupViaSeqReplay({});
+
+		expect(res.ran).toBe(false);
+		expect(res.complete).toBe(false);
+		expect(res.serverIds.size).toBe(0);
+	});
+
+	test("open: the feed is walked and the cursor advances", async () => {
+		const { engine } = makeEngine(threeRowFeed());
+		let fetches = 0;
+		engine.setCrdtCatchupSince(async () => {
+			fetches += 1;
+			return { changes: threeRowFeed(), has_more: false, next_seq: null };
+		});
+		engine.setCatchupSeq(0);
+		engine.setSyncBlocked(false);
+
+		await engine.catchUp({ reportProgress: true });
+
+		expect(fetches).toBeGreaterThan(0);
+		expect(engine.getCatchupSeq()).toBeGreaterThan(0);
 	});
 });

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -588,9 +588,10 @@ describe("hasServerNote after a handshake heal (#339)", () => {
 	test("a note that converged via STEP2 is known to exist on the server", async () => {
 		// The server just handed us this note's full state, so it demonstrably
 		// holds a row for it. Without a crdtHead the oracle says false and the
-		// note's next push takes the genesis path — on a first sync that
-		// misroutes the WHOLE pulled vault through crdtCreateBatch, which is
-		// what surfaced as "122 files to upload" from an empty local vault.
+		// note's next push takes pushFile's genesis branch (the `!hasServerNote`
+		// arm) instead of the live-CRDT arm — on a first sync that re-uploads the
+		// WHOLE pulled vault, which surfaced as "122 files to upload" from an
+		// empty local vault.
 		const { engine } = makeEngine([]);
 		const map = new NoteIdMap();
 		map.set("Notes/a.md", "id-a");
@@ -606,6 +607,49 @@ describe("hasServerNote after a handshake heal (#339)", () => {
 		await engine.commitCrdtConvergence("id-a");
 
 		expect(engine.hasServerNote("id-a")).toBe(true);
+	});
+
+	test("a note pulled by a first sync is known to exist on the server", async () => {
+		// THE journey this issue is actually about, and the one my first fix
+		// missed. A fresh vault materialises every note through the discovery
+		// branch (`flushFromCrdt` -> `recordCrdtBaseline`, no markCreated) —
+		// `commitCrdtConvergence` never runs, so driving that function directly
+		// proved nothing. The row came off the server's own op-log feed, which
+		// IS proof the server holds it; without a head the note's next push
+		// takes pushFile's genesis branch and the whole pulled vault re-uploads.
+		const { engine } = makeEngine([noteRow({ id: "id-a", seq: 1, path: "Notes/a.md" })]);
+
+		await engine.catchUp({ reportProgress: true });
+
+		expect(engine.hasServerNote("id-a")).toBe(true);
+	});
+
+	test("the sentinel never downgrades an authoritative crdtHead", async () => {
+		// patchSyncedRow MERGES, so writing the placeholder over a real head
+		// recorded by applyPushedNoteUpdate would invert the sentinel's contract
+		// and defeat the convergence cost gate — re-firing STEP1 forever.
+		const { engine } = makeEngine([]);
+		const map = new NoteIdMap();
+		map.set("Notes/a.md", "id-a");
+		engine.setNoteIdMap(map);
+		(engine as unknown as { setCrdtHead(p: string, h: string): void }).setCrdtHead(
+			"Notes/a.md",
+			"real-server-head-abc",
+		);
+		stage(engine, "id-a", {
+			path: "Notes/a.md",
+			serverHash: "h1",
+			content: "server body",
+			version: 3,
+			seq: 7,
+		});
+
+		await engine.commitCrdtConvergence("id-a");
+
+		const head = (
+			engine as unknown as { getCrdtHead(p: string): string | undefined }
+		).getCrdtHead("Notes/a.md");
+		expect(head).toBe("real-server-head-abc");
 	});
 
 	test("an EMPTY converged doc does NOT claim the server has the note", async () => {

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -9,12 +9,13 @@
  * and real failure tallies. Mock-engine pattern mirrors
  * tests/sync-socket-catchup.test.ts.
  */
-import { describe, expect, mock, spyOn, test } from "bun:test";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import "fake-indexeddb/auto";
 import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { NoteIdMap } from "../src/crdt/note-id-map";
 import type { ProviderRegistry as CrdtManager } from "../src/crdt/provider-registry";
+import { destroyRemoteLog, initRemoteLog } from "../src/remote-log";
 import { SyncEngine } from "../src/sync";
 import { DEFAULT_SETTINGS, type SyncChange, type SyncProgress } from "../src/types";
 
@@ -671,5 +672,60 @@ describe("hasServerNote after a handshake heal (#339)", () => {
 		await engine.commitCrdtConvergence("id-empty");
 
 		expect(engine.hasServerNote("id-empty")).toBe(false);
+	});
+});
+
+describe("replay outcome summary (prod 2026-08-13 blindness)", () => {
+	// initRemoteLog() installs a GLOBAL singleton. Leaving it configured leaks a
+	// live logger into every later test file in the process — it made
+	// crdt/wiring.test.ts fail in the full run while passing alone.
+	afterEach(async () => {
+		await destroyRemoteLog();
+	});
+
+	/** Capture what the plugin would ship, with diagnostics OFF — the default,
+	 *  and the state Todd's install was in when 316 of 316 notes vanished with
+	 *  zero client log lines to look at. */
+	const captureShipped = () => {
+		const sent: Array<{ level: string; category: string; message: string }> = [];
+		const logger = initRemoteLog();
+		logger.configure(
+			async (batch: any[]) => {
+				sent.push(...batch);
+			},
+			"test",
+			"test",
+		);
+		logger.setEnabled(false);
+		return { sent, flush: () => logger.flush() };
+	};
+
+	test("a replay that consumes rows but produces NOTHING reports itself", async () => {
+		// applied > 0, files === 0, deletes === 0 — work went in, nothing came
+		// out. That is the exact shape of the prod failure and it was silent.
+		const { sent, flush } = captureShipped();
+		const { engine } = makeEngine(threeRowFeed());
+		spyOn(engine, "applySyncChange").mockResolvedValue(false);
+
+		await engine.catchUp({ reportProgress: true });
+		await flush();
+
+		const anomaly = sent.find((e) => e.message.includes("produced no files"));
+		expect(anomaly).toBeDefined();
+		expect(anomaly?.level).toBe("warn");
+		// Counts + reasons only — never a path. The diagnostics setting is
+		// protecting the user from per-note telemetry and that stays intact.
+		expect(anomaly?.message).not.toContain("Notes/");
+		expect(anomaly?.message).toContain("applied=3");
+	});
+
+	test("a healthy replay stays silent with diagnostics off", async () => {
+		const { sent, flush } = captureShipped();
+		const { engine } = makeEngine(threeRowFeed());
+
+		await engine.catchUp({ reportProgress: true });
+		await flush();
+
+		expect(sent.filter((e) => e.message.includes("produced no files")).length).toBe(0);
 	});
 });

--- a/tests/sync-progress-firstsync.test.ts
+++ b/tests/sync-progress-firstsync.test.ts
@@ -729,3 +729,55 @@ describe("replay outcome summary (prod 2026-08-13 blindness)", () => {
 		expect(sent.filter((e) => e.message.includes("produced no files")).length).toBe(0);
 	});
 });
+
+describe("the sync gate must not fake success (prod 2026-08-13 root cause)", () => {
+	afterEach(async () => {
+		await destroyRemoteLog();
+	});
+
+	const captureShipped = () => {
+		const sent: Array<{ level: string; message: string }> = [];
+		const logger = initRemoteLog();
+		logger.configure(
+			async (b: any[]) => {
+				sent.push(...b);
+			},
+			"test",
+			"test",
+		);
+		logger.setEnabled(false);
+		return { sent, flush: () => logger.flush() };
+	};
+
+	test("a gate-blocked pull writes nothing and does NOT count files", async () => {
+		// THE bug. flushFromCrdt short-circuited on syncBlocked and returned
+		// TRUE, so a write that never happened counted as a downloaded file:
+		// the bar hit 100%, the recap claimed success, the anomaly could not
+		// fire, and the only trace was a devLog that never leaves the machine.
+		// Folders bypass the gate (direct vault.createFolder), which is why the
+		// user saw folders arrive and not one note.
+		const { sent, flush } = captureShipped();
+		const { engine } = makeEngine(threeRowFeed());
+		engine.setSyncBlocked(true);
+
+		const res = await engine.catchUp({ reportProgress: true });
+		await flush();
+
+		expect(res.files).toBe(0);
+		const anomaly = sent.find((e) => e.message.includes("produced no files"));
+		expect(anomaly).toBeDefined();
+		expect(anomaly?.level).toBe("warn");
+	});
+
+	test("with the gate open the same feed materialises normally", async () => {
+		const { sent, flush } = captureShipped();
+		const { engine } = makeEngine(threeRowFeed());
+		engine.setSyncBlocked(false);
+
+		const res = await engine.catchUp({ reportProgress: true });
+		await flush();
+
+		expect(res.files).toBe(2);
+		expect(sent.filter((e) => e.message.includes("produced no files")).length).toBe(0);
+	});
+});

--- a/tests/sync-push-consolidation.test.ts
+++ b/tests/sync-push-consolidation.test.ts
@@ -17,6 +17,7 @@ import { TFile } from "obsidian";
 import * as syncProtocol from "y-protocols/sync";
 import * as Y from "yjs";
 import type { EngramApi } from "../src/api";
+import { fnv1a } from "../src/content-hash";
 import {
 	CONTENT_KEY,
 	frontmatterOf,
@@ -493,5 +494,39 @@ describe("pushPartitioned — per-file genesis (no batch RPC)", () => {
 
 		expect(out).toEqual({ pushed: 2, failed: 1 });
 		expect((engine as any).issues.get("Notes/f1.md")?.message).toContain("timeout");
+	});
+});
+
+describe("pushFile — echo suppression runs before the push slot (#426)", () => {
+	test("an echoed note does not queue behind in-flight pushes", async () => {
+		const file = new TFile("Notes/Echo.md", Date.now());
+		const { engine } = makeEngine([file], { "Notes/Echo.md": "# same" });
+		// The engine itself wrote this content (flushFromCrdt → recordCrdtBaseline),
+		// so syncState already holds the exact disk hash. Obsidian still fires a
+		// modify event for it; the resulting push is pure echo.
+		(engine as any).stampSyncedRow("Notes/Echo.md", { hash: fnv1a("# same") });
+		// Every push slot held by a real in-flight upload.
+		(engine as any).activePushCount = (engine as any).maxConcurrentPushes;
+
+		const result = await Promise.race([
+			(engine as any).pushFile(file),
+			new Promise((r) => setTimeout(() => r("HUNG"), 50)),
+		]);
+
+		expect(result).toBe(false);
+	});
+
+	test("a genuinely changed note still waits for a slot", async () => {
+		const file = new TFile("Notes/Real.md", Date.now());
+		const { engine } = makeEngine([file], { "Notes/Real.md": "# edited" });
+		(engine as any).stampSyncedRow("Notes/Real.md", { hash: fnv1a("# stale") });
+		(engine as any).activePushCount = (engine as any).maxConcurrentPushes;
+
+		const result = await Promise.race([
+			(engine as any).pushFile(file),
+			new Promise((r) => setTimeout(() => r("HUNG"), 50)),
+		]);
+
+		expect(result).toBe("HUNG");
 	});
 });


### PR DESCRIPTION
## Why

Prod multi-device first-sync test, 2026-08-13. Four symptoms reported:
download progress bar showed nothing, filenames never populated, the pull
stalled and "took forever", and then the plugin announced **122 files to
upload from a 100% empty local vault**.

Telemetry says the server was not the problem. Across the whole window it
burned **~9.6 vCPU-seconds and ~2s of DB time for 122 files**, CPU peaked at
24% of a 0.5-vCPU task for 2 minutes and returned to a 5% idle baseline, and
Loki logged **zero errors**. The wall clock was spent waiting, not computing.
Both defects are client-side.

## 1. Coalesced callers lost the per-file stream

`#422` made a coalescing `catchupViaSeqReplay` report honest **counts**, but
its early return (`src/sync.ts`, the `seqReplayRunning` branch) never reaches
the exclusive call site's `opts.onFileApplied` hand-off. The callback was
silently discarded.

On a first sync this is **guaranteed, not racy**. The topic-join handler is
one of many bare `catchupViaSeqReplay()` callers and always starts the replay
first, so the user's sync modal always coalesces behind it. The modal then
blocked on the entire replay showing a dead 0% bar and no filenames, and
printed a single final number when it was over.

**Fix:** the running session owns a `seqReplayFileListeners` fan-out.
Coalescers subscribe for the life of their await and unsubscribe in a
`finally`; the exclusive caller's own callback joins the same set. One
mechanism instead of two divergent ones.

Ticks applied before a coalescer registers are lost by construction — the
returned counts still carry the session's true totals, so the recap stays
honest.

## 2. `hasServerNote` stayed false after a handshake heal (#339)

`commitCrdtConvergence` recorded `serverHash`/`version`/`seq` but never a
`crdtHead`. So for a note whose full server state we had *just merged*, the
oracle still answered "the server has no row for this". Its next push took the
genesis branch, and on a first sync `splitGenesisVsKnown` misrouted the entire
freshly-pulled vault through `crdtCreateBatch` — the phantom 122 uploads.

**Fix:** a STEP2 that delivered **content** now sets `CRDT_HEAD_CREATED`.

An **empty** converged doc deliberately does not — genesis is still the
correct route for a genuinely-new note, and a test pins that boundary so the
fix cannot over-apply. This is option 1 from #339; option 2 (broadening the
oracle to trust op-log rows) was not taken, since `hasServerNote` gates write
routing in four places.

## Tests

TDD, all watched red first:

- `a progress-reporting catch-up that coalesces still gets per-file pulling events` — failed with `received []`, i.e. zero events, the exact diagnosed symptom
- `a note that converged via STEP2 is known to exist on the server` — failed `false`
- `an EMPTY converged doc does NOT claim the server has the note` — **passed from the start**; it exists to keep the fix from over-applying

Suite **2546 pass / 0 fail** (was 2543). `biome ci` + `eslint` + `stylelint` +
`tsc -noEmit` + build all green.

## Not in this PR

- 2× `crdt_channel: dropped crdt_msg → {:error, :not_found}` (note `019ffc9d-…`) during the same window — separate create-race class, only 2 occurrences.
- Plugin #159 blames a `240/10s` limit for slow fresh installs. That premise is **stale** — handshakes have had their own `2400/10s` lane for a while, and the limiter logged only 6 denials in 15 minutes. That issue needs updating, not code.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC
