### PR TITLE
feat(device-flow): carry the code in the verification URL

### DIFF
--- a/main.js
+++ b/main.js
@@ -18015,21 +18015,33 @@ function simplifiedScreenCopy(simple) {
     note: "Nothing will be removed from this device."
   };
 }
+var LOADING_TEXT_DELAY_MS = 400, LOADING_MIN_VISIBLE_MS = 600;
+function loadingHoldMs(shownAt, now) {
+  if (shownAt === null) return 0;
+  let held = now - shownAt;
+  return held >= LOADING_MIN_VISIBLE_MS ? 0 : LOADING_MIN_VISIBLE_MS - held;
+}
 var SyncPreviewModal = class extends import_obsidian21.Modal {
   constructor(app, plan, opts) {
     super(app);
     this.opts = opts;
     this.resolvedChoice = null;
     this.resolveFn = null;
+    this.loadingTextTimer = null;
+    this.holdTimer = null;
+    /** null until the "Comparing…" line is actually on screen. Doubles as the
+     *  flag renderPlanLoading reads and the clock the hold window measures. */
+    this.loadingTextShownAt = null;
     this.remoteVaultName = opts.remoteVaultName, this.state = new SyncPreviewState(plan, (choice) => {
       this.resolvedChoice = choice, this.close();
     });
   }
   onOpen() {
-    this.contentEl.addClass("engram-sync-preview-modal"), this.opts.initialView === "vault-picker" ? this.openVaultPicker() : this.render();
+    this.contentEl.addClass("engram-sync-preview-modal"), this.startLoadingTextTimer(), this.opts.initialView === "vault-picker" ? this.openVaultPicker() : this.render();
   }
   onClose() {
     var _a;
+    this.clearLoadingTimers();
     let resolve = this.resolveFn;
     this.resolveFn = null, this.contentEl.empty(), resolve && resolve((_a = this.resolvedChoice) != null ? _a : "cancel");
   }
@@ -18044,13 +18056,38 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
    *  applyVaultChange's replacePlan is authoritative and a late-arriving plan
    *  for the old vault must not clobber it. */
   setPlan(plan) {
-    this.state.plan == null && (this.state.replacePlan(plan), this.state.view === "preview" && this.render());
+    if (this.state.plan != null) return;
+    let hold = loadingHoldMs(this.loadingTextShownAt, Date.now());
+    if (hold > 0) {
+      this.holdTimer = window.setTimeout(() => {
+        this.holdTimer = null, this.applyPlan(plan);
+      }, hold);
+      return;
+    }
+    this.applyPlan(plan);
+  }
+  applyPlan(plan) {
+    this.state.plan == null && (this.clearLoadingTimers(), this.state.replacePlan(plan), this.state.view === "preview" && this.render());
+  }
+  /** The loading LINE is deferred, not the modal — the modal itself opens
+   *  instantly and keeps its header/footer the whole time. A plan that
+   *  resolves inside this window therefore shows no loading copy at all,
+   *  which is the point: a sentence displayed for 80ms is a flicker, not
+   *  information. Slowing every sync down to make it readable would tax the
+   *  fast path forever to fix a frame nobody wanted. */
+  startLoadingTextTimer() {
+    this.state.plan == null && (this.loadingTextTimer = window.setTimeout(() => {
+      this.loadingTextTimer = null, this.state.plan == null && (this.loadingTextShownAt = Date.now(), this.state.view === "preview" && this.render());
+    }, LOADING_TEXT_DELAY_MS));
+  }
+  clearLoadingTimers() {
+    this.loadingTextTimer !== null && (window.clearTimeout(this.loadingTextTimer), this.loadingTextTimer = null), this.holdTimer !== null && (window.clearTimeout(this.holdTimer), this.holdTimer = null);
   }
   /** Surface a plan-load failure in the instant-open loading view. Skipped once
    *  a plan exists (e.g. the user switched vaults), so a stale failure never
    *  overwrites a good plan. */
   setPlanError(message) {
-    this.state.plan == null && (this.state.planError = message, this.state.view === "preview" && this.render());
+    this.state.plan == null && (this.clearLoadingTimers(), this.loadingTextShownAt = Date.now(), this.state.planError = message, this.state.view === "preview" && this.render());
   }
   /** The plan the user ultimately chose against (after any vault switch), or
    *  null if it never loaded. Lets the caller describe the planned work in the
@@ -18110,7 +18147,7 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
     this.state.planError ? body.createSpan({
       cls: "engram-sync-preview-picker-error",
       text: this.state.planError
-    }) : body.createSpan({ text: "Comparing your vault with the cloud\u2026" }), this.renderFooter(parent, "Cancel", !1);
+    }) : this.loadingTextShownAt !== null && body.createSpan({ text: "Comparing your vault with the cloud\u2026" }), this.renderFooter(parent, "Cancel", !1);
   }
   /** Dismiss + optional "Change vault" footer, shared by the loaded preview
    *  and the loading state (previously identical blocks). */

--- a/main.js
+++ b/main.js
@@ -17377,39 +17377,38 @@ function renderEngramUrlSetting(ctx) {
         status.addClass("is-unreachable"), status.setText("\u2717 couldn't reach a server at this URL");
         break;
     }
-  }, runPreflight = (value) => {
+  }, runPreflight = (value, mayCommit = !1) => {
     if (!completeOrigin(value)) {
       status.removeClasses(STATUS_CLASSES), status.setText("");
       return;
     }
     let seq2 = ++probeSeq;
     status.removeClasses(STATUS_CLASSES), status.addClass("is-checking"), status.setText("Checking server\u2026"), EngramApi.probeHealth(value).then((result) => {
-      seq2 === probeSeq && (status.removeClass("is-checking"), renderStatus(result));
+      seq2 === probeSeq && (status.removeClass("is-checking"), renderStatus(result), mayCommit && result.kind === "engram" && commit());
     });
+  }, commit = async () => {
+    let next = pendingUrl.trim();
+    if (next === plugin.settings.apiUrl) return;
+    let { cleared, rejected } = await applyApiUrlChange(
+      pluginSwitchTarget(plugin),
+      next,
+      () => plugin.saveSettings()
+    );
+    if (rejected) {
+      new import_obsidian18.Notice(
+        "That does not look like a complete server address. Include the scheme, for example http://127.0.0.1:4000"
+      );
+      return;
+    }
+    plugin.settings.backendMode = modeForUrl(plugin.settings.apiUrl, ENGRAM_CLOUD_URL), await plugin.saveSettings(), cleared && new import_obsidian18.Notice("Engram backend changed \u2014 sign in again to continue."), redisplay();
   };
   setting.addText((text2) => {
     text2.setPlaceholder("https://engram.example.com"), text2.setValue(plugin.settings.apiUrl), text2.onChange((value) => {
-      pendingUrl = value, debounce !== null && window.clearTimeout(debounce), debounce = window.setTimeout(() => runPreflight(value), PREFLIGHT_DEBOUNCE_MS);
+      pendingUrl = value, debounce !== null && window.clearTimeout(debounce), debounce = window.setTimeout(() => runPreflight(value, !0), PREFLIGHT_DEBOUNCE_MS);
+    }), text2.inputEl.addEventListener("blur", () => {
+      debounce !== null && window.clearTimeout(debounce), commit();
     });
-  }).addButton(
-    (btn) => btn.setButtonText("Save").setCta().onClick(async () => {
-      let { cleared, rejected } = await applyApiUrlChange(
-        pluginSwitchTarget(plugin),
-        pendingUrl.trim(),
-        () => plugin.saveSettings()
-      );
-      if (rejected) {
-        new import_obsidian18.Notice(
-          "That does not look like a complete server address. Include the scheme, for example http://127.0.0.1:4000"
-        );
-        return;
-      }
-      plugin.settings.backendMode = modeForUrl(
-        plugin.settings.apiUrl,
-        ENGRAM_CLOUD_URL
-      ), await plugin.saveSettings(), cleared && new import_obsidian18.Notice("Engram backend changed \u2014 sign in again to continue."), redisplay();
-    })
-  ), completeOrigin(plugin.settings.apiUrl) && runPreflight(plugin.settings.apiUrl);
+  }), completeOrigin(plugin.settings.apiUrl) && runPreflight(plugin.settings.apiUrl);
 }
 function renderAuthSection(ctx) {
   var _a, _b;
@@ -17580,7 +17579,16 @@ function renderConnectionTab(ctx) {
       href: "https://github.com/engram-app/engram"
     }), renderEngramUrlSetting(ctx);
   }
-  renderAuthSection(ctx), renderVaultSection(ctx), mode === "selfhost" && renderSupportSection(ctx);
+  (mode === "cloud" || state !== "needs-url") && (renderAuthSection(ctx), renderFinishSetupRow(ctx), renderVaultSection(ctx)), mode === "selfhost" && renderSupportSection(ctx);
+}
+function renderFinishSetupRow(ctx) {
+  let { containerEl, plugin } = ctx;
+  if (!plugin.hasAuthConfigured() || !plugin.syncEngine.isSyncBlocked()) return;
+  new import_obsidian19.Setting(containerEl).setName("Finish sync setup").setDesc("Nothing in this vault syncs until you choose how to merge it with the server.").addButton(
+    (btn) => btn.setButtonText("Choose sync direction").setCta().onClick(() => {
+      plugin.doSyncWithFirstSyncCheck();
+    })
+  ).settingEl.addClass("engram-connection-warning");
 }
 
 // src/tabs/start-tab.ts

--- a/main.js
+++ b/main.js
@@ -25071,7 +25071,7 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
         let choice = await modal.awaitChoice();
         this.openPreviewModal = null, choice === "cancel" && this.syncEngine.isSyncBlocked() && new import_obsidian26.Notice(
           `Engram: sync is not set up yet, so nothing in this vault will sync.
-Click \u201CEngram: finish setup\u201D in the status bar to pick up where you left off.`,
+Click the Engram item in the status bar to pick up where you left off.`,
           1e4
         ), await this.runSyncWithProgress(choice, {
           plan: modal.getPlan(),

--- a/main.js
+++ b/main.js
@@ -16736,7 +16736,7 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
   }
   onOpen() {
     let { contentEl } = this;
-    contentEl.empty(), contentEl.createEl("h2", { text: "Link Obsidian to Engram" });
+    contentEl.addClass("engram-flow-modal"), contentEl.empty(), contentEl.createEl("h2", { text: "Link Obsidian to Engram" });
     let statusEl = contentEl.createEl("p", { text: "Starting..." });
     this.beginDeviceFlow(contentEl, statusEl);
   }
@@ -17078,7 +17078,7 @@ var SyncProgressModal = class extends import_obsidian15.Modal {
   onOpen() {
     var _a;
     let { contentEl } = this;
-    contentEl.empty(), contentEl.addClass("engram-sync-progress-modal"), contentEl.createEl("h2", { text: "Syncing your vault" }), this.opts.intro && contentEl.createEl("p", { text: this.opts.intro, cls: "engram-progress-intro" }), this.statusEl = contentEl.createEl("p", {
+    contentEl.empty(), contentEl.addClass("engram-sync-progress-modal"), contentEl.addClass("engram-flow-modal"), contentEl.createEl("h2", { text: "Syncing your vault" }), this.opts.intro && contentEl.createEl("p", { text: this.opts.intro, cls: "engram-progress-intro" }), this.statusEl = contentEl.createEl("p", {
       text: "Getting started\u2026",
       cls: "engram-progress-status"
     }), this.rowsWrap = contentEl.createDiv({ cls: "engram-progress-rows" }), this.rows = ((_a = this.opts.phases) != null ? _a : []).map((p) => ({
@@ -18037,7 +18037,7 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
     });
   }
   onOpen() {
-    this.contentEl.addClass("engram-sync-preview-modal"), this.startLoadingTextTimer(), this.opts.initialView === "vault-picker" ? this.openVaultPicker() : this.render();
+    this.contentEl.addClass("engram-sync-preview-modal"), this.contentEl.addClass("engram-flow-modal"), this.startLoadingTextTimer(), this.opts.initialView === "vault-picker" ? this.openVaultPicker() : this.render();
   }
   onClose() {
     var _a;

--- a/main.js
+++ b/main.js
@@ -18152,9 +18152,15 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
   /** Dismiss + optional "Change vault" footer, shared by the loaded preview
    *  and the loading state (previously identical blocks). */
   renderFooter(parent, dismissLabel, dismissCta) {
+    var _a;
+    let gated = ((_a = this.opts.context) != null ? _a : "review") !== "review" && !dismissCta;
+    gated && parent.createEl("p", {
+      cls: "engram-sync-preview-gate-note",
+      text: "Until you choose, nothing in this vault will sync."
+    });
     let footer = parent.createDiv({ cls: "engram-sync-preview-footer" });
     footer.createEl("button", {
-      text: dismissLabel,
+      text: gated ? "Not now" : dismissLabel,
       cls: dismissCta ? "mod-cta" : void 0
     }).addEventListener("click", () => this.state.cancel()), this.opts.showChangeVault && footer.createEl("button", { text: "Change vault" }).addEventListener("click", () => {
       this.openVaultPicker();
@@ -24992,7 +24998,11 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           modal.setPlanError(planLoadErrorMessage(this.hasAuthConfigured())), rlog().error("lifecycle", `Sync plan compute failed: ${errMsg(e)}`);
         }), this.openPreviewModal = modal;
         let choice = await modal.awaitChoice();
-        this.openPreviewModal = null, await this.runSyncWithProgress(choice, {
+        this.openPreviewModal = null, choice === "cancel" && this.syncEngine.isSyncBlocked() && new import_obsidian26.Notice(
+          `Engram: sync is not set up yet, so nothing in this vault will sync.
+Click \u201CEngram: finish setup\u201D in the status bar to pick up where you left off.`,
+          1e4
+        ), await this.runSyncWithProgress(choice, {
           plan: modal.getPlan(),
           firstSync: context === "first-time"
         });
@@ -25034,8 +25044,13 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
   updateStatusBar(status) {
     var _a, _b, _c, _d, _e;
     if (!this.statusBarEl) return;
-    let blocked = (_b = (_a = this.syncEngine) == null ? void 0 : _a.isSyncBlocked()) != null ? _b : !1, text2, tooltip;
-    this.hasAuthConfigured() ? blocked && status.state !== "syncing" ? (text2 = status.pending > 0 ? `Engram: sync paused (${status.pending} queued)` : "Engram: sync paused", tooltip = "Sync paused \u2014 click to choose a sync direction") : status.state === "offline" ? (text2 = status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline", tooltip = "Server unreachable \u2014 changes will sync when connected") : status.state === "error" ? (text2 = "Engram: error", tooltip = status.error || "Unknown error") : status.state === "syncing" ? (text2 = status.pending > 0 ? `Engram: syncing (${status.pending})` : "Engram: syncing", tooltip = "Sync in progress...") : status.pending > 0 ? (text2 = `Engram: pending (${status.pending})`, tooltip = `${status.pending} file(s) queued`) : this.liveConnected ? (text2 = "Engram: live", tooltip = "WebSocket connected \u2014 live sync active") : (text2 = "Engram: ready", tooltip = "Click to sync") : (text2 = "Engram: signed out", tooltip = "Not signed in. Click to open settings and reconnect.");
+    let blocked = (_b = (_a = this.syncEngine) == null ? void 0 : _a.isSyncBlocked()) != null ? _b : !1, text2, tooltip, neverSynced = !status.lastSync;
+    if (!this.hasAuthConfigured())
+      text2 = neverSynced ? "Engram: not connected" : "Engram: signed out", tooltip = neverSynced ? "Not connected yet. Click to open settings and link this vault." : "Not signed in. Click to open settings and reconnect.";
+    else if (blocked && status.state !== "syncing") {
+      let label = neverSynced ? "Engram: finish setup" : "Engram: sync paused";
+      text2 = status.pending > 0 ? `${label} (${status.pending} queued)` : label, tooltip = neverSynced ? "Setup is not finished \u2014 nothing will sync until you choose a sync direction. Click to finish." : "Sync paused \u2014 click to choose a sync direction";
+    } else status.state === "offline" ? (text2 = status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline", tooltip = "Server unreachable \u2014 changes will sync when connected") : status.state === "error" ? (text2 = "Engram: error", tooltip = status.error || "Unknown error") : status.state === "syncing" ? (text2 = status.pending > 0 ? `Engram: syncing (${status.pending})` : "Engram: syncing", tooltip = "Sync in progress...") : status.pending > 0 ? (text2 = `Engram: pending (${status.pending})`, tooltip = `${status.pending} file(s) queued`) : this.liveConnected ? (text2 = "Engram: live", tooltip = "WebSocket connected \u2014 live sync active") : (text2 = "Engram: ready", tooltip = "Click to sync");
     let errorCount = (_d = (_c = this.syncLog) == null ? void 0 : _c.errorCount()) != null ? _d : 0;
     if (errorCount > 0 && status.state === "idle" && !blocked && this.hasAuthConfigured() && (text2 = `Engram: \u26A0 ${errorCount} sync errors`), status.lastSync) {
       let date = new Date(status.lastSync);

--- a/main.js
+++ b/main.js
@@ -16657,6 +16657,50 @@ var import_obsidian23 = require("obsidian");
 
 // src/device-flow-modal.ts
 var import_obsidian14 = require("obsidian");
+
+// src/device-flow-socket.ts
+var HEARTBEAT_MS = 3e4;
+function waitForDeviceAuthorization(apiUrl, deviceCode, onAuthorized, opts = {}) {
+  let topic = `device:${deviceCode}`, socket = null, heartbeat = null, disposed = !1, ref = 0, dispose = () => {
+    disposed = !0, heartbeat !== null && (window.clearInterval(heartbeat), heartbeat = null);
+    try {
+      socket == null || socket.close();
+    } catch (e) {
+    }
+    socket = null;
+  };
+  try {
+    let wsBase = apiUrl.replace(/\/api\/?$/, "").replace(/^http/, "ws");
+    socket = new WebSocket(`${wsBase}/socket/device/websocket?vsn=2.0.0`);
+  } catch (e) {
+    return devLog().log("device-flow", `socket construct failed: ${errMsg(e)}`), dispose;
+  }
+  let send = (frame) => {
+    try {
+      socket == null || socket.send(JSON.stringify(frame));
+    } catch (e) {
+      devLog().log("device-flow", `socket send failed: ${errMsg(e)}`);
+    }
+  };
+  return socket.onopen = () => {
+    var _a;
+    disposed || (send(["1", String(++ref), topic, "phx_join", {}]), heartbeat = window.setInterval(() => {
+      send([null, String(++ref), "phoenix", "heartbeat", {}]);
+    }, (_a = opts.heartbeatMs) != null ? _a : HEARTBEAT_MS));
+  }, socket.onmessage = (evt) => {
+    if (!disposed)
+      try {
+        let frame = JSON.parse(String(evt.data));
+        frame[2] === topic && frame[3] === "authorized" && onAuthorized();
+      } catch (e) {
+        devLog().log("device-flow", `socket frame parse failed: ${errMsg(e)}`);
+      }
+  }, socket.onerror = () => {
+    devLog().log("device-flow", "socket error \u2014 falling back to poll");
+  }, dispose;
+}
+
+// src/device-flow-modal.ts
 function verificationUrlWithCode(verificationUrl, userCode) {
   try {
     let url = new URL(verificationUrl);
@@ -16671,6 +16715,8 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     this.resolve = () => {
     };
     this.pollInterval = null;
+    this.disposeSocket = null;
+    this.exchanging = !1;
     this.aborted = !1;
     this.plugin = plugin;
   }
@@ -16689,7 +16735,8 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     }
   }
   onClose() {
-    this.aborted = !0, this.pollInterval && (window.clearInterval(this.pollInterval), this.pollInterval = null), this.contentEl.empty(), this.resolve(null);
+    var _a;
+    this.aborted = !0, this.pollInterval && (window.clearInterval(this.pollInterval), this.pollInterval = null), (_a = this.disposeSocket) == null || _a.call(this), this.disposeSocket = null, this.contentEl.empty(), this.resolve(null);
   }
   waitForResult() {
     return new Promise((resolve) => {
@@ -16731,19 +16778,39 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     }), contentEl.createDiv({ cls: "engram-device-buttons" }).createEl("button", { text: "Cancel" }).addEventListener("click", () => this.close()), window.open(verificationUrlWithCode(resp.verification_url, resp.user_code));
   }
   startPolling(deviceCode) {
-    let apiUrl = EngramApi.normalizeBaseUrl(this.plugin.settings.apiUrl), startedAt = Date.now(), maxSeconds = 300, inFlight = !1, poll = async () => {
-      if (!(this.aborted || inFlight)) {
-        inFlight = !0;
+    let apiUrl = EngramApi.normalizeBaseUrl(this.plugin.settings.apiUrl);
+    this.disposeSocket = waitForDeviceAuthorization(apiUrl, deviceCode, () => {
+      this.exchangeNow(apiUrl, deviceCode);
+    });
+    let startedAt = Date.now(), maxSeconds = 300, poll = async () => {
+      if (!(this.aborted || this.exchanging)) {
+        this.exchanging = !0;
         try {
           await this.pollOnce(apiUrl, deviceCode, startedAt, maxSeconds);
         } finally {
-          inFlight = !1;
+          this.exchanging = !1;
         }
       }
     };
     this.pollInterval = window.setInterval(() => {
       poll();
-    }, 5e3);
+    }, 3e4);
+  }
+  /** Socket said the code was authorized: exchange it once, right now.
+   *
+   *  Guarded because the fallback interval is still armed — without this a
+   *  poll already in flight and the socket-triggered exchange could both
+   *  redeem, and the loser would see the 410 from a single-use code and
+   *  render "expired" over a flow that actually succeeded. */
+  async exchangeNow(apiUrl, deviceCode) {
+    if (!(this.aborted || this.exchanging)) {
+      this.exchanging = !0;
+      try {
+        await this.pollOnce(apiUrl, deviceCode, Date.now(), 300);
+      } finally {
+        this.exchanging = !1;
+      }
+    }
   }
   async pollOnce(apiUrl, deviceCode, startedAt, maxSeconds) {
     if ((Date.now() - startedAt) / 1e3 >= maxSeconds) {

--- a/main.js
+++ b/main.js
@@ -773,8 +773,13 @@ function isSaveableUrl(url) {
   }
   return parsed.protocol !== "http:" && parsed.protocol !== "https:" ? !1 : parsed.hostname.length > 0;
 }
+function saveableOrigin(url) {
+  if (!isSaveableUrl(url)) return null;
+  let parsed = new URL(url);
+  return `${parsed.protocol}//${parsed.host}`.toLowerCase();
+}
 function isBackendChange(oldUrl, newUrl) {
-  let oldO = completeOrigin(oldUrl), newO = completeOrigin(newUrl);
+  let oldO = saveableOrigin(oldUrl), newO = saveableOrigin(newUrl);
   return !oldO || !newO ? !1 : oldO !== newO;
 }
 function interpretHealthProbe(status, body) {
@@ -16689,7 +16694,7 @@ function waitForDeviceAuthorization(apiUrl, deviceCode, onAuthorized, opts = {})
       send([null, String(++ref), "phoenix", "heartbeat", {}]);
     }, (_a2 = opts.heartbeatMs) != null ? _a2 : HEARTBEAT_MS));
   }, socket.onmessage = (evt) => {
-    var _a2, _b;
+    var _a2, _b, _c;
     if (!disposed)
       try {
         let frame = JSON.parse(String(evt.data));
@@ -16697,19 +16702,23 @@ function waitForDeviceAuthorization(apiUrl, deviceCode, onAuthorized, opts = {})
           onAuthorized();
           return;
         }
+        if (frame[2] === topic && (frame[3] === "phx_error" || frame[3] === "phx_close")) {
+          (_a2 = opts.onStatus) == null || _a2.call(opts, !1);
+          return;
+        }
         if (frame[2] === topic && frame[3] === "phx_reply") {
-          let ok = ((_a2 = frame[4]) == null ? void 0 : _a2.status) === "ok";
-          devLog().log("device-flow", `join reply status=${ok ? "ok" : "error"}`), (_b = opts.onStatus) == null || _b.call(opts, ok);
+          let ok = ((_b = frame[4]) == null ? void 0 : _b.status) === "ok";
+          devLog().log("device-flow", `join reply status=${ok ? "ok" : "error"}`), (_c = opts.onStatus) == null || _c.call(opts, ok);
         }
       } catch (e) {
         devLog().log("device-flow", `socket frame parse failed: ${errMsg(e)}`);
       }
   }, socket.onerror = () => {
     var _a2;
-    devLog().log("device-flow", "socket error \u2014 falling back to poll"), (_a2 = opts.onStatus) == null || _a2.call(opts, !1);
+    disposed || (devLog().log("device-flow", "socket error \u2014 falling back to poll"), (_a2 = opts.onStatus) == null || _a2.call(opts, !1));
   }, socket.onclose = (evt) => {
     var _a2;
-    disposed || (devLog().log("device-flow", `socket closed code=${evt.code} \u2014 falling back to poll`), (_a2 = opts.onStatus) == null || _a2.call(opts, !1));
+    disposed || (devLog().log("device-flow", `socket closed code=${evt.code} \u2014 falling back to poll`), (_a2 = opts.onStatus) == null || _a2.call(opts, !1), dispose());
   }, dispose;
 }
 
@@ -16730,6 +16739,8 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     this.pollInterval = null;
     this.disposeSocket = null;
     this.exchanging = !1;
+    /** Socket said "authorized" while an exchange was already in flight. */
+    this.pendingAuthorized = !1;
     this.waitingEl = null;
     this.aborted = !1;
     this.plugin = plugin;
@@ -16748,9 +16759,20 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
       statusEl.setText("Failed to start device flow. Check your Engram URL and try again.");
     }
   }
-  onClose() {
+  /** Tear down everything belonging to ONE attempt at the flow.
+   *
+   *  Both exits need this. Close is the obvious one; "Try again" is the one
+   *  that bit: it re-ran onOpen(), and startPolling() then OVERWROTE
+   *  disposeSocket and pollInterval, leaking the previous socket and its
+   *  heartbeat for the rest of the Obsidian session. Worse, the orphan's
+   *  onAuthorized closure still held the OLD device_code and could take
+   *  `exchanging`, blocking the retry the user is standing there watching. */
+  resetFlow() {
     var _a;
-    this.aborted = !0, this.pollInterval && (window.clearInterval(this.pollInterval), this.pollInterval = null), (_a = this.disposeSocket) == null || _a.call(this), this.disposeSocket = null, this.contentEl.empty(), this.resolve(null);
+    this.pollInterval && (window.clearInterval(this.pollInterval), this.pollInterval = null), (_a = this.disposeSocket) == null || _a.call(this), this.disposeSocket = null, this.exchanging = !1, this.pendingAuthorized = !1;
+  }
+  onClose() {
+    this.aborted = !0, this.resetFlow(), this.contentEl.empty(), this.resolve(null);
   }
   waitForResult() {
     return new Promise((resolve) => {
@@ -16814,11 +16836,14 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
         } finally {
           this.exchanging = !1;
         }
+        await this.drainPendingAuthorized(apiUrl, deviceCode);
       }
     };
-    this.pollInterval = window.setInterval(() => {
-      poll();
-    }, 3e4);
+    this.pollInterval = this.plugin.registerInterval(
+      window.setInterval(() => {
+        poll();
+      }, 3e4)
+    ), this.plugin.register(() => this.resetFlow());
   }
   /** Socket said the code was authorized: exchange it once, right now.
    *
@@ -16827,14 +16852,25 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
    *  redeem, and the loser would see the 410 from a single-use code and
    *  render "expired" over a flow that actually succeeded. */
   async exchangeNow(apiUrl, deviceCode) {
-    if (!(this.aborted || this.exchanging)) {
+    if (!this.aborted) {
+      if (this.exchanging) {
+        this.pendingAuthorized = !0;
+        return;
+      }
       this.exchanging = !0;
       try {
         await this.pollOnce(apiUrl, deviceCode, Date.now(), 300);
       } finally {
         this.exchanging = !1;
       }
+      await this.drainPendingAuthorized(apiUrl, deviceCode);
     }
+  }
+  /** Re-run an exchange that arrived while the lock was held. Bounded: the
+   *  flag is only ever set while `exchanging` is true, and cleared before the
+   *  retry, so this cannot loop. */
+  async drainPendingAuthorized(apiUrl, deviceCode) {
+    !this.pendingAuthorized || this.aborted || (this.pendingAuthorized = !1, await this.exchangeNow(apiUrl, deviceCode));
   }
   async pollOnce(apiUrl, deviceCode, startedAt, maxSeconds) {
     var _a;
@@ -16874,7 +16910,7 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     contentEl.empty(), contentEl.createEl("h2", { text: "Link Obsidian to Engram" }), contentEl.createEl("p", { text: "Code expired. Please try again." });
     let btnContainer = contentEl.createDiv({ cls: "engram-device-buttons" });
     btnContainer.createEl("button", { text: "Try again", cls: "mod-cta" }).addEventListener("click", () => {
-      this.aborted = !1, this.onOpen();
+      this.resetFlow(), this.aborted = !1, this.onOpen();
     }), btnContainer.createEl("button", { text: "Close" }).addEventListener("click", () => this.close());
   }
 };
@@ -17361,11 +17397,11 @@ var import_obsidian19 = require("obsidian");
 
 // src/tabs/self-hosted-tab.ts
 var import_obsidian18 = require("obsidian");
-var PREFLIGHT_DEBOUNCE_MS = 600, API_KEY_PREFIX = "engram_";
+var PREFLIGHT_DEBOUNCE_MS = 600, refocusUrlInput = !1, API_KEY_PREFIX = "engram_";
 function renderEngramUrlSetting(ctx) {
   let { containerEl, plugin, redisplay } = ctx, setting = new import_obsidian18.Setting(containerEl).setName("Engram URL");
   setting.settingEl.addClass("engram-url-setting");
-  let status = setting.descEl.createDiv({ cls: "engram-url-preflight" }), STATUS_CLASSES = ["is-checking", "is-engram", "is-reachable", "is-unreachable"], pendingUrl = plugin.settings.apiUrl, debounce = null, probeSeq = 0, renderStatus = (result) => {
+  let status = setting.descEl.createDiv({ cls: "engram-url-preflight" }), STATUS_CLASSES = ["is-checking", "is-engram", "is-reachable", "is-unreachable"], pendingUrl = plugin.settings.apiUrl, debounce = null, probeSeq = 0, inputEl = null, renderStatus = (result) => {
     switch (status.removeClasses(STATUS_CLASSES), result.kind) {
       case "engram":
         status.addClass("is-engram"), status.setText(`\u2713 Engram server reachable (v${result.version})`);
@@ -17384,7 +17420,7 @@ function renderEngramUrlSetting(ctx) {
     }
     let seq2 = ++probeSeq;
     status.removeClasses(STATUS_CLASSES), status.addClass("is-checking"), status.setText("Checking server\u2026"), EngramApi.probeHealth(value).then((result) => {
-      seq2 === probeSeq && (status.removeClass("is-checking"), renderStatus(result), mayCommit && result.kind === "engram" && commit());
+      seq2 === probeSeq && (status.removeClass("is-checking"), renderStatus(result), mayCommit && result.kind === "engram" && (refocusUrlInput = document.activeElement === inputEl, commit()));
     });
   }, commit = async () => {
     let next = pendingUrl.trim();
@@ -17403,11 +17439,15 @@ function renderEngramUrlSetting(ctx) {
     plugin.settings.backendMode = modeForUrl(plugin.settings.apiUrl, ENGRAM_CLOUD_URL), await plugin.saveSettings(), cleared && new import_obsidian18.Notice("Engram backend changed \u2014 sign in again to continue."), redisplay();
   };
   setting.addText((text2) => {
-    text2.setPlaceholder("https://engram.example.com"), text2.setValue(plugin.settings.apiUrl), text2.onChange((value) => {
+    if (inputEl = text2.inputEl, text2.setPlaceholder("https://engram.example.com"), text2.setValue(plugin.settings.apiUrl), text2.onChange((value) => {
       pendingUrl = value, debounce !== null && window.clearTimeout(debounce), debounce = window.setTimeout(() => runPreflight(value, !0), PREFLIGHT_DEBOUNCE_MS);
     }), text2.inputEl.addEventListener("blur", () => {
-      debounce !== null && window.clearTimeout(debounce), commit();
-    });
+      document.hasFocus() && (debounce !== null && window.clearTimeout(debounce), commit());
+    }), refocusUrlInput) {
+      refocusUrlInput = !1, text2.inputEl.focus();
+      let end = text2.inputEl.value.length;
+      text2.inputEl.setSelectionRange(end, end);
+    }
   }), completeOrigin(plugin.settings.apiUrl) && runPreflight(plugin.settings.apiUrl);
 }
 function renderAuthSection(ctx) {
@@ -18024,8 +18064,8 @@ function simplifiedScreenCopy(simple) {
   };
 }
 var LOADING_TEXT_DELAY_MS = 400, LOADING_MIN_VISIBLE_MS = 600;
-function emptyPlanDismiss(context) {
-  return context === "review" ? { label: "Close", accept: !1 } : { label: "Done", accept: !0 };
+function emptyPlanDismiss(gateClosed) {
+  return gateClosed ? { label: "Done", accept: !0 } : { label: "Close", accept: !1 };
 }
 function loadingHoldMs(shownAt, now) {
   if (shownAt === null) return 0;
@@ -18111,7 +18151,7 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
     contentEl.empty(), this.state.view === "preview" ? this.renderPreview() : this.state.view === "vault-picker" ? this.renderVaultPicker() : this.renderConfirm();
   }
   renderPreview() {
-    var _a;
+    var _a, _b;
     let { contentEl } = this, context = (_a = this.opts.context) != null ? _a : "review";
     if (this.state.plan == null) {
       this.renderPlanLoading(contentEl, context);
@@ -18131,7 +18171,7 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
     });
     let mergeRow = options.createDiv({ cls: "engram-sync-preview-options-merge" });
     if (this.renderOptionCard(mergeRow, MERGE_CARD), this.renderAdvancedOptions(options), empty) {
-      let { label, accept } = emptyPlanDismiss(context);
+      let { label, accept } = emptyPlanDismiss((_b = this.opts.gateClosed) != null ? _b : !1);
       this.renderFooter(
         contentEl,
         label,
@@ -18174,7 +18214,7 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
    *  and the loading state (previously identical blocks). */
   renderFooter(parent, dismissLabel, dismissCta, dismissAction) {
     var _a;
-    let gated = ((_a = this.opts.context) != null ? _a : "review") !== "review" && !dismissCta;
+    let gated = ((_a = this.opts.gateClosed) != null ? _a : !1) && !dismissCta;
     gated && parent.createEl("p", {
       cls: "engram-sync-preview-gate-note",
       text: "Until you choose, nothing in this vault will sync."
@@ -18556,7 +18596,8 @@ function renderActions(parent, plugin, refresh) {
       let modal = new SyncPreviewModal(plugin.app, null, {
         remoteVaultName: plugin.settings.remoteVaultName,
         showChangeVault: !1,
-        context: "review"
+        context: "review",
+        gateClosed: plugin.syncEngine.isSyncBlocked()
       });
       plugin.syncEngine.computeSyncPlan("full").then((p) => modal.setPlan(p)).catch(() => modal.setPlanError(planLoadErrorMessage(plugin.hasAuthConfigured()))), plugin.trackPreviewModal(modal);
       let choice;
@@ -25012,6 +25053,9 @@ var _EngramSyncPlugin = class _EngramSyncPlugin extends import_obsidian26.Plugin
           remoteVaultName: this.settings.remoteVaultName,
           showChangeVault: !0,
           context,
+          // The fact, not the copy variable: this decides whether the
+          // modal warns that nothing will sync until you choose.
+          gateClosed: this.syncEngine.isSyncBlocked(),
           initialView: opts.startInVaultPicker ? "vault-picker" : "preview",
           attachmentsTextOnly: (_b = (_a = this.syncEngine.getPlanState()) == null ? void 0 : _a.attachmentsTextOnly) != null ? _b : !1,
           listVaults: () => this.api.listVaults(),

--- a/main.js
+++ b/main.js
@@ -16717,7 +16717,6 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     this.pollInterval = null;
     this.disposeSocket = null;
     this.exchanging = !1;
-    this.linkedSyncBtn = null;
     this.aborted = !1;
     this.plugin = plugin;
   }
@@ -16813,35 +16812,6 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
       }
     }
   }
-  /** Success screen. The modal used to just close here, so a successful link
-   *  was indistinguishable from the modal crashing — it vanished, said
-   *  nothing, and left the user with no idea that linking does NOT sync
-   *  anything on its own and a first sync still has to be started.
-   *
-   *  The sync button starts disabled: syncing needs persisted tokens, and
-   *  those are written by the caller after `waitForResult()` resolves. It is
-   *  armed by `markLinked()` so a fast click can't kick off a sync that would
-   *  401 on a token that isn't saved yet. */
-  renderLinked(result) {
-    let { contentEl } = this;
-    contentEl.empty(), contentEl.createEl("h2", { text: "Vault linked" }), result.user_email && contentEl.createEl("p", { text: `Signed in as ${result.user_email}.` }), contentEl.createEl("p", {
-      text: "Nothing has synced yet \u2014 linking only connects the account. Start the first sync to push this vault to Engram."
-    });
-    let btnContainer = contentEl.createDiv({ cls: "engram-device-buttons" });
-    btnContainer.createEl("button", { text: "Later" }).addEventListener("click", () => this.close());
-    let syncBtn = btnContainer.createEl("button", {
-      text: "Finishing link\u2026",
-      cls: "mod-cta"
-    });
-    syncBtn.disabled = !0, syncBtn.addEventListener("click", () => {
-      this.close(), this.plugin.doSyncWithFirstSyncCheck();
-    }), this.linkedSyncBtn = syncBtn;
-  }
-  /** Called by the caller once the tokens are persisted — only then is a sync
-   *  able to authenticate. No-op if the linked screen was never rendered. */
-  markLinked() {
-    this.linkedSyncBtn && (this.linkedSyncBtn.disabled = !1, this.linkedSyncBtn.setText("Start first sync"));
-  }
   async pollOnce(apiUrl, deviceCode, startedAt, maxSeconds) {
     var _a;
     if ((Date.now() - startedAt) / 1e3 >= maxSeconds) {
@@ -16863,8 +16833,8 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
       if (resp.status >= 200 && resp.status < 300) {
         this.pollInterval && window.clearInterval(this.pollInterval), (_a = this.disposeSocket) == null || _a.call(this), this.disposeSocket = null;
         let result = resp.json;
-        this.renderLinked(result), this.resolve(result), this.resolve = () => {
-        };
+        this.resolve(result), this.resolve = () => {
+        }, this.close();
         return;
       }
       if (resp.status === 410) {
@@ -18910,12 +18880,12 @@ var EngramSyncSettingTab = class extends import_obsidian23.PluginSettingTab {
     wrapper && (this.installedProgressCb = null, this.plugin.syncEngine.onSyncProgress === wrapper && (this.plugin.syncEngine.onSyncProgress = this.prevProgressCb));
   }
   async startDeviceFlow() {
-    let modal = new DeviceFlowModal(this.app, this.plugin), result = await modal.waitForResult();
+    let result = await new DeviceFlowModal(this.app, this.plugin).waitForResult();
     result && (await this.plugin.saveOAuthTokens(
       result.refresh_token,
       result.vault_id,
       result.user_email
-    ), modal.markLinked(), this.rerender());
+    ), this.rerender(), this.plugin.doSyncWithFirstSyncCheck());
   }
   /** Render (or re-render) the connection status row in place. Idempotent —
    *  empties the container first so it can be wired to live status events. */

--- a/main.js
+++ b/main.js
@@ -18016,6 +18016,9 @@ function simplifiedScreenCopy(simple) {
   };
 }
 var LOADING_TEXT_DELAY_MS = 400, LOADING_MIN_VISIBLE_MS = 600;
+function emptyPlanDismiss(context) {
+  return context === "review" ? { label: "Close", accept: !1 } : { label: "Done", accept: !0 };
+}
 function loadingHoldMs(shownAt, now) {
   if (shownAt === null) return 0;
   let held = now - shownAt;
@@ -18119,7 +18122,17 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
       text: mergeHelperText(optionBreakdown(this.requirePlan(), "smart-merge"), context)
     });
     let mergeRow = options.createDiv({ cls: "engram-sync-preview-options-merge" });
-    this.renderOptionCard(mergeRow, MERGE_CARD), this.renderAdvancedOptions(options), this.renderFooter(contentEl, empty ? "Close" : "Cancel", empty);
+    if (this.renderOptionCard(mergeRow, MERGE_CARD), this.renderAdvancedOptions(options), empty) {
+      let { label, accept } = emptyPlanDismiss(context);
+      this.renderFooter(
+        contentEl,
+        label,
+        !0,
+        accept ? () => this.state.pickOption("smart-merge") : void 0
+      );
+      return;
+    }
+    this.renderFooter(contentEl, "Cancel", !1);
   }
   /** The one-click screen for an empty-side first sync. One primary action
    *  (always smart-merge — non-destructive by construction), plus the footer's
@@ -18151,7 +18164,7 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
   }
   /** Dismiss + optional "Change vault" footer, shared by the loaded preview
    *  and the loading state (previously identical blocks). */
-  renderFooter(parent, dismissLabel, dismissCta) {
+  renderFooter(parent, dismissLabel, dismissCta, dismissAction) {
     var _a;
     let gated = ((_a = this.opts.context) != null ? _a : "review") !== "review" && !dismissCta;
     gated && parent.createEl("p", {
@@ -18162,7 +18175,13 @@ var SyncPreviewModal = class extends import_obsidian21.Modal {
     footer.createEl("button", {
       text: gated ? "Not now" : dismissLabel,
       cls: dismissCta ? "mod-cta" : void 0
-    }).addEventListener("click", () => this.state.cancel()), this.opts.showChangeVault && footer.createEl("button", { text: "Change vault" }).addEventListener("click", () => {
+    }).addEventListener("click", () => {
+      if (dismissAction) {
+        dismissAction();
+        return;
+      }
+      this.state.cancel();
+    }), this.opts.showChangeVault && footer.createEl("button", { text: "Change vault" }).addEventListener("click", () => {
       this.openVaultPicker();
     });
   }

--- a/main.js
+++ b/main.js
@@ -16657,6 +16657,14 @@ var import_obsidian23 = require("obsidian");
 
 // src/device-flow-modal.ts
 var import_obsidian14 = require("obsidian");
+function verificationUrlWithCode(verificationUrl, userCode) {
+  try {
+    let url = new URL(verificationUrl);
+    return url.searchParams.set("code", userCode), url.toString();
+  } catch (e) {
+    return verificationUrl;
+  }
+}
 var DeviceFlowModal = class extends import_obsidian14.Modal {
   constructor(app, plugin) {
     super(app);
@@ -16720,7 +16728,7 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     }), contentEl.createEl("p", {
       text: "Waiting for authorization...",
       cls: "engram-device-waiting"
-    }), contentEl.createDiv({ cls: "engram-device-buttons" }).createEl("button", { text: "Cancel" }).addEventListener("click", () => this.close()), window.open(resp.verification_url);
+    }), contentEl.createDiv({ cls: "engram-device-buttons" }).createEl("button", { text: "Cancel" }).addEventListener("click", () => this.close()), window.open(verificationUrlWithCode(resp.verification_url, resp.user_code));
   }
   startPolling(deviceCode) {
     let apiUrl = EngramApi.normalizeBaseUrl(this.plugin.settings.apiUrl), startedAt = Date.now(), maxSeconds = 300, inFlight = !1, poll = async () => {

--- a/main.js
+++ b/main.js
@@ -16717,6 +16717,7 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     this.pollInterval = null;
     this.disposeSocket = null;
     this.exchanging = !1;
+    this.linkedSyncBtn = null;
     this.aborted = !1;
     this.plugin = plugin;
   }
@@ -16812,7 +16813,37 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
       }
     }
   }
+  /** Success screen. The modal used to just close here, so a successful link
+   *  was indistinguishable from the modal crashing — it vanished, said
+   *  nothing, and left the user with no idea that linking does NOT sync
+   *  anything on its own and a first sync still has to be started.
+   *
+   *  The sync button starts disabled: syncing needs persisted tokens, and
+   *  those are written by the caller after `waitForResult()` resolves. It is
+   *  armed by `markLinked()` so a fast click can't kick off a sync that would
+   *  401 on a token that isn't saved yet. */
+  renderLinked(result) {
+    let { contentEl } = this;
+    contentEl.empty(), contentEl.createEl("h2", { text: "Vault linked" }), result.user_email && contentEl.createEl("p", { text: `Signed in as ${result.user_email}.` }), contentEl.createEl("p", {
+      text: "Nothing has synced yet \u2014 linking only connects the account. Start the first sync to push this vault to Engram."
+    });
+    let btnContainer = contentEl.createDiv({ cls: "engram-device-buttons" });
+    btnContainer.createEl("button", { text: "Later" }).addEventListener("click", () => this.close());
+    let syncBtn = btnContainer.createEl("button", {
+      text: "Finishing link\u2026",
+      cls: "mod-cta"
+    });
+    syncBtn.disabled = !0, syncBtn.addEventListener("click", () => {
+      this.close(), this.plugin.doSyncWithFirstSyncCheck();
+    }), this.linkedSyncBtn = syncBtn;
+  }
+  /** Called by the caller once the tokens are persisted — only then is a sync
+   *  able to authenticate. No-op if the linked screen was never rendered. */
+  markLinked() {
+    this.linkedSyncBtn && (this.linkedSyncBtn.disabled = !1, this.linkedSyncBtn.setText("Start first sync"));
+  }
   async pollOnce(apiUrl, deviceCode, startedAt, maxSeconds) {
+    var _a;
     if ((Date.now() - startedAt) / 1e3 >= maxSeconds) {
       this.pollInterval && window.clearInterval(this.pollInterval), this.renderExpired();
       return;
@@ -16830,10 +16861,10 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
       );
       if (resp.status === 400 || resp.status === 428) return;
       if (resp.status >= 200 && resp.status < 300) {
-        this.pollInterval && window.clearInterval(this.pollInterval);
+        this.pollInterval && window.clearInterval(this.pollInterval), (_a = this.disposeSocket) == null || _a.call(this), this.disposeSocket = null;
         let result = resp.json;
-        this.resolve(result), this.resolve = () => {
-        }, this.close();
+        this.renderLinked(result), this.resolve(result), this.resolve = () => {
+        };
         return;
       }
       if (resp.status === 410) {
@@ -18879,12 +18910,12 @@ var EngramSyncSettingTab = class extends import_obsidian23.PluginSettingTab {
     wrapper && (this.installedProgressCb = null, this.plugin.syncEngine.onSyncProgress === wrapper && (this.plugin.syncEngine.onSyncProgress = this.prevProgressCb));
   }
   async startDeviceFlow() {
-    let result = await new DeviceFlowModal(this.app, this.plugin).waitForResult();
+    let modal = new DeviceFlowModal(this.app, this.plugin), result = await modal.waitForResult();
     result && (await this.plugin.saveOAuthTokens(
       result.refresh_token,
       result.vault_id,
       result.user_email
-    ), this.rerender());
+    ), modal.markLinked(), this.rerender());
   }
   /** Render (or re-render) the connection status row in place. Idempotent —
    *  empties the container first so it can be wired to live status events. */

--- a/main.js
+++ b/main.js
@@ -16661,6 +16661,7 @@ var import_obsidian14 = require("obsidian");
 // src/device-flow-socket.ts
 var HEARTBEAT_MS = 3e4;
 function waitForDeviceAuthorization(apiUrl, deviceCode, onAuthorized, opts = {}) {
+  var _a;
   let topic = `device:${deviceCode}`, socket = null, heartbeat = null, disposed = !1, ref = 0, dispose = () => {
     disposed = !0, heartbeat !== null && (window.clearInterval(heartbeat), heartbeat = null);
     try {
@@ -16673,7 +16674,7 @@ function waitForDeviceAuthorization(apiUrl, deviceCode, onAuthorized, opts = {})
     let wsBase = apiUrl.replace(/\/api\/?$/, "").replace(/^http/, "ws");
     socket = new WebSocket(`${wsBase}/socket/device/websocket?vsn=2.0.0`);
   } catch (e) {
-    return devLog().log("device-flow", `socket construct failed: ${errMsg(e)}`), dispose;
+    return devLog().log("device-flow", `socket construct failed: ${errMsg(e)}`), (_a = opts.onStatus) == null || _a.call(opts, !1), dispose;
   }
   let send = (frame) => {
     try {
@@ -16683,20 +16684,32 @@ function waitForDeviceAuthorization(apiUrl, deviceCode, onAuthorized, opts = {})
     }
   };
   return socket.onopen = () => {
-    var _a;
+    var _a2;
     disposed || (send(["1", String(++ref), topic, "phx_join", {}]), heartbeat = window.setInterval(() => {
       send([null, String(++ref), "phoenix", "heartbeat", {}]);
-    }, (_a = opts.heartbeatMs) != null ? _a : HEARTBEAT_MS));
+    }, (_a2 = opts.heartbeatMs) != null ? _a2 : HEARTBEAT_MS));
   }, socket.onmessage = (evt) => {
+    var _a2, _b;
     if (!disposed)
       try {
         let frame = JSON.parse(String(evt.data));
-        frame[2] === topic && frame[3] === "authorized" && onAuthorized();
+        if (frame[2] === topic && frame[3] === "authorized") {
+          onAuthorized();
+          return;
+        }
+        if (frame[2] === topic && frame[3] === "phx_reply") {
+          let ok = ((_a2 = frame[4]) == null ? void 0 : _a2.status) === "ok";
+          devLog().log("device-flow", `join reply status=${ok ? "ok" : "error"}`), (_b = opts.onStatus) == null || _b.call(opts, ok);
+        }
       } catch (e) {
         devLog().log("device-flow", `socket frame parse failed: ${errMsg(e)}`);
       }
   }, socket.onerror = () => {
-    devLog().log("device-flow", "socket error \u2014 falling back to poll");
+    var _a2;
+    devLog().log("device-flow", "socket error \u2014 falling back to poll"), (_a2 = opts.onStatus) == null || _a2.call(opts, !1);
+  }, socket.onclose = (evt) => {
+    var _a2;
+    disposed || (devLog().log("device-flow", `socket closed code=${evt.code} \u2014 falling back to poll`), (_a2 = opts.onStatus) == null || _a2.call(opts, !1));
   }, dispose;
 }
 
@@ -16717,6 +16730,7 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
     this.pollInterval = null;
     this.disposeSocket = null;
     this.exchanging = !1;
+    this.waitingEl = null;
     this.aborted = !1;
     this.plugin = plugin;
   }
@@ -16772,16 +16786,26 @@ var DeviceFlowModal = class extends import_obsidian14.Modal {
       navigator.clipboard.writeText(resp.user_code), new import_obsidian14.Notice("Code copied!");
     }), contentEl.createEl("p", {
       text: "A browser window has opened. Sign in and enter this code to link your vault."
-    }), contentEl.createEl("p", {
-      text: "Waiting for authorization...",
-      cls: "engram-device-waiting"
-    }), contentEl.createDiv({ cls: "engram-device-buttons" }).createEl("button", { text: "Cancel" }).addEventListener("click", () => this.close()), window.open(verificationUrlWithCode(resp.verification_url, resp.user_code));
+    }), this.waitingEl = contentEl.createEl("p", { cls: "engram-device-waiting" }), this.setWaitingStatus(!1), contentEl.createDiv({ cls: "engram-device-buttons" }).createEl("button", { text: "Cancel" }).addEventListener("click", () => this.close()), window.open(verificationUrlWithCode(resp.verification_url, resp.user_code));
+  }
+  /** Say which path we are actually on. Without this, "the socket isn't
+   *  working" and "the socket is working" look identical from the outside
+   *  until you time the flow with a stopwatch. */
+  setWaitingStatus(live) {
+    this.waitingEl && this.waitingEl.setText(
+      live ? "Waiting for authorization \u2014 connected, this will complete instantly." : "Waiting for authorization \u2014 no live connection, checking every 30s."
+    );
   }
   startPolling(deviceCode) {
     let apiUrl = EngramApi.normalizeBaseUrl(this.plugin.settings.apiUrl);
-    this.disposeSocket = waitForDeviceAuthorization(apiUrl, deviceCode, () => {
-      this.exchangeNow(apiUrl, deviceCode);
-    });
+    this.disposeSocket = waitForDeviceAuthorization(
+      apiUrl,
+      deviceCode,
+      () => {
+        this.exchangeNow(apiUrl, deviceCode);
+      },
+      { onStatus: (live) => this.setWaitingStatus(live) }
+    );
     let startedAt = Date.now(), maxSeconds = 300, poll = async () => {
       if (!(this.aborted || this.exchanging)) {
         this.exchanging = !0;

--- a/src/auth-state.ts
+++ b/src/auth-state.ts
@@ -58,12 +58,30 @@ export function isSaveableUrl(url: string): boolean {
 	return parsed.hostname.length > 0;
 }
 
-/** Returns true only when both URLs parse to a *complete-looking* origin AND
- *  those origins differ. Path, query, trailing slash, and case differences in
- *  host do NOT count. Partial URLs (mid-keystroke) and empty URLs return false. */
+/** scheme://host:port for any URL `isSaveableUrl` accepts, lowercased.
+ *  Null when the URL is not something we would store at all. */
+function saveableOrigin(url: string): string | null {
+	if (!isSaveableUrl(url)) return null;
+	// Already proven parseable by isSaveableUrl.
+	const parsed = new URL(url);
+	return `${parsed.protocol}//${parsed.host}`.toLowerCase();
+}
+
+/** Returns true when both URLs are storable server addresses AND their origins
+ *  differ. Path, query, trailing slash, and host case do NOT count. An empty or
+ *  unusable URL on either side returns false.
+ *
+ *  Judged with `isSaveableUrl`, not `completeOrigin`: this is only ever reached
+ *  from `applyApiUrlChange`, which has already accepted the URL for storage.
+ *  Using the stricter mid-typing heuristic here meant the two disagreed about
+ *  single-label and IPv6 hosts — `http://engram:4000`, i.e. the docker-compose
+ *  and Tailscale names self-hosters actually use. The URL got saved and the OLD
+ *  backend's credentials were kept, so the plugin pointed at a new server
+ *  holding tokens it would never accept: every call failed while the settings
+ *  page looked green. The two questions must be answered by one predicate. */
 export function isBackendChange(oldUrl: string, newUrl: string): boolean {
-	const oldO = completeOrigin(oldUrl);
-	const newO = completeOrigin(newUrl);
+	const oldO = saveableOrigin(oldUrl);
+	const newO = saveableOrigin(newUrl);
 	if (!oldO || !newO) return false;
 	return oldO !== newO;
 }

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -36,6 +36,8 @@ export class DeviceFlowModal extends Modal {
 	private pollInterval: number | null = null;
 	private disposeSocket: (() => void) | null = null;
 	private exchanging = false;
+	/** Socket said "authorized" while an exchange was already in flight. */
+	private pendingAuthorized = false;
 	private waitingEl: HTMLElement | null = null;
 	private aborted = false;
 
@@ -66,17 +68,28 @@ export class DeviceFlowModal extends Modal {
 		}
 	}
 
-	onClose(): void {
-		this.aborted = true;
+	/** Tear down everything belonging to ONE attempt at the flow.
+	 *
+	 *  Both exits need this. Close is the obvious one; "Try again" is the one
+	 *  that bit: it re-ran onOpen(), and startPolling() then OVERWROTE
+	 *  disposeSocket and pollInterval, leaking the previous socket and its
+	 *  heartbeat for the rest of the Obsidian session. Worse, the orphan's
+	 *  onAuthorized closure still held the OLD device_code and could take
+	 *  `exchanging`, blocking the retry the user is standing there watching. */
+	private resetFlow(): void {
 		if (this.pollInterval) {
 			window.clearInterval(this.pollInterval);
 			this.pollInterval = null;
 		}
-		// Cancelling the modal must take the socket with it — otherwise every
-		// abandoned link attempt leaves a live WebSocket (and its heartbeat)
-		// running for the rest of the Obsidian session.
 		this.disposeSocket?.();
 		this.disposeSocket = null;
+		this.exchanging = false;
+		this.pendingAuthorized = false;
+	}
+
+	onClose(): void {
+		this.aborted = true;
+		this.resetFlow();
 		this.contentEl.empty();
 		this.resolve(null);
 	}
@@ -206,15 +219,22 @@ export class DeviceFlowModal extends Modal {
 			} finally {
 				this.exchanging = false;
 			}
+			await this.drainPendingAuthorized(apiUrl, deviceCode);
 		};
 
 		// 30s, not 5s. This is no longer how the flow completes — the socket is —
 		// so it exists purely to rescue a user whose network blocks WebSockets.
 		// Tightening it would just add request volume to the common path where
 		// it never wins the race.
-		this.pollInterval = window.setInterval(() => {
-			void poll();
-		}, 30_000);
+		// registerInterval + register so a plugin unload (update, disable) takes
+		// the fallback timer AND the socket with it. A Modal is not a child of
+		// the plugin's component tree, so nothing else would.
+		this.pollInterval = this.plugin.registerInterval(
+			window.setInterval(() => {
+				void poll();
+			}, 30_000),
+		);
+		this.plugin.register(() => this.resetFlow());
 	}
 
 	/** Socket said the code was authorized: exchange it once, right now.
@@ -224,13 +244,31 @@ export class DeviceFlowModal extends Modal {
 	 *  redeem, and the loser would see the 410 from a single-use code and
 	 *  render "expired" over a flow that actually succeeded. */
 	private async exchangeNow(apiUrl: string, deviceCode: string): Promise<void> {
-		if (this.aborted || this.exchanging) return;
+		if (this.aborted) return;
+		if (this.exchanging) {
+			// Don't drop the notification. The in-flight request is very likely a
+			// fallback poll that STARTED before the user authorized, so it will
+			// come back 400 "still waiting" — and without this the live path's
+			// whole benefit is lost to the next 30s tick.
+			this.pendingAuthorized = true;
+			return;
+		}
 		this.exchanging = true;
 		try {
 			await this.pollOnce(apiUrl, deviceCode, Date.now(), 300);
 		} finally {
 			this.exchanging = false;
 		}
+		await this.drainPendingAuthorized(apiUrl, deviceCode);
+	}
+
+	/** Re-run an exchange that arrived while the lock was held. Bounded: the
+	 *  flag is only ever set while `exchanging` is true, and cleared before the
+	 *  retry, so this cannot loop. */
+	private async drainPendingAuthorized(apiUrl: string, deviceCode: string): Promise<void> {
+		if (!this.pendingAuthorized || this.aborted) return;
+		this.pendingAuthorized = false;
+		await this.exchangeNow(apiUrl, deviceCode);
 	}
 
 	private async pollOnce(
@@ -302,8 +340,11 @@ export class DeviceFlowModal extends Modal {
 
 		const retryBtn = btnContainer.createEl("button", { text: "Try again", cls: "mod-cta" });
 		retryBtn.addEventListener("click", () => {
+			// Kill the expired attempt's socket and interval BEFORE onOpen()
+			// starts a fresh set — see resetFlow.
+			this.resetFlow();
 			this.aborted = false;
-			void this.onOpen();
+			this.onOpen();
 		});
 
 		const closeBtn = btnContainer.createEl("button", { text: "Close" });

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -36,6 +36,7 @@ export class DeviceFlowModal extends Modal {
 	private pollInterval: number | null = null;
 	private disposeSocket: (() => void) | null = null;
 	private exchanging = false;
+	private waitingEl: HTMLElement | null = null;
 	private aborted = false;
 
 	constructor(app: App, plugin: EngramSyncPlugin) {
@@ -143,16 +144,28 @@ export class DeviceFlowModal extends Modal {
 			text: "A browser window has opened. Sign in and enter this code to link your vault.",
 		});
 
-		contentEl.createEl("p", {
-			text: "Waiting for authorization...",
-			cls: "engram-device-waiting",
-		});
+		// Text is set by setWaitingStatus once the socket reports in. Starts
+		// pessimistic: until the join is acked we are genuinely on the poll.
+		this.waitingEl = contentEl.createEl("p", { cls: "engram-device-waiting" });
+		this.setWaitingStatus(false);
 
 		const btnContainer = contentEl.createDiv({ cls: "engram-device-buttons" });
 		const cancelBtn = btnContainer.createEl("button", { text: "Cancel" });
 		cancelBtn.addEventListener("click", () => this.close());
 
 		window.open(verificationUrlWithCode(resp.verification_url, resp.user_code));
+	}
+
+	/** Say which path we are actually on. Without this, "the socket isn't
+	 *  working" and "the socket is working" look identical from the outside
+	 *  until you time the flow with a stopwatch. */
+	private setWaitingStatus(live: boolean): void {
+		if (!this.waitingEl) return;
+		this.waitingEl.setText(
+			live
+				? "Waiting for authorization — connected, this will complete instantly."
+				: "Waiting for authorization — no live connection, checking every 30s.",
+		);
 	}
 
 	private startPolling(deviceCode: string): void {
@@ -162,9 +175,14 @@ export class DeviceFlowModal extends Modal {
 		// so completion is immediate instead of landing somewhere in a 5s
 		// window. The interval below is now only a fallback for networks that
 		// block WebSockets — see waitForDeviceAuthorization.
-		this.disposeSocket = waitForDeviceAuthorization(apiUrl, deviceCode, () => {
-			void this.exchangeNow(apiUrl, deviceCode);
-		});
+		this.disposeSocket = waitForDeviceAuthorization(
+			apiUrl,
+			deviceCode,
+			() => {
+				void this.exchangeNow(apiUrl, deviceCode);
+			},
+			{ onStatus: (live) => this.setWaitingStatus(live) },
+		);
 
 		// Wall-clock deadline, not a tick counter: a 15s-timeout request holding
 		// its 5s tick hostage made `elapsed += 5` undercount real time.

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -36,6 +36,7 @@ export class DeviceFlowModal extends Modal {
 	private pollInterval: number | null = null;
 	private disposeSocket: (() => void) | null = null;
 	private exchanging = false;
+	private linkedSyncBtn: HTMLButtonElement | null = null;
 	private aborted = false;
 
 	constructor(app: App, plugin: EngramSyncPlugin) {
@@ -212,6 +213,56 @@ export class DeviceFlowModal extends Modal {
 		}
 	}
 
+	/** Success screen. The modal used to just close here, so a successful link
+	 *  was indistinguishable from the modal crashing — it vanished, said
+	 *  nothing, and left the user with no idea that linking does NOT sync
+	 *  anything on its own and a first sync still has to be started.
+	 *
+	 *  The sync button starts disabled: syncing needs persisted tokens, and
+	 *  those are written by the caller after `waitForResult()` resolves. It is
+	 *  armed by `markLinked()` so a fast click can't kick off a sync that would
+	 *  401 on a token that isn't saved yet. */
+	private renderLinked(result: DeviceFlowResult): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.createEl("h2", { text: "Vault linked" });
+
+		if (result.user_email) {
+			contentEl.createEl("p", { text: `Signed in as ${result.user_email}.` });
+		}
+
+		contentEl.createEl("p", {
+			text: "Nothing has synced yet — linking only connects the account. Start the first sync to push this vault to Engram.",
+		});
+
+		const btnContainer = contentEl.createDiv({ cls: "engram-device-buttons" });
+
+		const laterBtn = btnContainer.createEl("button", { text: "Later" });
+		laterBtn.addEventListener("click", () => this.close());
+
+		const syncBtn = btnContainer.createEl("button", {
+			text: "Finishing link…",
+			cls: "mod-cta",
+		});
+		syncBtn.disabled = true;
+		syncBtn.addEventListener("click", () => {
+			// Close first, then sync. doSyncWithFirstSyncCheck opens its own
+			// preview modal, and stacking one over this leaves a modal cascade
+			// the user has to dismiss twice.
+			this.close();
+			void this.plugin.doSyncWithFirstSyncCheck();
+		});
+		this.linkedSyncBtn = syncBtn;
+	}
+
+	/** Called by the caller once the tokens are persisted — only then is a sync
+	 *  able to authenticate. No-op if the linked screen was never rendered. */
+	markLinked(): void {
+		if (!this.linkedSyncBtn) return;
+		this.linkedSyncBtn.disabled = false;
+		this.linkedSyncBtn.setText("Start first sync");
+	}
+
 	private async pollOnce(
 		apiUrl: string,
 		deviceCode: string,
@@ -246,10 +297,15 @@ export class DeviceFlowModal extends Modal {
 
 			if (resp.status >= 200 && resp.status < 300) {
 				if (this.pollInterval) window.clearInterval(this.pollInterval);
+				this.disposeSocket?.();
+				this.disposeSocket = null;
 				const result = resp.json as DeviceFlowResult;
+				// Render BEFORE resolving. Resolving hands control to the caller,
+				// which persists the tokens and then calls markLinked() to arm the
+				// sync button — that button has to exist by then.
+				this.renderLinked(result);
 				this.resolve(result);
 				this.resolve = () => {};
-				this.close();
 				return;
 			}
 

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -1,6 +1,7 @@
 import { type App, Modal, Notice, requestUrl } from "obsidian";
 import { EngramApi, withTimeout } from "./api";
 import { devLog } from "./dev-log";
+import { waitForDeviceAuthorization } from "./device-flow-socket";
 import { errMsg } from "./error-util";
 import type EngramSyncPlugin from "./main";
 
@@ -33,6 +34,8 @@ export class DeviceFlowModal extends Modal {
 	private plugin: EngramSyncPlugin;
 	private resolve: (result: DeviceFlowResult | null) => void = () => {};
 	private pollInterval: number | null = null;
+	private disposeSocket: (() => void) | null = null;
+	private exchanging = false;
 	private aborted = false;
 
 	constructor(app: App, plugin: EngramSyncPlugin) {
@@ -65,6 +68,11 @@ export class DeviceFlowModal extends Modal {
 			window.clearInterval(this.pollInterval);
 			this.pollInterval = null;
 		}
+		// Cancelling the modal must take the socket with it — otherwise every
+		// abandoned link attempt leaves a live WebSocket (and its heartbeat)
+		// running for the rest of the Obsidian session.
+		this.disposeSocket?.();
+		this.disposeSocket = null;
 		this.contentEl.empty();
 		this.resolve(null);
 	}
@@ -149,6 +157,15 @@ export class DeviceFlowModal extends Modal {
 
 	private startPolling(deviceCode: string): void {
 		const apiUrl = EngramApi.normalizeBaseUrl(this.plugin.settings.apiUrl);
+
+		// Primary path: the server tells us the instant the browser authorizes,
+		// so completion is immediate instead of landing somewhere in a 5s
+		// window. The interval below is now only a fallback for networks that
+		// block WebSockets — see waitForDeviceAuthorization.
+		this.disposeSocket = waitForDeviceAuthorization(apiUrl, deviceCode, () => {
+			void this.exchangeNow(apiUrl, deviceCode);
+		});
+
 		// Wall-clock deadline, not a tick counter: a 15s-timeout request holding
 		// its 5s tick hostage made `elapsed += 5` undercount real time.
 		const startedAt = Date.now();
@@ -156,21 +173,43 @@ export class DeviceFlowModal extends Modal {
 		// One request at a time: the interval fires regardless of whether the
 		// previous poll (up to 15s) is still in flight, which stacked up to three
 		// concurrent token requests.
-		let inFlight = false;
-
+		//
+		// Deliberately `this.exchanging` and not a local flag — the socket path
+		// redeems the same single-use code, so the two must share one guard or
+		// the loser of that race renders "expired" over a successful link.
 		const poll = async (): Promise<void> => {
-			if (this.aborted || inFlight) return;
-			inFlight = true;
+			if (this.aborted || this.exchanging) return;
+			this.exchanging = true;
 			try {
 				await this.pollOnce(apiUrl, deviceCode, startedAt, maxSeconds);
 			} finally {
-				inFlight = false;
+				this.exchanging = false;
 			}
 		};
 
+		// 30s, not 5s. This is no longer how the flow completes — the socket is —
+		// so it exists purely to rescue a user whose network blocks WebSockets.
+		// Tightening it would just add request volume to the common path where
+		// it never wins the race.
 		this.pollInterval = window.setInterval(() => {
 			void poll();
-		}, 5000);
+		}, 30_000);
+	}
+
+	/** Socket said the code was authorized: exchange it once, right now.
+	 *
+	 *  Guarded because the fallback interval is still armed — without this a
+	 *  poll already in flight and the socket-triggered exchange could both
+	 *  redeem, and the loser would see the 410 from a single-use code and
+	 *  render "expired" over a flow that actually succeeded. */
+	private async exchangeNow(apiUrl: string, deviceCode: string): Promise<void> {
+		if (this.aborted || this.exchanging) return;
+		this.exchanging = true;
+		try {
+			await this.pollOnce(apiUrl, deviceCode, Date.now(), 300);
+		} finally {
+			this.exchanging = false;
+		}
 	}
 
 	private async pollOnce(

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -36,7 +36,6 @@ export class DeviceFlowModal extends Modal {
 	private pollInterval: number | null = null;
 	private disposeSocket: (() => void) | null = null;
 	private exchanging = false;
-	private linkedSyncBtn: HTMLButtonElement | null = null;
 	private aborted = false;
 
 	constructor(app: App, plugin: EngramSyncPlugin) {
@@ -213,56 +212,6 @@ export class DeviceFlowModal extends Modal {
 		}
 	}
 
-	/** Success screen. The modal used to just close here, so a successful link
-	 *  was indistinguishable from the modal crashing — it vanished, said
-	 *  nothing, and left the user with no idea that linking does NOT sync
-	 *  anything on its own and a first sync still has to be started.
-	 *
-	 *  The sync button starts disabled: syncing needs persisted tokens, and
-	 *  those are written by the caller after `waitForResult()` resolves. It is
-	 *  armed by `markLinked()` so a fast click can't kick off a sync that would
-	 *  401 on a token that isn't saved yet. */
-	private renderLinked(result: DeviceFlowResult): void {
-		const { contentEl } = this;
-		contentEl.empty();
-		contentEl.createEl("h2", { text: "Vault linked" });
-
-		if (result.user_email) {
-			contentEl.createEl("p", { text: `Signed in as ${result.user_email}.` });
-		}
-
-		contentEl.createEl("p", {
-			text: "Nothing has synced yet — linking only connects the account. Start the first sync to push this vault to Engram.",
-		});
-
-		const btnContainer = contentEl.createDiv({ cls: "engram-device-buttons" });
-
-		const laterBtn = btnContainer.createEl("button", { text: "Later" });
-		laterBtn.addEventListener("click", () => this.close());
-
-		const syncBtn = btnContainer.createEl("button", {
-			text: "Finishing link…",
-			cls: "mod-cta",
-		});
-		syncBtn.disabled = true;
-		syncBtn.addEventListener("click", () => {
-			// Close first, then sync. doSyncWithFirstSyncCheck opens its own
-			// preview modal, and stacking one over this leaves a modal cascade
-			// the user has to dismiss twice.
-			this.close();
-			void this.plugin.doSyncWithFirstSyncCheck();
-		});
-		this.linkedSyncBtn = syncBtn;
-	}
-
-	/** Called by the caller once the tokens are persisted — only then is a sync
-	 *  able to authenticate. No-op if the linked screen was never rendered. */
-	markLinked(): void {
-		if (!this.linkedSyncBtn) return;
-		this.linkedSyncBtn.disabled = false;
-		this.linkedSyncBtn.setText("Start first sync");
-	}
-
 	private async pollOnce(
 		apiUrl: string,
 		deviceCode: string,
@@ -300,12 +249,13 @@ export class DeviceFlowModal extends Modal {
 				this.disposeSocket?.();
 				this.disposeSocket = null;
 				const result = resp.json as DeviceFlowResult;
-				// Render BEFORE resolving. Resolving hands control to the caller,
-				// which persists the tokens and then calls markLinked() to arm the
-				// sync button — that button has to exist by then.
-				this.renderLinked(result);
 				this.resolve(result);
 				this.resolve = () => {};
+				// Close and get out of the way. The caller persists the tokens and
+				// goes straight into the first-sync preview — a step that confirms
+				// "yes it connected" and then makes you click again is a speed bump,
+				// and the sync preview already names what happens next.
+				this.close();
 				return;
 			}
 

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -12,6 +12,23 @@ export interface DeviceFlowResult {
 	expires_in: number;
 }
 
+// RFC 8628 §3.3.1 `verification_uri_complete`: hand the browser the code so
+// /link prefills (and auto-verifies) instead of making the user retype what
+// the plugin already knows. The backend returns the bare page URL, so the
+// plugin — which holds both halves — is where they get joined.
+// Safe to put in the URL: authorizing still requires a signed-in user to pick
+// a vault and click Sync, and the page scrubs the param out of history on
+// arrival. Falls back to the bare URL if the backend ever sends a non-URL.
+export function verificationUrlWithCode(verificationUrl: string, userCode: string): string {
+	try {
+		const url = new URL(verificationUrl);
+		url.searchParams.set("code", userCode);
+		return url.toString();
+	} catch {
+		return verificationUrl;
+	}
+}
+
 export class DeviceFlowModal extends Modal {
 	private plugin: EngramSyncPlugin;
 	private resolve: (result: DeviceFlowResult | null) => void = () => {};
@@ -127,7 +144,7 @@ export class DeviceFlowModal extends Modal {
 		const cancelBtn = btnContainer.createEl("button", { text: "Cancel" });
 		cancelBtn.addEventListener("click", () => this.close());
 
-		window.open(resp.verification_url);
+		window.open(verificationUrlWithCode(resp.verification_url, resp.user_code));
 	}
 
 	private startPolling(deviceCode: string): void {

--- a/src/device-flow-modal.ts
+++ b/src/device-flow-modal.ts
@@ -46,6 +46,9 @@ export class DeviceFlowModal extends Modal {
 
 	onOpen(): void {
 		const { contentEl } = this;
+		// Shared sizing with the preview + progress modals — this is step one of
+		// one task, so the window must not change shape between steps.
+		contentEl.addClass("engram-flow-modal");
 		contentEl.empty();
 		contentEl.createEl("h2", { text: "Link Obsidian to Engram" });
 		const statusEl = contentEl.createEl("p", { text: "Starting..." });

--- a/src/device-flow-socket.ts
+++ b/src/device-flow-socket.ts
@@ -109,6 +109,15 @@ export function waitForDeviceAuthorization(
 				onAuthorized();
 				return;
 			}
+			// A channel that dies AFTER joining leaves the socket open, so
+			// without this the modal keeps promising "connected, this will
+			// complete instantly" while the user is silently back on the poll —
+			// the same failure class the join-reply check exists to kill, just
+			// on the other side of a successful join.
+			if (frame[2] === topic && (frame[3] === "phx_error" || frame[3] === "phx_close")) {
+				opts.onStatus?.(false);
+				return;
+			}
 			// The join reply is the only proof the live path actually works —
 			// the socket opening says nothing, because a channel whose join
 			// crashes server-side still gets you a happily OPEN socket first.
@@ -123,6 +132,9 @@ export function waitForDeviceAuthorization(
 	};
 
 	socket.onerror = () => {
+		if (disposed) {
+			return;
+		}
 		// Not fatal: the poll is still running. But the user should be told
 		// which path they are on.
 		devLog().log("device-flow", "socket error — falling back to poll");
@@ -135,6 +147,11 @@ export function waitForDeviceAuthorization(
 		}
 		devLog().log("device-flow", `socket closed code=${evt.code} — falling back to poll`);
 		opts.onStatus?.(false);
+		// There is no reconnect, so the listener is genuinely finished. Without
+		// this the heartbeat keeps firing every 30s at a CLOSED socket, throwing
+		// into the swallowed catch — dead work on a path whose whole contract is
+		// "silent and harmless". dispose() is idempotent.
+		dispose();
 	};
 
 	return dispose;

--- a/src/device-flow-socket.ts
+++ b/src/device-flow-socket.ts
@@ -1,0 +1,116 @@
+import { devLog } from "./dev-log";
+import { errMsg } from "./error-util";
+
+/** Phoenix drops idle sockets at ~60s; a device code lives for 300s. Without
+ *  a heartbeat the listener dies partway through and the user silently falls
+ *  back to the slow poll. */
+const HEARTBEAT_MS = 30_000;
+
+interface Options {
+	/** Override for tests. Production always wants HEARTBEAT_MS. */
+	heartbeatMs?: number;
+}
+
+/**
+ * Wait for the browser half of the device flow to authorize this code, and
+ * call `onAuthorized` the moment it does.
+ *
+ * Replaces a 5s polling loop. The plugin holds no token yet — obtaining one
+ * IS this flow — so it cannot use the authenticated socket in `channel.ts`.
+ * This rides `/socket/device`, which is unauthenticated by necessity and
+ * gates authorization per-topic on the `device_code` instead.
+ *
+ * What arrives is a NOTIFICATION, never credentials: a broadcast reaches
+ * every subscriber at once whereas the token exchange is single-use, so
+ * shipping tokens here would be weaker than the REST endpoint it front-runs.
+ * The caller reacts by performing exactly one exchange.
+ *
+ * Best-effort by design. Every failure path is silent-and-harmless because
+ * the caller keeps a slow REST poll running underneath for networks that
+ * block WebSockets — this makes the common case instant, it is not a
+ * correctness dependency.
+ *
+ * Speaks the Phoenix v2 wire protocol directly (`[join_ref, ref, topic,
+ * event, payload]`), same as `channel.ts`, so no phoenix npm dependency.
+ *
+ * @returns a disposer. After calling it, `onAuthorized` will not fire.
+ */
+export function waitForDeviceAuthorization(
+	apiUrl: string,
+	deviceCode: string,
+	onAuthorized: () => void,
+	opts: Options = {},
+): () => void {
+	const topic = `device:${deviceCode}`;
+	let socket: WebSocket | null = null;
+	let heartbeat: number | null = null;
+	let disposed = false;
+	let ref = 0;
+
+	const dispose = (): void => {
+		disposed = true;
+		if (heartbeat !== null) {
+			window.clearInterval(heartbeat);
+			heartbeat = null;
+		}
+		try {
+			socket?.close();
+		} catch {
+			// Already closing/closed — nothing to salvage.
+		}
+		socket = null;
+	};
+
+	try {
+		// The socket lives at the ORIGIN, not under /api — apiUrl is normalized
+		// to end in /api, so strip it the way channel.ts does for its own base.
+		const wsBase = apiUrl.replace(/\/api\/?$/, "").replace(/^http/, "ws");
+		socket = new WebSocket(`${wsBase}/socket/device/websocket?vsn=2.0.0`);
+	} catch (e) {
+		// WebSockets blocked outright. The fallback poll carries the flow.
+		devLog().log("device-flow", `socket construct failed: ${errMsg(e)}`);
+		return dispose;
+	}
+
+	const send = (frame: unknown[]): void => {
+		try {
+			socket?.send(JSON.stringify(frame));
+		} catch (e) {
+			devLog().log("device-flow", `socket send failed: ${errMsg(e)}`);
+		}
+	};
+
+	socket.onopen = () => {
+		if (disposed) {
+			return;
+		}
+		send(["1", String(++ref), topic, "phx_join", {}]);
+		heartbeat = window.setInterval(() => {
+			// join_ref is null for the phoenix control topic.
+			send([null, String(++ref), "phoenix", "heartbeat", {}]);
+		}, opts.heartbeatMs ?? HEARTBEAT_MS);
+	};
+
+	socket.onmessage = (evt: MessageEvent) => {
+		if (disposed) {
+			return;
+		}
+		try {
+			const frame = JSON.parse(String(evt.data)) as unknown[];
+			// Match the topic explicitly. One socket only ever joins one device
+			// topic, but a stray frame must never be read as our authorization.
+			if (frame[2] === topic && frame[3] === "authorized") {
+				onAuthorized();
+			}
+		} catch (e) {
+			devLog().log("device-flow", `socket frame parse failed: ${errMsg(e)}`);
+		}
+	};
+
+	socket.onerror = () => {
+		// Not fatal and not worth surfacing: the poll is still running.
+		devLog().log("device-flow", "socket error — falling back to poll");
+	};
+
+	return dispose;
+}

--- a/src/device-flow-socket.ts
+++ b/src/device-flow-socket.ts
@@ -9,6 +9,11 @@ const HEARTBEAT_MS = 30_000;
 interface Options {
 	/** Override for tests. Production always wants HEARTBEAT_MS. */
 	heartbeatMs?: number;
+	/** Called with true once the topic is actually joined, false on any
+	 *  failure. Surfaced in the modal so "is the live path working?" is a
+	 *  thing you can SEE, rather than something inferred from how long the
+	 *  flow took. */
+	onStatus?: (live: boolean) => void;
 }
 
 /**
@@ -69,6 +74,7 @@ export function waitForDeviceAuthorization(
 	} catch (e) {
 		// WebSockets blocked outright. The fallback poll carries the flow.
 		devLog().log("device-flow", `socket construct failed: ${errMsg(e)}`);
+		opts.onStatus?.(false);
 		return dispose;
 	}
 
@@ -101,6 +107,15 @@ export function waitForDeviceAuthorization(
 			// topic, but a stray frame must never be read as our authorization.
 			if (frame[2] === topic && frame[3] === "authorized") {
 				onAuthorized();
+				return;
+			}
+			// The join reply is the only proof the live path actually works —
+			// the socket opening says nothing, because a channel whose join
+			// crashes server-side still gets you a happily OPEN socket first.
+			if (frame[2] === topic && frame[3] === "phx_reply") {
+				const ok = (frame[4] as { status?: string } | undefined)?.status === "ok";
+				devLog().log("device-flow", `join reply status=${ok ? "ok" : "error"}`);
+				opts.onStatus?.(ok);
 			}
 		} catch (e) {
 			devLog().log("device-flow", `socket frame parse failed: ${errMsg(e)}`);
@@ -108,8 +123,18 @@ export function waitForDeviceAuthorization(
 	};
 
 	socket.onerror = () => {
-		// Not fatal and not worth surfacing: the poll is still running.
+		// Not fatal: the poll is still running. But the user should be told
+		// which path they are on.
 		devLog().log("device-flow", "socket error — falling back to poll");
+		opts.onStatus?.(false);
+	};
+
+	socket.onclose = (evt: CloseEvent) => {
+		if (disposed) {
+			return;
+		}
+		devLog().log("device-flow", `socket closed code=${evt.code} — falling back to poll`);
+		opts.onStatus?.(false);
 	};
 
 	return dispose;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2695,6 +2695,19 @@ export default class EngramSyncPlugin extends Plugin {
 				const choice = await modal.awaitChoice();
 				this.openPreviewModal = null;
 
+				// Dismissing without a choice leaves the gate CLOSED, and the gate
+				// stops every sync path (sync.ts isSyncBlocked callers) — not just
+				// this run. The vault then silently syncs nothing at all, so say so
+				// once, here, instead of relying on the user noticing a small label
+				// change in the status bar they were not looking at.
+				if (choice === "cancel" && this.syncEngine.isSyncBlocked()) {
+					new Notice(
+						"Engram: sync is not set up yet, so nothing in this vault will sync.\n" +
+							"Click \u201cEngram: finish setup\u201d in the status bar to pick up where you left off.",
+						10_000,
+					);
+				}
+
 				await this.runSyncWithProgress(choice, {
 					plan: modal.getPlan(),
 					firstSync: context === "first-time",
@@ -2757,20 +2770,28 @@ export default class EngramSyncPlugin extends Plugin {
 		let text: string;
 		let tooltip: string;
 
+		// Never completed a sync => this user is mid-SETUP, not mid-anything-else.
+		// "paused" and "signed out" both imply a working state that lapsed, which
+		// sends a first-run user off looking for what broke instead of finishing
+		// the two steps they abandoned.
+		const neverSynced = !status.lastSync;
+
 		if (!this.hasAuthConfigured()) {
 			// Signed out (or never linked): "ready" here was a lie the 2026-08-12
 			// incident shipped — after a forced sign-out the bar claimed ready
 			// while every sync path was dead.
-			text = "Engram: signed out";
-			tooltip = "Not signed in. Click to open settings and reconnect.";
+			text = neverSynced ? "Engram: not connected" : "Engram: signed out";
+			tooltip = neverSynced
+				? "Not connected yet. Click to open settings and link this vault."
+				: "Not signed in. Click to open settings and reconnect.";
 		} else if (blocked && status.state !== "syncing") {
 			// Sync gate closed — user has not picked a direction in SyncPreviewModal
 			// for the current auth+vault fingerprint. Show a click-to-resolve nag.
-			text =
-				status.pending > 0
-					? `Engram: sync paused (${status.pending} queued)`
-					: "Engram: sync paused";
-			tooltip = "Sync paused — click to choose a sync direction";
+			const label = neverSynced ? "Engram: finish setup" : "Engram: sync paused";
+			text = status.pending > 0 ? `${label} (${status.pending} queued)` : label;
+			tooltip = neverSynced
+				? "Setup is not finished — nothing will sync until you choose a sync direction. Click to finish."
+				: "Sync paused — click to choose a sync direction";
 		} else if (status.state === "offline") {
 			text =
 				status.queued > 0 ? `Engram: offline (${status.queued} queued)` : "Engram: offline";

--- a/src/main.ts
+++ b/src/main.ts
@@ -2624,6 +2624,9 @@ export default class EngramSyncPlugin extends Plugin {
 					remoteVaultName: this.settings.remoteVaultName,
 					showChangeVault: true,
 					context,
+					// The fact, not the copy variable: this decides whether the
+					// modal warns that nothing will sync until you choose.
+					gateClosed: this.syncEngine.isSyncBlocked(),
 					initialView: opts.startInVaultPicker ? "vault-picker" : "preview",
 					attachmentsTextOnly:
 						this.syncEngine.getPlanState()?.attachmentsTextOnly ?? false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2704,9 +2704,13 @@ export default class EngramSyncPlugin extends Plugin {
 				// once, here, instead of relying on the user noticing a small label
 				// change in the status bar they were not looking at.
 				if (choice === "cancel" && this.syncEngine.isSyncBlocked()) {
+					// Names the status bar ITEM, not a label. The bar says "finish
+					// setup" only when this vault has never synced; a user who has
+					// synced before sees "sync paused", and quoting the wrong words
+					// sends them looking for something that is not there.
 					new Notice(
 						"Engram: sync is not set up yet, so nothing in this vault will sync.\n" +
-							"Click \u201cEngram: finish setup\u201d in the status bar to pick up where you left off.",
+							"Click the Engram item in the status bar to pick up where you left off.",
 						10_000,
 					);
 				}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -283,6 +283,10 @@ export class EngramSyncSettingTab extends PluginSettingTab {
 				result.vault_id,
 				result.user_email,
 			);
+			// Tokens are now persisted, so a sync can authenticate — arm the
+			// modal's "Start first sync" button. The modal deliberately stays
+			// open after linking to tell the user that step still exists.
+			modal.markLinked();
 			this.rerender();
 		}
 	}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -283,11 +283,13 @@ export class EngramSyncSettingTab extends PluginSettingTab {
 				result.vault_id,
 				result.user_email,
 			);
-			// Tokens are now persisted, so a sync can authenticate — arm the
-			// modal's "Start first sync" button. The modal deliberately stays
-			// open after linking to tell the user that step still exists.
-			modal.markLinked();
 			this.rerender();
+			// Go straight into the first-sync preview. Linking connects the
+			// account but syncs nothing, and the preview is where that gets said
+			// AND acted on — so it replaces the old "you're linked, now click
+			// here" screen rather than sitting behind it. Tokens are persisted
+			// above, so the sync can authenticate.
+			void this.plugin.doSyncWithFirstSyncCheck();
 		}
 	}
 

--- a/src/sync-center-render.ts
+++ b/src/sync-center-render.ts
@@ -148,6 +148,7 @@ function renderActions(parent: HTMLElement, plugin: EngramSyncPlugin, refresh: (
 				remoteVaultName: plugin.settings.remoteVaultName,
 				showChangeVault: false,
 				context: "review",
+				gateClosed: plugin.syncEngine.isSyncBlocked(),
 			});
 			void plugin.syncEngine
 				.computeSyncPlan("full")

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -619,9 +619,28 @@ export class SyncPreviewModal extends Modal {
 	/** Dismiss + optional "Change vault" footer, shared by the loaded preview
 	 *  and the loading state (previously identical blocks). */
 	private renderFooter(parent: HTMLElement, dismissLabel: string, dismissCta: boolean): void {
+		// "review" is a manual sync with the gate already open — walking away
+		// costs nothing. The other contexts are opened BY the closed gate, and
+		// that gate stops every sync path, not just this run: dismiss here and
+		// the vault silently syncs nothing at all, forever, until it is resolved.
+		//
+		// So say that at the decision point rather than after it, and drop the
+		// word "Cancel" — there is no operation in flight to cancel, and the
+		// choice is genuinely deferrable.
+		//
+		// Skipped when dismissCta: that is the nothing-to-sync screen, where the
+		// button is the primary action and there is no choice being deferred.
+		const gated = (this.opts.context ?? "review") !== "review" && !dismissCta;
+		if (gated) {
+			parent.createEl("p", {
+				cls: "engram-sync-preview-gate-note",
+				text: "Until you choose, nothing in this vault will sync.",
+			});
+		}
+
 		const footer = parent.createDiv({ cls: "engram-sync-preview-footer" });
 		const dismissBtn = footer.createEl("button", {
-			text: dismissLabel,
+			text: gated ? "Not now" : dismissLabel,
 			cls: dismissCta ? "mod-cta" : undefined,
 		});
 		dismissBtn.addEventListener("click", () => this.state.cancel());

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -350,6 +350,25 @@ export function simplifiedScreenCopy(simple: NonNullable<ReturnType<typeof simpl
 	};
 }
 
+/** Wait this long before the "Comparing…" line appears. Plans that resolve
+ *  faster show no loading copy at all. */
+const LOADING_TEXT_DELAY_MS = 400;
+/** Once that line IS on screen, keep it there at least this long. */
+const LOADING_MIN_VISIBLE_MS = 600;
+
+/** How long to hold the loaded plan back so the "Comparing…" line stays
+ *  readable. 0 when the line was never shown (the fast path — nothing to
+ *  hold) or has already had its time.
+ *
+ *  Deliberately NOT a blanket delay on every sync: the fast case should feel
+ *  instant, and only a line that actually reached the screen has earned the
+ *  right to stay on it. */
+export function loadingHoldMs(shownAt: number | null, now: number): number {
+	if (shownAt === null) return 0;
+	const held = now - shownAt;
+	return held >= LOADING_MIN_VISIBLE_MS ? 0 : LOADING_MIN_VISIBLE_MS - held;
+}
+
 export class SyncPreviewModal extends Modal {
 	private state: SyncPreviewState;
 	private resolvedChoice: SyncChoice | null = null;
@@ -371,8 +390,15 @@ export class SyncPreviewModal extends Modal {
 		});
 	}
 
+	private loadingTextTimer: number | null = null;
+	private holdTimer: number | null = null;
+	/** null until the "Comparing…" line is actually on screen. Doubles as the
+	 *  flag renderPlanLoading reads and the clock the hold window measures. */
+	private loadingTextShownAt: number | null = null;
+
 	onOpen(): void {
 		this.contentEl.addClass("engram-sync-preview-modal");
+		this.startLoadingTextTimer();
 		if (this.opts.initialView === "vault-picker") {
 			void this.openVaultPicker();
 		} else {
@@ -381,6 +407,7 @@ export class SyncPreviewModal extends Modal {
 	}
 
 	onClose(): void {
+		this.clearLoadingTimers();
 		// Defensive: if the user dismisses via Esc/backdrop before picking,
 		// treat that as a cancel.
 		const resolve = this.resolveFn;
@@ -403,8 +430,53 @@ export class SyncPreviewModal extends Modal {
 	 *  for the old vault must not clobber it. */
 	setPlan(plan: SyncPlan): void {
 		if (this.state.plan != null) return;
+
+		// If "Comparing…" is on screen, let it be readable. Swapping it out
+		// after 80ms is what made the step feel skipped rather than fast.
+		const hold = loadingHoldMs(this.loadingTextShownAt, Date.now());
+		if (hold > 0) {
+			this.holdTimer = window.setTimeout(() => {
+				this.holdTimer = null;
+				this.applyPlan(plan);
+			}, hold);
+			return;
+		}
+
+		this.applyPlan(plan);
+	}
+
+	private applyPlan(plan: SyncPlan): void {
+		if (this.state.plan != null) return;
+		this.clearLoadingTimers();
 		this.state.replacePlan(plan);
 		if (this.state.view === "preview") this.render();
+	}
+
+	/** The loading LINE is deferred, not the modal — the modal itself opens
+	 *  instantly and keeps its header/footer the whole time. A plan that
+	 *  resolves inside this window therefore shows no loading copy at all,
+	 *  which is the point: a sentence displayed for 80ms is a flicker, not
+	 *  information. Slowing every sync down to make it readable would tax the
+	 *  fast path forever to fix a frame nobody wanted. */
+	private startLoadingTextTimer(): void {
+		if (this.state.plan != null) return;
+		this.loadingTextTimer = window.setTimeout(() => {
+			this.loadingTextTimer = null;
+			if (this.state.plan != null) return;
+			this.loadingTextShownAt = Date.now();
+			if (this.state.view === "preview") this.render();
+		}, LOADING_TEXT_DELAY_MS);
+	}
+
+	private clearLoadingTimers(): void {
+		if (this.loadingTextTimer !== null) {
+			window.clearTimeout(this.loadingTextTimer);
+			this.loadingTextTimer = null;
+		}
+		if (this.holdTimer !== null) {
+			window.clearTimeout(this.holdTimer);
+			this.holdTimer = null;
+		}
 	}
 
 	/** Surface a plan-load failure in the instant-open loading view. Skipped once
@@ -412,6 +484,10 @@ export class SyncPreviewModal extends Modal {
 	 *  overwrites a good plan. */
 	setPlanError(message: string): void {
 		if (this.state.plan != null) return;
+		this.clearLoadingTimers();
+		// An error is not a progress message — show it the instant it exists,
+		// regardless of where the delay window stands.
+		this.loadingTextShownAt = Date.now();
 		this.state.planError = message;
 		if (this.state.view === "preview") this.render();
 	}
@@ -532,7 +608,7 @@ export class SyncPreviewModal extends Modal {
 				cls: "engram-sync-preview-picker-error",
 				text: this.state.planError,
 			});
-		} else {
+		} else if (this.loadingTextShownAt !== null) {
 			body.createSpan({ text: "Comparing your vault with the cloud…" });
 		}
 

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -363,6 +363,26 @@ const LOADING_MIN_VISIBLE_MS = 600;
  *  Deliberately NOT a blanket delay on every sync: the fast case should feel
  *  instant, and only a line that actually reached the screen has earned the
  *  right to stay on it. */
+/** What the button on the "nothing to sync" screen should say and do.
+ *
+ *  Both sides already match, so there is no transfer to run — but in a GATED
+ *  context the sync gate still has to be accepted or the plugin stays inert.
+ *  "Close" used to dispatch `cancel`, which returns false from
+ *  runSyncFromChoice and never reaches markSyncGateAccepted: a user whose
+ *  vault was already in sync from another device clicked the one obvious
+ *  button and silently ended up with sync blocked forever.
+ *
+ *  In "review" the gate is already open and there genuinely is nothing to do,
+ *  so dismissing is correct there. */
+export function emptyPlanDismiss(context: SyncPreviewContext): {
+	label: string;
+	accept: boolean;
+} {
+	return context === "review"
+		? { label: "Close", accept: false }
+		: { label: "Done", accept: true };
+}
+
 export function loadingHoldMs(shownAt: number | null, now: number): number {
 	if (shownAt === null) return 0;
 	const held = now - shownAt;
@@ -561,7 +581,20 @@ export class SyncPreviewModal extends Modal {
 
 		this.renderAdvancedOptions(options);
 
-		this.renderFooter(contentEl, empty ? "Close" : "Cancel", empty);
+		if (empty) {
+			// Accepting the gate is the whole job on this screen — see
+			// emptyPlanDismiss. smart-merge is a no-op transfer here (the sides
+			// match) that routes through markSyncGateAccepted.
+			const { label, accept } = emptyPlanDismiss(context);
+			this.renderFooter(
+				contentEl,
+				label,
+				true,
+				accept ? () => this.state.pickOption("smart-merge") : undefined,
+			);
+			return;
+		}
+		this.renderFooter(contentEl, "Cancel", false);
 	}
 
 	/** The one-click screen for an empty-side first sync. One primary action
@@ -618,7 +651,12 @@ export class SyncPreviewModal extends Modal {
 
 	/** Dismiss + optional "Change vault" footer, shared by the loaded preview
 	 *  and the loading state (previously identical blocks). */
-	private renderFooter(parent: HTMLElement, dismissLabel: string, dismissCta: boolean): void {
+	private renderFooter(
+		parent: HTMLElement,
+		dismissLabel: string,
+		dismissCta: boolean,
+		dismissAction?: () => void,
+	): void {
 		// "review" is a manual sync with the gate already open — walking away
 		// costs nothing. The other contexts are opened BY the closed gate, and
 		// that gate stops every sync path, not just this run: dismiss here and
@@ -643,7 +681,13 @@ export class SyncPreviewModal extends Modal {
 			text: gated ? "Not now" : dismissLabel,
 			cls: dismissCta ? "mod-cta" : undefined,
 		});
-		dismissBtn.addEventListener("click", () => this.state.cancel());
+		dismissBtn.addEventListener("click", () => {
+			if (dismissAction) {
+				dismissAction();
+				return;
+			}
+			this.state.cancel();
+		});
 		if (this.opts.showChangeVault) {
 			const changeBtn = footer.createEl("button", { text: "Change vault" });
 			changeBtn.addEventListener("click", () => {

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -398,6 +398,7 @@ export class SyncPreviewModal extends Modal {
 
 	onOpen(): void {
 		this.contentEl.addClass("engram-sync-preview-modal");
+		this.contentEl.addClass("engram-flow-modal");
 		this.startLoadingTextTimer();
 		if (this.opts.initialView === "vault-picker") {
 			void this.openVaultPicker();

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -293,6 +293,16 @@ export interface SyncPreviewOptions {
 	showChangeVault: boolean;
 	/** Drives header copy. Defaults to "review" when not provided. */
 	context?: SyncPreviewContext;
+	/** Is the sync gate currently CLOSED — i.e. does walking away from this
+	 *  modal leave the vault syncing nothing?
+	 *
+	 *  Separate from `context` on purpose. `context` answers "what should the
+	 *  header say", and it never carries "review" from the first-sync path
+	 *  (derivePreviewContext only returns first-time / vault-switch), so keying
+	 *  the gate warning and the empty-plan action off it told an already-syncing
+	 *  user that nothing would sync, and ran a pointless full sync on dismiss.
+	 *  Callers pass syncEngine.isSyncBlocked(), which is the actual fact. */
+	gateClosed?: boolean;
 	/** Fetches the list of vaults the user can switch to. Called when the
 	 *  user presses Change Vault. Required when showChangeVault is true. */
 	listVaults?: () => Promise<VaultInfo[]>;
@@ -372,15 +382,13 @@ const LOADING_MIN_VISIBLE_MS = 600;
  *  vault was already in sync from another device clicked the one obvious
  *  button and silently ended up with sync blocked forever.
  *
- *  In "review" the gate is already open and there genuinely is nothing to do,
- *  so dismissing is correct there. */
-export function emptyPlanDismiss(context: SyncPreviewContext): {
+ *  With the gate already open there genuinely is nothing to do, so plain
+ *  dismissal is correct. */
+export function emptyPlanDismiss(gateClosed: boolean): {
 	label: string;
 	accept: boolean;
 } {
-	return context === "review"
-		? { label: "Close", accept: false }
-		: { label: "Done", accept: true };
+	return gateClosed ? { label: "Done", accept: true } : { label: "Close", accept: false };
 }
 
 export function loadingHoldMs(shownAt: number | null, now: number): number {
@@ -585,7 +593,7 @@ export class SyncPreviewModal extends Modal {
 			// Accepting the gate is the whole job on this screen — see
 			// emptyPlanDismiss. smart-merge is a no-op transfer here (the sides
 			// match) that routes through markSyncGateAccepted.
-			const { label, accept } = emptyPlanDismiss(context);
+			const { label, accept } = emptyPlanDismiss(this.opts.gateClosed ?? false);
 			this.renderFooter(
 				contentEl,
 				label,
@@ -668,7 +676,7 @@ export class SyncPreviewModal extends Modal {
 		//
 		// Skipped when dismissCta: that is the nothing-to-sync screen, where the
 		// button is the primary action and there is no choice being deferred.
-		const gated = (this.opts.context ?? "review") !== "review" && !dismissCta;
+		const gated = (this.opts.gateClosed ?? false) && !dismissCta;
 		if (gated) {
 			parent.createEl("p", {
 				cls: "engram-sync-preview-gate-note",

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -366,13 +366,6 @@ const LOADING_TEXT_DELAY_MS = 400;
 /** Once that line IS on screen, keep it there at least this long. */
 const LOADING_MIN_VISIBLE_MS = 600;
 
-/** How long to hold the loaded plan back so the "Comparing…" line stays
- *  readable. 0 when the line was never shown (the fast path — nothing to
- *  hold) or has already had its time.
- *
- *  Deliberately NOT a blanket delay on every sync: the fast case should feel
- *  instant, and only a line that actually reached the screen has earned the
- *  right to stay on it. */
 /** What the button on the "nothing to sync" screen should say and do.
  *
  *  Both sides already match, so there is no transfer to run — but in a GATED
@@ -391,6 +384,13 @@ export function emptyPlanDismiss(gateClosed: boolean): {
 	return gateClosed ? { label: "Done", accept: true } : { label: "Close", accept: false };
 }
 
+/** How long to hold the loaded plan back so the "Comparing…" line stays
+ *  readable. 0 when the line was never shown (the fast path — nothing to
+ *  hold) or has already had its time.
+ *
+ *  Deliberately NOT a blanket delay on every sync: the fast case should feel
+ *  instant, and only a line that actually reached the screen has earned the
+ *  right to stay on it. */
 export function loadingHoldMs(shownAt: number | null, now: number): number {
 	if (shownAt === null) return 0;
 	const held = now - shownAt;

--- a/src/sync-progress-modal.ts
+++ b/src/sync-progress-modal.ts
@@ -266,6 +266,7 @@ export class SyncProgressModal extends Modal {
 		const { contentEl } = this;
 		contentEl.empty();
 		contentEl.addClass("engram-sync-progress-modal");
+		contentEl.addClass("engram-flow-modal");
 
 		contentEl.createEl("h2", { text: "Syncing your vault" });
 

--- a/src/tabs/connection-tab.ts
+++ b/src/tabs/connection-tab.ts
@@ -68,7 +68,47 @@ export function renderConnectionTab(ctx: TabContext): void {
 		renderEngramUrlSetting(ctx);
 	}
 
-	renderAuthSection(ctx);
-	renderVaultSection(ctx);
+	// Progressive disclosure: signing in and picking a vault are impossible
+	// without a server to do them against, so self-host starts with the URL
+	// field alone instead of three sections the user cannot act on yet.
+	//
+	// Keyed on "has a URL been configured", NOT on whether the server answers
+	// right now. Hiding on a live probe failure would make a 30-second outage
+	// look like the auth and vault sections had been wiped — the exact screen
+	// a user in that state most needs to see. A dead server shows as the
+	// warning above, never as a disappearance.
+	//
+	// Cloud has no URL step (the address is fixed), so it always discloses.
+	if (mode === "cloud" || state !== "needs-url") {
+		renderAuthSection(ctx);
+		renderFinishSetupRow(ctx);
+		renderVaultSection(ctx);
+	}
 	if (mode === "selfhost") renderSupportSection(ctx);
+}
+
+/** Sitting between auth and vault: the user is signed in and has a vault, but
+ *  dismissed the sync preview without choosing a direction.
+ *
+ *  That leaves the gate closed, and the gate stops EVERY sync path — the vault
+ *  syncs nothing at all until it is resolved. The status bar says so, but the
+ *  settings page is where someone goes to work out why nothing is happening,
+ *  so it has to say so here too. */
+function renderFinishSetupRow(ctx: TabContext): void {
+	const { containerEl, plugin } = ctx;
+	if (!plugin.hasAuthConfigured()) return;
+	if (!plugin.syncEngine.isSyncBlocked()) return;
+
+	const row = new Setting(containerEl)
+		.setName("Finish sync setup")
+		.setDesc("Nothing in this vault syncs until you choose how to merge it with the server.")
+		.addButton((btn) =>
+			btn
+				.setButtonText("Choose sync direction")
+				.setCta()
+				.onClick(() => {
+					void plugin.doSyncWithFirstSyncCheck();
+				}),
+		);
+	row.settingEl.addClass("engram-connection-warning");
 }

--- a/src/tabs/self-hosted-tab.ts
+++ b/src/tabs/self-hosted-tab.ts
@@ -13,21 +13,25 @@ import { ENGRAM_CLOUD_URL, ENGRAM_MARKETING_URL } from "./urls";
 
 const PREFLIGHT_DEBOUNCE_MS = 600;
 
-/** Engram API keys carry this prefix. Kept as a constant so Save can VALIDATE
- *  the format instead of describing it: the obsidianmd sentence-case lint
- *  rewrites a lowercase "engram_" in prose to "Engram_", which is wrong. */
+/** Engram API keys carry this prefix. Kept as a constant so the key field can
+ *  VALIDATE the format instead of describing it: the obsidianmd sentence-case
+ *  lint rewrites a lowercase "engram_" in prose to "Engram_", which is wrong. */
 const API_KEY_PREFIX = "engram_";
 
 /** Render the "Engram URL" field with a debounced background preflight that
- *  confirms the URL points at a real Engram server, committed via an explicit
- *  Save button (same buffered pattern as the API-key field).
+ *  confirms the URL points at a real Engram server, and commits on that
+ *  confirmation.
  *
- *  Why this shape: the original handler called `applyApiUrlChange` on every
- *  keystroke. Once a complete origin was typed it cleared auth and
- *  `redisplay()`'d the whole tab mid-edit — destroying the input and stealing
- *  focus on every character. Now keystrokes only buffer the value + schedule a
- *  read-only `/health` probe; the apiUrl is committed only when the user clicks
- *  Save, the single point that may clear auth and redisplay. */
+ *  There is deliberately no Save button. The preflight already tells the user
+ *  whether the address works; a button next to it asked them to confirm a
+ *  thing the page had just confirmed for them.
+ *
+ *  Why keystrokes still only buffer: the original handler called
+ *  `applyApiUrlChange` on every keystroke. Once a complete origin was typed it
+ *  cleared auth and `redisplay()`'d the whole tab mid-edit — destroying the
+ *  input and stealing focus on every character. Commit is therefore reached
+ *  from exactly two places, both of which mean "the user is done typing": a
+ *  probe that confirms an Engram backend, or blur. */
 export function renderEngramUrlSetting(ctx: TabContext): void {
 	const { containerEl, plugin, redisplay } = ctx;
 
@@ -37,7 +41,7 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 	const status = setting.descEl.createDiv({ cls: "engram-url-preflight" });
 	const STATUS_CLASSES = ["is-checking", "is-engram", "is-reachable", "is-unreachable"];
 
-	// Buffer the typed value; only the Save button writes it to settings.
+	// Buffer the typed value; only commit() writes it to settings.
 	let pendingUrl = plugin.settings.apiUrl;
 	let debounce: number | null = null;
 	// Monotonic token: a slow probe that resolves after the user kept typing
@@ -62,7 +66,7 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 		}
 	};
 
-	const runPreflight = (value: string): void => {
+	const runPreflight = (value: string, mayCommit = false): void => {
 		if (!completeOrigin(value)) {
 			status.removeClasses(STATUS_CLASSES);
 			status.setText("");
@@ -76,57 +80,64 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 			if (seq !== probeSeq) return; // superseded by a newer probe
 			status.removeClass("is-checking");
 			renderStatus(result);
+			// The probe IS the confirmation — a Save button next to it was a
+			// second, worse one. Commit only on a verified Engram backend:
+			// "reachable" means something answered but is not Engram, and
+			// committing that would clear auth for a typo.
+			if (mayCommit && result.kind === "engram") void commit();
 		});
 	};
 
-	setting
-		.addText((text) => {
-			// Pre-fill the saved URL so the configured backend is always visible
-			// (unlike the API-key field, the URL isn't a secret and the user needs
-			// to confirm it's correct). `pendingUrl` already mirrors this value, so
-			// an untouched Save stays a no-op — applyApiUrlChange short-circuits
-			// when the URL is unchanged — and never wipes the configured URL.
-			text.setPlaceholder("https://engram.example.com");
-			text.setValue(plugin.settings.apiUrl);
-			text.onChange((value) => {
-				pendingUrl = value;
-				if (debounce !== null) window.clearTimeout(debounce);
-				debounce = window.setTimeout(() => runPreflight(value), PREFLIGHT_DEBOUNCE_MS);
-			});
-		})
-		.addButton((btn) =>
-			btn
-				.setButtonText("Save")
-				.setCta()
-				.onClick(async () => {
-					const { cleared, rejected } = await applyApiUrlChange(
-						pluginSwitchTarget(plugin),
-						pendingUrl.trim(),
-						() => plugin.saveSettings(),
-					);
-					if (rejected) {
-						// Deliberately no redisplay: the typed value stays in the box
-						// so the user can correct it instead of retyping from scratch.
-						new Notice(
-							"That does not look like a complete server address. Include the scheme, for example http://127.0.0.1:4000",
-						);
-						return;
-					}
-					// Keep the explicit mode in step with the URL. Pasting the Cloud
-					// address into this box IS a switch to Cloud; leaving backendMode
-					// on "selfhost" would make the next dropdown switch stash the
-					// Cloud config into the self-host slot.
-					plugin.settings.backendMode = modeForUrl(
-						plugin.settings.apiUrl,
-						ENGRAM_CLOUD_URL,
-					);
-					await plugin.saveSettings();
-					if (cleared) {
-						new Notice("Engram backend changed — sign in again to continue.");
-					}
-					redisplay();
-				}),
+	/** The one place that may clear auth and redisplay. applyApiUrlChange is a
+	 *  backend IDENTITY swap, so it must never fire mid-keystroke: only on a
+	 *  confirmed Engram server, or on blur once the user has stopped typing. */
+	const commit = async (): Promise<void> => {
+		const next = pendingUrl.trim();
+		if (next === plugin.settings.apiUrl) return;
+		const { cleared, rejected } = await applyApiUrlChange(
+			pluginSwitchTarget(plugin),
+			next,
+			() => plugin.saveSettings(),
 		);
+		if (rejected) {
+			// Deliberately no redisplay: the typed value stays in the box so the
+			// user can correct it instead of retyping from scratch.
+			new Notice(
+				"That does not look like a complete server address. Include the scheme, for example http://127.0.0.1:4000",
+			);
+			return;
+		}
+		// Keep the explicit mode in step with the URL. Pasting the Cloud address
+		// into this box IS a switch to Cloud; leaving backendMode on "selfhost"
+		// would make the next dropdown switch stash the Cloud config into the
+		// self-host slot.
+		plugin.settings.backendMode = modeForUrl(plugin.settings.apiUrl, ENGRAM_CLOUD_URL);
+		await plugin.saveSettings();
+		if (cleared) {
+			new Notice("Engram backend changed — sign in again to continue.");
+		}
+		redisplay();
+	};
+
+	setting.addText((text) => {
+		// Pre-fill the saved URL so the configured backend is always visible
+		// (unlike the API-key field, the URL isn't a secret and the user needs
+		// to confirm it's correct).
+		text.setPlaceholder("https://engram.example.com");
+		text.setValue(plugin.settings.apiUrl);
+		text.onChange((value) => {
+			pendingUrl = value;
+			if (debounce !== null) window.clearTimeout(debounce);
+			debounce = window.setTimeout(() => runPreflight(value, true), PREFLIGHT_DEBOUNCE_MS);
+		});
+		// Blur fallback: someone pointing at a server they have not started yet
+		// would otherwise be unable to save at all, because the probe never
+		// confirms. Leaving the field is an unambiguous "I meant that".
+		text.inputEl.addEventListener("blur", () => {
+			if (debounce !== null) window.clearTimeout(debounce);
+			void commit();
+		});
+	});
 
 	// Surface the current backend's status immediately on open (no typing needed).
 	if (completeOrigin(plugin.settings.apiUrl)) runPreflight(plugin.settings.apiUrl);

--- a/src/tabs/self-hosted-tab.ts
+++ b/src/tabs/self-hosted-tab.ts
@@ -13,6 +13,10 @@ import { ENGRAM_CLOUD_URL, ENGRAM_MARKETING_URL } from "./urls";
 
 const PREFLIGHT_DEBOUNCE_MS = 600;
 
+/** Module scope on purpose: a commit ends in `redisplay()`, which rebuilds this
+ *  whole tab, so the flag has to outlive the render that set it. */
+let refocusUrlInput = false;
+
 /** Engram API keys carry this prefix. Kept as a constant so the key field can
  *  VALIDATE the format instead of describing it: the obsidianmd sentence-case
  *  lint rewrites a lowercase "engram_" in prose to "Engram_", which is wrong. */
@@ -47,6 +51,7 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 	// Monotonic token: a slow probe that resolves after the user kept typing
 	// must not overwrite the status belonging to a newer value.
 	let probeSeq = 0;
+	let inputEl: HTMLInputElement | null = null;
 
 	const renderStatus = (result: PreflightResult): void => {
 		status.removeClasses(STATUS_CLASSES);
@@ -84,7 +89,13 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 			// second, worse one. Commit only on a verified Engram backend:
 			// "reachable" means something answered but is not Engram, and
 			// committing that would clear auth for a typo.
-			if (mayCommit && result.kind === "engram") void commit();
+			if (mayCommit && result.kind === "engram") {
+				// commit() ends in redisplay(), which tears this input out of the
+				// DOM. If the user is still in the field, that eats their caret
+				// mid-word. Remember it so the rebuilt field takes focus back.
+				refocusUrlInput = document.activeElement === inputEl;
+				void commit();
+			}
 		});
 	};
 
@@ -120,6 +131,7 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 	};
 
 	setting.addText((text) => {
+		inputEl = text.inputEl;
 		// Pre-fill the saved URL so the configured backend is always visible
 		// (unlike the API-key field, the URL isn't a secret and the user needs
 		// to confirm it's correct).
@@ -134,9 +146,22 @@ export function renderEngramUrlSetting(ctx: TabContext): void {
 		// would otherwise be unable to save at all, because the probe never
 		// confirms. Leaving the field is an unambiguous "I meant that".
 		text.inputEl.addEventListener("blur", () => {
+			// Alt-tabbing out of Obsidian fires blur too, and that is NOT "I meant
+			// that" — it is a half-typed address the user is coming back to.
+			// Committing it swaps the stored backend behind their back.
+			if (!document.hasFocus()) return;
 			if (debounce !== null) window.clearTimeout(debounce);
 			void commit();
 		});
+
+		if (refocusUrlInput) {
+			refocusUrlInput = false;
+			text.inputEl.focus();
+			// Caret to the end: the user was appending (port, path), and
+			// select-all-on-focus would make the next keystroke wipe the URL.
+			const end = text.inputEl.value.length;
+			text.inputEl.setSelectionRange(end, end);
+		}
 	});
 
 	// Surface the current backend's status immediately on open (no typing needed).

--- a/styles.css
+++ b/styles.css
@@ -1249,6 +1249,13 @@ body.is-mobile .engram-support-buttons > a {
 	color: var(--text-muted);
 	padding: 1.5em 0;
 	text-align: center;
+	/* Reserve the body so the modal does not collapse to one line and then
+	   snap back open when the plan lands. That resize is what made a single
+	   modal read as three different ones. */
+	min-height: 8em;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .engram-sync-preview-picker-body {

--- a/styles.css
+++ b/styles.css
@@ -1226,6 +1226,35 @@ body.is-mobile .engram-support-buttons > a {
 }
 
 /* SyncPreviewModal */
+
+/* Shared chrome for the connect -> preview -> progress flow.
+
+   These three modals run back-to-back as one user task, but each was a
+   separate Modal relying on Obsidian's content-driven sizing, so every step
+   came out a different width and height. A resize is the strongest cue a UI
+   has for "this is a different thing", which is why one flow read as three
+   unrelated dialogs.
+
+   Sizing only — each modal keeps its own body styles. Staged fix; the real
+   one is a single shell with the steps as renderers (see engram-app
+   issue for the flow-shell refactor). */
+.engram-flow-modal {
+	/* min(), not a flat value: Obsidian on mobile is narrower than 32em and a
+	   hard min-width would overflow the viewport. */
+	min-width: min(32em, 100%);
+	min-height: 16em;
+	display: flex;
+	flex-direction: column;
+}
+
+/* Matches .engram-sync-preview-header exactly, so the two modals that use a
+   bare h2 stop looking like a different product mid-flow. */
+.engram-flow-modal h2 {
+	margin: 0 0 1em 0;
+	font-size: 1.4em;
+	font-weight: 600;
+}
+
 .engram-sync-preview-modal .engram-sync-preview-header {
 	margin: 0 0 1em 0;
 	font-size: 1.4em;
@@ -1249,6 +1278,7 @@ body.is-mobile .engram-support-buttons > a {
 	color: var(--text-muted);
 	padding: 1.5em 0;
 	text-align: center;
+
 	/* Reserve the body so the modal does not collapse to one line and then
 	   snap back open when the plan lands. That resize is what made a single
 	   modal read as three different ones. */

--- a/styles.css
+++ b/styles.css
@@ -1536,6 +1536,12 @@ body.is-mobile .engram-support-buttons > a {
 	color: var(--text-on-accent);
 }
 
+.engram-sync-preview-gate-note {
+	margin: 0 0 0.5em 0;
+	color: var(--text-muted);
+	font-size: 0.9em;
+}
+
 .engram-sync-preview-footer {
 	display: flex;
 	justify-content: flex-end;

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -95,6 +95,12 @@ export class Plugin {
 		return { setText: () => {} };
 	}
 	registerEvent(_evt: any): void {}
+	// Component teardown hooks. The real ones fire on plugin unload; tests only
+	// need them to exist and to hand back the id registerInterval returns.
+	registerInterval(id: number): number {
+		return id;
+	}
+	register(_cb: () => any): void {}
 }
 
 export class PluginSettingTab {
@@ -113,7 +119,15 @@ export function makeEl(): any {
 		// deep inside a .catch, which is a miserable thing to debug.
 		remove: () => el,
 		empty: () => el,
-		addEventListener: () => el,
+		// Record handlers. A modal's only affordance IS its buttons, so a mock
+		// that swallows the listener makes every "what happens when the user
+		// clicks Try again" test unwritable.
+		listeners: {} as Record<string, () => void>,
+		addEventListener: (evt: string, cb: () => void) => {
+			el.listeners[evt] = cb;
+			return el;
+		},
+		click: () => el.listeners.click?.(),
 		addClass: () => el,
 		removeClass: () => el,
 		removeClasses: () => el,
@@ -123,9 +137,25 @@ export function makeEl(): any {
 		},
 		setAttribute: () => el,
 		textContent: "",
-		createDiv: () => makeEl(),
-		createSpan: () => makeEl(),
-		createEl: () => makeEl(),
+		// Keep the tree. Tests need to reach the button a modal rendered three
+		// levels down, and a mock that returns orphans makes that impossible.
+		children: [] as any[],
+		createDiv: (opts?: any) => el.__child("div", opts),
+		createSpan: (opts?: any) => el.__child("span", opts),
+		createEl: (tag: string, opts?: any) => el.__child(tag, opts),
+		__child: (tag: string, opts?: any) => {
+			const child = makeEl();
+			child.tag = tag;
+			if (typeof opts?.text === "string") child.textContent = opts.text;
+			el.children.push(child);
+			return child;
+		},
+		/** Depth-first search of the rendered tree by visible text. */
+		__find: (text: string): any =>
+			el.children.reduce(
+				(hit: any, c: any) => hit ?? (c.textContent === text ? c : c.__find(text)),
+				null,
+			),
 	};
 	return el;
 }
@@ -243,21 +273,7 @@ export class FileSystemAdapter {
 
 export class Modal {
 	app: any;
-	contentEl: any = {
-		empty: () => {},
-		createEl: (_tag: string, _opts?: any) => ({
-			setText: () => {},
-			style: {},
-		}),
-		createDiv: (_opts?: any) => ({
-			createEl: (_tag: string, _opts2?: any) => ({
-				setText: () => {},
-				addEventListener: () => {},
-				style: {},
-			}),
-			style: {},
-		}),
-	};
+	contentEl: any = makeEl();
 	constructor(app: any) {
 		this.app = app;
 	}

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -168,11 +168,21 @@ class TextComponent {
 	// component doing that throws mid-render, and the failure surfaces as a
 	// confusing "the field was never captured" rather than as itself.
 	blurCb: (() => void) | null = null;
+	/** Did the component under test put the caret back into this field? */
+	focused = false;
+	caret: [number, number] | null = null;
 	inputEl: any = {
 		type: "text",
+		value: "",
 		addClass: () => {},
 		addEventListener: (evt: string, cb: () => void) => {
 			if (evt === "blur") this.blurCb = cb;
+		},
+		focus: () => {
+			this.focused = true;
+		},
+		setSelectionRange: (a: number, b: number) => {
+			this.caret = [a, b];
 		},
 	};
 	setPlaceholder(_p: string): this {
@@ -180,6 +190,7 @@ class TextComponent {
 	}
 	setValue(v: string): this {
 		this.value = v;
+		this.inputEl.value = v;
 		return this;
 	}
 	getValue(): string {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -106,8 +106,14 @@ export class PluginSettingTab {
 }
 
 /** Chainable DOM-element stub used by the Setting mock. */
-function makeEl(): any {
+export function makeEl(): any {
 	const el: any = {
+		// Real elements get detached; code under test calls this on placeholders
+		// it swaps out. Without it the failure reads as an unrelated TypeError
+		// deep inside a .catch, which is a miserable thing to debug.
+		remove: () => el,
+		empty: () => el,
+		addEventListener: () => el,
 		addClass: () => el,
 		removeClass: () => el,
 		removeClasses: () => el,
@@ -127,7 +133,18 @@ function makeEl(): any {
 class TextComponent {
 	value = "";
 	changeCb: ((v: string) => void) | null = null;
-	inputEl: any = { type: "text", addClass: () => {} };
+	// Real Obsidian TextComponents expose the underlying <input>, and callers
+	// attach listeners to it (blur, keydown). Without addEventListener here a
+	// component doing that throws mid-render, and the failure surfaces as a
+	// confusing "the field was never captured" rather than as itself.
+	blurCb: (() => void) | null = null;
+	inputEl: any = {
+		type: "text",
+		addClass: () => {},
+		addEventListener: (evt: string, cb: () => void) => {
+			if (evt === "blur") this.blurCb = cb;
+		},
+	};
 	setPlaceholder(_p: string): this {
 		return this;
 	}
@@ -163,9 +180,16 @@ class ButtonComponent {
 
 /** Components created during the last render, for assertions in tests.
  *  Reset it in a beforeEach when rendering Settings. */
-export const __settingCapture: { texts: TextComponent[]; buttons: ButtonComponent[] } = {
+export const __settingCapture: {
+	texts: TextComponent[];
+	buttons: ButtonComponent[];
+	// Section/row names, so a test can assert WHICH settings a tab rendered —
+	// the only way to check progressive disclosure without a real DOM.
+	names: string[];
+} = {
 	texts: [],
 	buttons: [],
+	names: [],
 };
 
 export class Setting {
@@ -173,7 +197,8 @@ export class Setting {
 	descEl: any = makeEl();
 	controlEl: any = makeEl();
 	constructor(_containerEl: any) {}
-	setName(_name: string): this {
+	setName(name: string): this {
+		__settingCapture.names.push(name);
 		return this;
 	}
 	setDesc(_desc: string): this {

--- a/tests/auth-state.test.ts
+++ b/tests/auth-state.test.ts
@@ -36,8 +36,20 @@ describe("isBackendChange", () => {
 		expect(isBackendChange("", "https://engram.ras.band")).toBe(false);
 	});
 
-	test("false when new URL is partial (still typing)", () => {
-		expect(isBackendChange("https://engram.ras.band", "https://engr")).toBe(false);
+	// This function is no longer the mid-typing guard — nothing calls it on a
+	// keystroke. `applyApiUrlChange` calls it AFTER accepting the URL for
+	// storage, so a single-label host is a real backend, not a half-typed one,
+	// and the credentials of the previous backend must not survive the swap.
+	test("true for a single-label host — that is a server, not a half-typed URL", () => {
+		expect(isBackendChange("https://engram.ras.band", "http://engram:4000")).toBe(true);
+	});
+
+	test("false when the single-label host is unchanged", () => {
+		expect(isBackendChange("http://engram:4000", "http://engram:4000/api")).toBe(false);
+	});
+
+	test("true for an IPv6 literal swap", () => {
+		expect(isBackendChange("http://[::1]:4000", "http://[::2]:4000")).toBe(true);
 	});
 
 	test("false when both URLs target the same origin", () => {

--- a/tests/connection-tab-disclosure.test.ts
+++ b/tests/connection-tab-disclosure.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Progressive disclosure on the Connection tab.
+ *
+ * Signing in and picking a vault are impossible without a server to do them
+ * against, so self-host starts with the URL field alone rather than three
+ * sections the user cannot act on yet.
+ */
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { __settingCapture, makeEl } from "obsidian";
+import { renderConnectionTab } from "../src/tabs/connection-tab";
+
+function ctxFor(opts: {
+	backendMode: "cloud" | "selfhost";
+	apiUrl: string;
+	refreshToken?: string;
+	syncBlocked?: boolean;
+}) {
+	const containerEl: any = makeEl();
+	const plugin: any = {
+		settings: {
+			backendMode: opts.backendMode,
+			apiUrl: opts.apiUrl,
+			apiKey: "",
+			refreshToken: opts.refreshToken ?? "",
+		},
+		// renderVaultSection fetches the vault list on render.
+		api: { listVaults: async () => [] },
+		noteStream: {},
+		saveSettings: async () => {},
+		hasAuthConfigured: () => Boolean(opts.apiUrl && opts.refreshToken),
+		syncEngine: { isSyncBlocked: () => opts.syncBlocked ?? false },
+		doSyncWithFirstSyncCheck: mock(async () => {}),
+	};
+	return { ctx: { containerEl, app: {}, plugin, redisplay: () => {} } as any };
+}
+
+const names = (): string => __settingCapture.names.join("|");
+
+beforeEach(() => {
+	__settingCapture.names.length = 0;
+	__settingCapture.texts.length = 0;
+	__settingCapture.buttons.length = 0;
+});
+
+describe("connection tab disclosure", () => {
+	test("self-host with no URL hides auth and vault", () => {
+		renderConnectionTab(ctxFor({ backendMode: "selfhost", apiUrl: "" }).ctx);
+		expect(names()).toMatch(/Engram URL/i);
+		expect(names()).not.toMatch(/Authentication/i);
+	});
+
+	// Cloud has no URL step — the address is fixed — so it must disclose
+	// immediately or a cloud user sees an empty tab.
+	test("cloud discloses immediately", () => {
+		renderConnectionTab(ctxFor({ backendMode: "cloud", apiUrl: "" }).ctx);
+		expect(names()).toMatch(/Authentication|Sign in/i);
+	});
+
+	// The trap this design has to avoid: disclosure keys on "a URL is
+	// configured", NOT on whether the server answers right now. Otherwise a
+	// brief outage makes the auth and vault sections vanish — the exact screen
+	// a user in that state most needs.
+	test("a configured URL keeps sections visible regardless of reachability", () => {
+		renderConnectionTab(
+			ctxFor({ backendMode: "selfhost", apiUrl: "http://127.0.0.1:4000" }).ctx,
+		);
+		expect(names()).toMatch(/Authentication|Sign in/i);
+	});
+
+	test("a blocked gate surfaces the finish-setup row", () => {
+		renderConnectionTab(
+			ctxFor({
+				backendMode: "selfhost",
+				apiUrl: "http://127.0.0.1:4000",
+				refreshToken: "rt",
+				syncBlocked: true,
+			}).ctx,
+		);
+		expect(names()).toMatch(/Finish sync setup/i);
+	});
+
+	test("an open gate does not nag", () => {
+		renderConnectionTab(
+			ctxFor({
+				backendMode: "selfhost",
+				apiUrl: "http://127.0.0.1:4000",
+				refreshToken: "rt",
+				syncBlocked: false,
+			}).ctx,
+		);
+		expect(names()).not.toMatch(/Finish sync setup/i);
+	});
+});

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -216,3 +216,60 @@ describe("verificationUrlWithCode", () => {
 		expect(verificationUrlWithCode("not a url", "ENGR-7X4K")).toBe("not a url");
 	});
 });
+
+describe("post-link guidance", () => {
+	const linkSuccessfully = () => {
+		mockRequestUrl.mockResolvedValue({
+			status: 200,
+			json: { access_token: "at", refresh_token: "rt", user_email: "me@example.test" },
+		});
+		const modal = new DeviceFlowModal(
+			makeApp("V"),
+			makePlugin("https://example.test", "cid-1"),
+		) as any;
+		const closed: number[] = [];
+		modal.close = () => closed.push(1);
+		modal.resolve = () => {};
+		modal.pollInterval = null;
+		const rendered: unknown[] = [];
+		modal.renderLinked = (r: unknown) => rendered.push(r);
+		return { modal, closed, rendered };
+	};
+
+	// The modal used to close itself the instant the exchange succeeded, so a
+	// successful link looked identical to the modal crashing: it just vanished,
+	// with no confirmation and no hint that a first sync still has to be run.
+	test("a successful exchange does NOT silently close the modal", async () => {
+		const { modal, closed } = linkSuccessfully();
+		await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
+		expect(closed.length).toBe(0);
+	});
+
+	test("a successful exchange renders the linked screen instead", async () => {
+		const { modal, rendered } = linkSuccessfully();
+		await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
+		expect(rendered.length).toBe(1);
+		expect((rendered[0] as { user_email: string }).user_email).toBe("me@example.test");
+	});
+
+	test("the linked screen renders before the promise resolves", async () => {
+		// The caller saves tokens on resolve and then calls markLinked(), which
+		// needs the screen to already exist. Render-then-resolve, not the reverse.
+		const { modal } = linkSuccessfully();
+		const order: string[] = [];
+		modal.renderLinked = () => order.push("render");
+		modal.resolve = () => order.push("resolve");
+		await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
+		expect(order).toEqual(["render", "resolve"]);
+	});
+
+	// Syncing needs persisted tokens. The button stays disabled until the caller
+	// confirms the save, so a fast click can't start a sync that would 401.
+	test("markLinked is a no-op when there is no linked screen", () => {
+		const modal = new DeviceFlowModal(
+			makeApp("V"),
+			makePlugin("https://example.test", "cid-1"),
+		) as any;
+		expect(() => modal.markLinked()).not.toThrow();
+	});
+});

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -247,3 +247,60 @@ describe("post-link handoff", () => {
 		expect(closed).toBe(1);
 	});
 });
+
+/**
+ * The expired-code retry path. "Try again" re-enters onOpen(), and onOpen ends
+ * in startPolling() — which ASSIGNS this.disposeSocket and this.pollInterval.
+ * Without an explicit teardown first, the previous attempt's WebSocket and its
+ * 30s heartbeat survive for the rest of the Obsidian session, and the orphan's
+ * onAuthorized closure (holding the OLD, dead device_code) can still take the
+ * `exchanging` lock and stall the retry the user is watching.
+ */
+describe("DeviceFlowModal — retry after expiry", () => {
+	const makeModal = () => {
+		const modal = new DeviceFlowModal(makeApp("V"), makePlugin("https://example.test", "cid"));
+		return modal as any;
+	};
+
+	test("resetFlow disposes the socket, the interval, and the exchange lock", () => {
+		const modal = makeModal();
+		let disposed = 0;
+		modal.disposeSocket = () => {
+			disposed += 1;
+		};
+		modal.pollInterval = window.setInterval(() => {}, 60_000);
+		modal.exchanging = true;
+		modal.pendingAuthorized = true;
+
+		modal.resetFlow();
+
+		expect(disposed).toBe(1);
+		expect(modal.disposeSocket).toBeNull();
+		expect(modal.pollInterval).toBeNull();
+		expect(modal.exchanging).toBe(false);
+		expect(modal.pendingAuthorized).toBe(false);
+	});
+
+	test("'Try again' tears the old attempt down BEFORE starting a new one", () => {
+		const modal = makeModal();
+		const order: string[] = [];
+		modal.resetFlow = () => order.push("reset");
+		modal.onOpen = () => order.push("open");
+
+		modal.renderExpired();
+		modal.contentEl.__find("Try again").click();
+
+		expect(order).toEqual(["reset", "open"]);
+	});
+
+	test("closing the modal also disposes the socket", () => {
+		const modal = makeModal();
+		let disposed = 0;
+		modal.disposeSocket = () => {
+			disposed += 1;
+		};
+		modal.onClose();
+		expect(disposed).toBe(1);
+		expect(modal.aborted).toBe(true);
+	});
+});

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -217,8 +217,12 @@ describe("verificationUrlWithCode", () => {
 	});
 });
 
-describe("post-link guidance", () => {
-	const linkSuccessfully = () => {
+describe("post-link handoff", () => {
+	// The modal used to gain a "you're linked, click to continue" screen. That
+	// step only confirmed what the next screen already implies, so it went away
+	// again: on success the modal closes and the caller opens the first-sync
+	// preview directly.
+	test("a successful exchange resolves and closes", async () => {
 		mockRequestUrl.mockResolvedValue({
 			status: 200,
 			json: { access_token: "at", refresh_token: "rt", user_email: "me@example.test" },
@@ -227,49 +231,19 @@ describe("post-link guidance", () => {
 			makeApp("V"),
 			makePlugin("https://example.test", "cid-1"),
 		) as any;
-		const closed: number[] = [];
-		modal.close = () => closed.push(1);
-		modal.resolve = () => {};
+		let resolvedWith: unknown = null;
+		let closed = 0;
+		modal.resolve = (r: unknown) => {
+			resolvedWith = r;
+		};
+		modal.close = () => {
+			closed += 1;
+		};
 		modal.pollInterval = null;
-		const rendered: unknown[] = [];
-		modal.renderLinked = (r: unknown) => rendered.push(r);
-		return { modal, closed, rendered };
-	};
 
-	// The modal used to close itself the instant the exchange succeeded, so a
-	// successful link looked identical to the modal crashing: it just vanished,
-	// with no confirmation and no hint that a first sync still has to be run.
-	test("a successful exchange does NOT silently close the modal", async () => {
-		const { modal, closed } = linkSuccessfully();
 		await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
-		expect(closed.length).toBe(0);
-	});
 
-	test("a successful exchange renders the linked screen instead", async () => {
-		const { modal, rendered } = linkSuccessfully();
-		await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
-		expect(rendered.length).toBe(1);
-		expect((rendered[0] as { user_email: string }).user_email).toBe("me@example.test");
-	});
-
-	test("the linked screen renders before the promise resolves", async () => {
-		// The caller saves tokens on resolve and then calls markLinked(), which
-		// needs the screen to already exist. Render-then-resolve, not the reverse.
-		const { modal } = linkSuccessfully();
-		const order: string[] = [];
-		modal.renderLinked = () => order.push("render");
-		modal.resolve = () => order.push("resolve");
-		await modal.pollOnce("https://example.test/api", "dc-1", Date.now(), 300);
-		expect(order).toEqual(["render", "resolve"]);
-	});
-
-	// Syncing needs persisted tokens. The button stays disabled until the caller
-	// confirms the save, so a fast click can't start a sync that would 401.
-	test("markLinked is a no-op when there is no linked screen", () => {
-		const modal = new DeviceFlowModal(
-			makeApp("V"),
-			makePlugin("https://example.test", "cid-1"),
-		) as any;
-		expect(() => modal.markLinked()).not.toThrow();
+		expect((resolvedWith as { user_email: string }).user_email).toBe("me@example.test");
+		expect(closed).toBe(1);
 	});
 });

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -5,7 +5,7 @@
  */
 import { beforeEach, describe, expect, type Mock, test } from "bun:test";
 import { requestUrl } from "obsidian";
-import { DeviceFlowModal } from "../src/device-flow-modal";
+import { DeviceFlowModal, verificationUrlWithCode } from "../src/device-flow-modal";
 
 const mockRequestUrl = requestUrl as unknown as Mock<() => Promise<any>>;
 
@@ -190,5 +190,29 @@ describe("DeviceFlowModal poll — pending statuses", () => {
 		const { resolved, stopped } = await pollOnceWith(200, { access_token: "at" });
 		expect(resolved).toBe(true);
 		expect(stopped).toBe(true);
+	});
+});
+
+describe("verificationUrlWithCode", () => {
+	test("appends the user code so /link prefills instead of asking for a re-type", () => {
+		expect(verificationUrlWithCode("https://app.engram.page/link", "ENGR-7X4K")).toBe(
+			"https://app.engram.page/link?code=ENGR-7X4K",
+		);
+	});
+
+	test("preserves an existing query string", () => {
+		expect(
+			verificationUrlWithCode("https://app.engram.page/link?src=obsidian", "ENGR-7X4K"),
+		).toBe("https://app.engram.page/link?src=obsidian&code=ENGR-7X4K");
+	});
+
+	test("overwrites a stale code rather than duplicating the param", () => {
+		expect(
+			verificationUrlWithCode("https://app.engram.page/link?code=OLD-CODE", "ENGR-7X4K"),
+		).toBe("https://app.engram.page/link?code=ENGR-7X4K");
+	});
+
+	test("falls back to the bare URL when the backend sends something unparseable", () => {
+		expect(verificationUrlWithCode("not a url", "ENGR-7X4K")).toBe("not a url");
 	});
 });

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -293,6 +293,78 @@ describe("DeviceFlowModal — retry after expiry", () => {
 		expect(order).toEqual(["reset", "open"]);
 	});
 
+	// The fallback poll and the socket redeem the SAME single-use code, so they
+	// share one `exchanging` lock. Dropping the socket's notification when that
+	// lock is held throws away the entire benefit of the live path: the poll in
+	// flight almost certainly STARTED before the user authorized, so it comes
+	// back "still waiting" and the link stalls until the next 30s tick.
+	test("an authorized push during an in-flight exchange is retried, not dropped", async () => {
+		const modal = makeModal();
+		let exchanges = 0;
+		modal.pollOnce = async () => {
+			exchanges += 1;
+			// The socket fires while the first exchange is still running.
+			if (exchanges === 1) await modal.exchangeNow("https://x/api", "code-1");
+		};
+
+		await modal.exchangeNow("https://x/api", "code-1");
+
+		expect(exchanges).toBe(2);
+		expect(modal.pendingAuthorized).toBe(false);
+	});
+
+	test("a dropped notification does not leave the lock stuck", async () => {
+		const modal = makeModal();
+		modal.pollOnce = async () => {
+			throw new Error("network");
+		};
+
+		await expect(modal.exchangeNow("https://x/api", "code-1")).rejects.toThrow("network");
+		expect(modal.exchanging).toBe(false);
+	});
+
+	// A Modal is not part of the plugin's component tree, so nothing tears it
+	// down on unload (update, disable). Without registering, an abandoned link
+	// attempt keeps a 30s timer and a live WebSocket for as long as Obsidian
+	// stays open.
+	test("the fallback timer and socket are registered for plugin unload", () => {
+		const registered: Array<() => void> = [];
+		const intervals: number[] = [];
+		const plugin: any = {
+			settings: { apiUrl: "https://example.test", clientId: "cid" },
+			registerInterval: (id: number) => {
+				intervals.push(id);
+				return id;
+			},
+			register: (cb: () => void) => registered.push(cb),
+		};
+		const modal = new DeviceFlowModal(makeApp("V"), plugin) as any;
+
+		const origWs = (globalThis as any).WebSocket;
+		(globalThis as any).WebSocket = class {
+			onopen: any = null;
+			onclose: any = null;
+			onmessage: any = null;
+			onerror: any = null;
+			send() {}
+			close() {}
+		};
+		try {
+			modal.startPolling("code-1");
+		} finally {
+			(globalThis as any).WebSocket = origWs;
+		}
+
+		expect(intervals.length).toBe(1);
+		expect(modal.pollInterval).toBe(intervals[0]);
+		expect(registered.length).toBe(1);
+
+		// The registered callback is the same teardown close() runs.
+		registered[0]();
+		expect(modal.pollInterval).toBeNull();
+		expect(modal.disposeSocket).toBeNull();
+	});
+
 	test("closing the modal also disposes the socket", () => {
 		const modal = makeModal();
 		let disposed = 0;

--- a/tests/device-flow-socket.test.ts
+++ b/tests/device-flow-socket.test.ts
@@ -120,6 +120,53 @@ describe("waitForDeviceAuthorization", () => {
 		expect(fired).toBe(0);
 	});
 
+	// The socket OPENING proves nothing — a channel whose join crashes
+	// server-side still leaves you with a happily open socket. Only the join
+	// reply distinguishes "live" from "silently on the fallback poll".
+	test("reports live only after the join is acked, not on open", () => {
+		const seen: boolean[] = [];
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-9", () => {}, {
+			onStatus: (live) => seen.push(live),
+		});
+		lastWs?.onopen?.();
+		expect(seen).toEqual([]);
+
+		lastWs?.onmessage?.({
+			data: JSON.stringify(["1", "1", "device:dev-code-9", "phx_reply", { status: "ok" }]),
+		});
+		expect(seen).toEqual([true]);
+	});
+
+	test("reports not-live when the join is rejected", () => {
+		const seen: boolean[] = [];
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-10", () => {}, {
+			onStatus: (live) => seen.push(live),
+		});
+		lastWs?.onopen?.();
+		lastWs?.onmessage?.({
+			data: JSON.stringify([
+				"1",
+				"1",
+				"device:dev-code-10",
+				"phx_reply",
+				{ status: "error", response: { reason: "unknown_or_expired" } },
+			]),
+		});
+		expect(seen).toEqual([false]);
+	});
+
+	// This is the exact shape of the bug that shipped: the server killed the
+	// transport right after join, and nothing told the user.
+	test("reports not-live when the server closes the socket", () => {
+		const seen: boolean[] = [];
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-11", () => {}, {
+			onStatus: (live) => seen.push(live),
+		});
+		lastWs?.onopen?.();
+		lastWs?.onclose?.({ code: 1011, reason: "", wasClean: false });
+		expect(seen).toEqual([false]);
+	});
+
 	// The flow can run for the code's full 300s lifetime. Phoenix drops idle
 	// sockets around 60s, so without a heartbeat the listener would silently
 	// die partway through and the user would be back to waiting on the

--- a/tests/device-flow-socket.test.ts
+++ b/tests/device-flow-socket.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the device-flow authorization listener — the socket that replaced
+ * the 5s polling loop.
+ *
+ * The plugin holds no token until the flow completes, so this rides the
+ * unauthenticated `/socket/device` and is keyed by the device_code. It carries
+ * a NOTIFICATION only: on "authorized" the caller performs exactly one token
+ * exchange through the existing single-use REST endpoint.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { waitForDeviceAuthorization } from "../src/device-flow-socket";
+
+type CloseEventLike = { code: number; reason: string; wasClean: boolean };
+
+let lastWsUrl = "";
+let lastWs: MockWebSocket | null = null;
+
+class MockWebSocket {
+	static OPEN = 1;
+	readyState = MockWebSocket.OPEN;
+	onopen: (() => void) | null = null;
+	onclose: ((evt: CloseEventLike) => void) | null = null;
+	onmessage: ((evt: { data: string }) => void) | null = null;
+	onerror: ((e: unknown) => void) | null = null;
+	sent: string[] = [];
+	closed = false;
+
+	constructor(url: string) {
+		lastWsUrl = url;
+		lastWs = this;
+	}
+
+	send(data: string): void {
+		this.sent.push(data);
+	}
+
+	close(): void {
+		this.closed = true;
+		this.onclose = null;
+	}
+}
+
+const origWebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
+
+beforeEach(() => {
+	lastWsUrl = "";
+	lastWs = null;
+	(globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
+});
+
+afterEach(() => {
+	(globalThis as unknown as { WebSocket: unknown }).WebSocket = origWebSocket;
+});
+
+const frames = (ws: MockWebSocket) => ws.sent.map((s) => JSON.parse(s) as unknown[]);
+
+describe("waitForDeviceAuthorization", () => {
+	test("connects to the unauthenticated device socket, not the user socket", () => {
+		waitForDeviceAuthorization("https://api.example.test/api", "dev-code-1", () => {});
+		expect(lastWsUrl).toContain("wss://api.example.test/socket/device/websocket");
+		// The Phoenix v2 wire protocol is what channel.ts already speaks.
+		expect(lastWsUrl).toContain("vsn=2.0.0");
+		// No token: the whole point is that we don't have one yet.
+		expect(lastWsUrl).not.toContain("token=");
+	});
+
+	test("strips the /api suffix — the socket is at the origin, not under /api", () => {
+		waitForDeviceAuthorization("https://api.example.test/api", "dev-code-1", () => {});
+		expect(lastWsUrl).not.toContain("/api/socket");
+	});
+
+	test("joins the topic for this device code once open", () => {
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-2", () => {});
+		lastWs?.onopen?.();
+
+		const join = frames(lastWs as MockWebSocket).find((f) => f[3] === "phx_join");
+		expect(join).toBeDefined();
+		expect(join?.[2]).toBe("device:dev-code-2");
+	});
+
+	test("fires the callback when the server pushes authorized", () => {
+		let fired = 0;
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-3", () => {
+			fired += 1;
+		});
+		lastWs?.onopen?.();
+		lastWs?.onmessage?.({
+			data: JSON.stringify(["1", "2", "device:dev-code-3", "authorized", {}]),
+		});
+
+		expect(fired).toBe(1);
+	});
+
+	test("ignores events for a different device code", () => {
+		let fired = 0;
+		waitForDeviceAuthorization("http://localhost:4000/api", "mine", () => {
+			fired += 1;
+		});
+		lastWs?.onopen?.();
+		lastWs?.onmessage?.({
+			data: JSON.stringify(["1", "2", "device:theirs", "authorized", {}]),
+		});
+
+		expect(fired).toBe(0);
+	});
+
+	// The flow can run for the code's full 300s lifetime. Phoenix drops idle
+	// sockets around 60s, so without a heartbeat the listener would silently
+	// die partway through and the user would be back to waiting on the
+	// fallback poll.
+	test("heartbeats so the socket survives the code's full lifetime", async () => {
+		const dispose = waitForDeviceAuthorization(
+			"http://localhost:4000/api",
+			"dev-code-4",
+			() => {},
+			{ heartbeatMs: 1 },
+		);
+		lastWs?.onopen?.();
+		await new Promise((r) => setTimeout(r, 20));
+		dispose();
+
+		const beats = frames(lastWs as MockWebSocket).filter((f) => f[3] === "heartbeat");
+		expect(beats.length).toBeGreaterThan(0);
+		// Phoenix heartbeats go to the "phoenix" topic with a null join_ref.
+		expect(beats[0]?.[2]).toBe("phoenix");
+	});
+
+	test("dispose closes the socket and stops the heartbeat", () => {
+		const dispose = waitForDeviceAuthorization(
+			"http://localhost:4000/api",
+			"dev-code-5",
+			() => {},
+		);
+		lastWs?.onopen?.();
+		dispose();
+
+		expect(lastWs?.closed).toBe(true);
+	});
+
+	test("a callback never fires after dispose", () => {
+		let fired = 0;
+		const dispose = waitForDeviceAuthorization(
+			"http://localhost:4000/api",
+			"dev-code-6",
+			() => {
+				fired += 1;
+			},
+		);
+		lastWs?.onopen?.();
+		const ws = lastWs as MockWebSocket;
+		dispose();
+		ws.onmessage?.({ data: JSON.stringify(["1", "2", "device:dev-code-6", "authorized", {}]) });
+
+		expect(fired).toBe(0);
+	});
+
+	// A blocked WebSocket must not take the whole flow down with it — the REST
+	// fallback poll is still running underneath.
+	test("survives a socket that fails to construct", () => {
+		(globalThis as unknown as { WebSocket: unknown }).WebSocket = function Boom() {
+			throw new Error("blocked");
+		};
+		expect(() =>
+			waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-7", () => {}),
+		).not.toThrow();
+	});
+});

--- a/tests/device-flow-socket.test.ts
+++ b/tests/device-flow-socket.test.ts
@@ -91,6 +91,22 @@ describe("waitForDeviceAuthorization", () => {
 		expect(fired).toBe(1);
 	});
 
+	// Verified against the real server: a Phoenix broadcast arrives with BOTH
+	// join_ref and ref null, not the string refs a reply carries. Matching on
+	// those positions instead of the topic would have silently ignored it.
+	test("accepts the real broadcast frame shape (null join_ref and ref)", () => {
+		let fired = 0;
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-8", () => {
+			fired += 1;
+		});
+		lastWs?.onopen?.();
+		lastWs?.onmessage?.({
+			data: JSON.stringify([null, null, "device:dev-code-8", "authorized", {}]),
+		});
+
+		expect(fired).toBe(1);
+	});
+
 	test("ignores events for a different device code", () => {
 		let fired = 0;
 		waitForDeviceAuthorization("http://localhost:4000/api", "mine", () => {

--- a/tests/device-flow-socket.test.ts
+++ b/tests/device-flow-socket.test.ts
@@ -217,6 +217,44 @@ describe("waitForDeviceAuthorization", () => {
 		expect(fired).toBe(0);
 	});
 
+	// The channel can die AFTER a successful join (server crash, code expiry
+	// sweep) while the transport stays open. Nothing else would notice, and the
+	// modal would keep promising "connected, this will complete instantly"
+	// while the user is silently back on the 30s poll.
+	test("reports not-live when the channel errors after joining", () => {
+		const seen: boolean[] = [];
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-12", () => {}, {
+			onStatus: (live) => seen.push(live),
+		});
+		lastWs?.onopen?.();
+		lastWs?.onmessage?.({
+			data: JSON.stringify(["1", "1", "device:dev-code-12", "phx_reply", { status: "ok" }]),
+		});
+		lastWs?.onmessage?.({
+			data: JSON.stringify([null, null, "device:dev-code-12", "phx_error", {}]),
+		});
+		expect(seen).toEqual([true, false]);
+	});
+
+	// There is no reconnect, so a closed socket means this listener is finished.
+	// Leaving the heartbeat armed just fires every 30s at a dead socket for the
+	// rest of the session.
+	test("a closed socket stops the heartbeat", async () => {
+		waitForDeviceAuthorization("http://localhost:4000/api", "dev-code-13", () => {}, {
+			heartbeatMs: 1,
+		});
+		const ws = lastWs as MockWebSocket;
+		ws.onopen?.();
+		await new Promise((r) => setTimeout(r, 10));
+		const before = frames(ws).filter((f) => f[3] === "heartbeat").length;
+		expect(before).toBeGreaterThan(0);
+
+		ws.onclose?.({ code: 1006, reason: "", wasClean: false });
+		await new Promise((r) => setTimeout(r, 15));
+
+		expect(frames(ws).filter((f) => f[3] === "heartbeat").length).toBe(before);
+	});
+
 	// A blocked WebSocket must not take the whole flow down with it — the REST
 	// fallback poll is still running underneath.
 	test("survives a socket that fails to construct", () => {

--- a/tests/main-auth-ux.test.ts
+++ b/tests/main-auth-ux.test.ts
@@ -43,6 +43,14 @@ describe("status bar when signed out", () => {
 		return { fake, texts };
 	}
 	const idle: SyncStatus = { state: "idle", pending: 0, queued: 0 } as SyncStatus;
+	// The 2026-08-12 incident is a user who WAS working and then got forcibly
+	// signed out — so they have a lastSync. That is what makes "signed out" the
+	// right words for them, and what distinguishes them from someone who never
+	// linked at all (covered separately below).
+	const idleAfterWorking: SyncStatus = {
+		...idle,
+		lastSync: "2026-08-12T00:00:00Z",
+	} as SyncStatus;
 
 	test("no auth configured → says signed out, not ready", () => {
 		const { fake, texts } = fakeFor({});
@@ -50,8 +58,23 @@ describe("status bar when signed out", () => {
 			EngramSyncPlugin.prototype as unknown as {
 				updateStatusBar(this: unknown, s: SyncStatus): void;
 			}
-		).updateStatusBar.call(fake, idle);
+		).updateStatusBar.call(fake, idleAfterWorking);
 		expect(texts[0]).toMatch(/signed out/i);
+		expect(texts[0]).not.toMatch(/ready/i);
+	});
+
+	// A user who never linked was never signed IN, so "signed out" reads like
+	// something broke rather than something is unfinished. Same protection —
+	// still never "ready" — different words.
+	test("never synced → says not connected, still not ready", () => {
+		const { fake, texts } = fakeFor({});
+		(
+			EngramSyncPlugin.prototype as unknown as {
+				updateStatusBar(this: unknown, s: SyncStatus): void;
+			}
+		).updateStatusBar.call(fake, idle);
+		expect(texts[0]).toMatch(/not connected/i);
+		expect(texts[0]).not.toMatch(/ready/i);
 	});
 
 	test("auth configured → unchanged ready state", () => {
@@ -133,8 +156,16 @@ describe("round-1 review fixes (#422)", () => {
 			EngramSyncPlugin.prototype as unknown as {
 				updateStatusBar(this: unknown, s: SyncStatus): void;
 			}
-		).updateStatusBar.call(fake, { state: "idle", pending: 0, queued: 0 } as SyncStatus);
+		).updateStatusBar.call(fake, {
+			state: "idle",
+			pending: 0,
+			queued: 0,
+			// Had been syncing before the forced sign-out — that is the incident.
+			lastSync: "2026-08-12T00:00:00Z",
+		} as SyncStatus);
 		expect(texts[0]).toMatch(/signed out/i);
+		// The point of the guard: the error badge must not overwrite it.
+		expect(texts[0]).not.toMatch(/sync errors/i);
 	});
 
 	test("trackPreviewModal registers a modal for the auth poke; untrack clears it", async () => {

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -154,4 +154,45 @@ describe("renderEngramUrlSetting — no Save button", () => {
 		render("");
 		expect(__settingCapture.texts[0]?.blurCb).toBeTruthy();
 	});
+
+	// Alt-tabbing out of Obsidian fires blur on the focused input too. That is
+	// not "I meant that" — it is a half-typed address the user is coming back
+	// to, and committing it swaps the stored backend (and clears auth) behind
+	// their back while they are looking at another window.
+	test("does NOT commit when blur came from the whole window losing focus", async () => {
+		const saved: string[] = [];
+		__settingCapture.texts.length = 0;
+		const plugin: any = {
+			settings: { apiUrl: "https://staging.engram.page", apiKey: "", refreshToken: "" },
+			api: { setAuthProvider: () => {} },
+			noteStream: { disconnect: () => {} },
+			resetAuthProvider: () => {},
+			saveSettings: async () => {
+				saved.push(plugin.settings.apiUrl);
+			},
+		};
+		renderEngramUrlSetting({
+			containerEl: {},
+			app: {},
+			plugin,
+			redisplay: () => {},
+		} as any);
+
+		const text = __settingCapture.texts[0];
+		text?.changeCb?.("http://halfway");
+
+		// No DOM in this runner, and the guard reads the real one. A blurred
+		// window is exactly `document.hasFocus() === false`.
+		const g = globalThis as any;
+		g.document = { hasFocus: () => false, activeElement: null };
+		try {
+			text?.blurCb?.();
+			await Promise.resolve();
+		} finally {
+			g.document = undefined;
+		}
+
+		expect(saved).toEqual([]);
+		expect(plugin.settings.apiUrl).toBe("https://staging.engram.page");
+	});
 });

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { __settingCapture } from "obsidian";
+import { EngramApi } from "../src/api";
 import {
 	applyVaultSwitch,
 	describeListVaultsError,
@@ -153,6 +154,49 @@ describe("renderEngramUrlSetting — no Save button", () => {
 	test("commits on blur, so a server that is not running yet can still be saved", () => {
 		render("");
 		expect(__settingCapture.texts[0]?.blurCb).toBeTruthy();
+	});
+
+	// The probe committing IS the design (there is no Save button), but commit
+	// ends in redisplay(), which tears the field out of the DOM. Doing that
+	// while the user is still typing in it eats their caret mid-word.
+	test("a commit fired while the field is focused hands focus back", async () => {
+		__settingCapture.texts.length = 0;
+		const plugin: any = {
+			settings: { apiUrl: "", apiKey: "", refreshToken: "" },
+			api: { setAuthProvider: () => {} },
+			noteStream: { disconnect: () => {} },
+			resetAuthProvider: () => {},
+			saveSettings: async () => {},
+		};
+		const ctx: any = { containerEl: {}, app: {}, plugin, redisplay: () => {} };
+		// redisplay rebuilds the tab — that is what destroys the input.
+		ctx.redisplay = () => renderEngramUrlSetting(ctx);
+		renderEngramUrlSetting(ctx);
+
+		const typed = __settingCapture.texts[0];
+		const g = globalThis as any;
+		g.document = { activeElement: typed?.inputEl, hasFocus: () => true };
+		const realProbe = (EngramApi as any).probeHealth;
+		(EngramApi as any).probeHealth = async () => ({ kind: "engram", version: "1.2.3" });
+		try {
+			typed?.changeCb?.("http://127.0.0.1:4000");
+			// Past the 600ms preflight debounce, then let the probe + commit settle.
+			await new Promise((r) => setTimeout(r, 900));
+		} finally {
+			(EngramApi as any).probeHealth = realProbe;
+			g.document = undefined;
+		}
+
+		expect(plugin.settings.apiUrl).toBe("http://127.0.0.1:4000");
+		const rebuilt = __settingCapture.texts[__settingCapture.texts.length - 1];
+		expect(rebuilt).not.toBe(typed);
+		expect(rebuilt?.focused).toBe(true);
+		// Caret at the end: the user was appending, and a select-all would make
+		// their next keystroke wipe the URL.
+		expect(rebuilt?.caret).toEqual([
+			"http://127.0.0.1:4000".length,
+			"http://127.0.0.1:4000".length,
+		]);
 	});
 
 	// Alt-tabbing out of Obsidian fires blur on the focused input too. That is

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -125,3 +125,33 @@ describe("describeListVaultsError", () => {
 		);
 	});
 });
+
+describe("renderEngramUrlSetting — no Save button", () => {
+	function render(apiUrl: string) {
+		__settingCapture.texts.length = 0;
+		__settingCapture.buttons.length = 0;
+		const plugin: any = {
+			settings: { apiUrl, apiKey: "", refreshToken: "" },
+			api: {},
+			noteStream: {},
+			saveSettings: async () => {},
+		};
+		renderEngramUrlSetting({ containerEl: {}, app: {}, plugin, redisplay: () => {} } as any);
+	}
+
+	// The debounced preflight already tells the user whether the address works.
+	// A Save button beside it asked them to confirm what the page had just
+	// confirmed for them.
+	test("renders no button — the preflight is the confirmation", () => {
+		render("https://staging.engram.page");
+		expect(__settingCapture.buttons.length).toBe(0);
+	});
+
+	// applyApiUrlChange is a backend IDENTITY swap (clears auth, bumps the auth
+	// generation). Reaching it on every keystroke is the bug this field was
+	// rebuilt to fix, so blur has to be a real, separate commit path.
+	test("commits on blur, so a server that is not running yet can still be saved", () => {
+		render("");
+		expect(__settingCapture.texts[0]?.blurCb).toBeTruthy();
+	});
+});

--- a/tests/sync-preview-modal.test.ts
+++ b/tests/sync-preview-modal.test.ts
@@ -479,15 +479,18 @@ describe("emptyPlanDismiss — the nothing-to-sync screen", () => {
 	// runSyncFromChoice and never reaches markSyncGateAccepted. A user whose
 	// vault was already in sync from another device clicked the one obvious
 	// button and ended up with sync silently blocked forever.
-	test("a gated context must ACCEPT, not dismiss", () => {
-		expect(emptyPlanDismiss("first-time")).toEqual({ label: "Done", accept: true });
-		expect(emptyPlanDismiss("vault-switch")).toEqual({ label: "Done", accept: true });
+	test("a CLOSED gate must ACCEPT, not dismiss", () => {
+		expect(emptyPlanDismiss(true)).toEqual({ label: "Done", accept: true });
 	});
 
-	// Manual sync with the gate already open: nothing to transfer and nothing
-	// to accept, so running a pointless fullSync just to emit "pulled 0,
-	// pushed 0" would be noise.
-	test("review dismisses, because there is genuinely nothing to do", () => {
-		expect(emptyPlanDismiss("review")).toEqual({ label: "Close", accept: false });
+	// Gate already open: nothing to transfer and nothing to accept, so running
+	// a pointless fullSync just to emit "pulled 0, pushed 0" would be noise.
+	//
+	// Keyed on the GATE, not the header context. derivePreviewContext only ever
+	// returns "first-time" or "vault-switch", so keying on context meant an
+	// already-syncing user reopening the preview got the accept-and-sync
+	// treatment plus a warning that nothing would sync until they chose.
+	test("an open gate dismisses, because there is genuinely nothing to do", () => {
+		expect(emptyPlanDismiss(false)).toEqual({ label: "Close", accept: false });
 	});
 });

--- a/tests/sync-preview-modal.test.ts
+++ b/tests/sync-preview-modal.test.ts
@@ -5,6 +5,7 @@ import {
 	confirmActions,
 	countSkippedAttachments,
 	describeCreateVaultError,
+	emptyPlanDismiss,
 	HEADER_BY_CONTEXT,
 	loadingHoldMs,
 	mergeHelperText,
@@ -470,5 +471,23 @@ describe("loadingHoldMs — 'Comparing…' pacing", () => {
 	// ages, so landing the results must be instant, not delayed again.
 	test("never delays a genuinely slow plan", () => {
 		expect(loadingHoldMs(1_000_000, 1_008_000)).toBe(0);
+	});
+});
+
+describe("emptyPlanDismiss — the nothing-to-sync screen", () => {
+	// The bug: "Close" dispatched `cancel`, which returns false from
+	// runSyncFromChoice and never reaches markSyncGateAccepted. A user whose
+	// vault was already in sync from another device clicked the one obvious
+	// button and ended up with sync silently blocked forever.
+	test("a gated context must ACCEPT, not dismiss", () => {
+		expect(emptyPlanDismiss("first-time")).toEqual({ label: "Done", accept: true });
+		expect(emptyPlanDismiss("vault-switch")).toEqual({ label: "Done", accept: true });
+	});
+
+	// Manual sync with the gate already open: nothing to transfer and nothing
+	// to accept, so running a pointless fullSync just to emit "pulled 0,
+	// pushed 0" would be noise.
+	test("review dismisses, because there is genuinely nothing to do", () => {
+		expect(emptyPlanDismiss("review")).toEqual({ label: "Close", accept: false });
 	});
 });

--- a/tests/sync-preview-modal.test.ts
+++ b/tests/sync-preview-modal.test.ts
@@ -6,6 +6,7 @@ import {
 	countSkippedAttachments,
 	describeCreateVaultError,
 	HEADER_BY_CONTEXT,
+	loadingHoldMs,
 	mergeHelperText,
 	SyncPreviewState,
 	skippedAttachmentsLine,
@@ -443,5 +444,31 @@ describe("HEADER_BY_CONTEXT", () => {
 		expect(HEADER_BY_CONTEXT["vault-switch"]).toBe(
 			"You are now pointing at a different cloud vault",
 		);
+	});
+});
+
+describe("loadingHoldMs — 'Comparing…' pacing", () => {
+	// The fast path. A plan that resolves before the line ever appears must not
+	// be delayed at all: there is nothing on screen to keep readable, and
+	// padding it would tax every quick sync to fix a frame no one saw.
+	test("no hold when the line was never shown", () => {
+		expect(loadingHoldMs(null, 1_000_000)).toBe(0);
+	});
+
+	// The bug being fixed: the line appeared and was replaced ~80ms later, which
+	// reads as a step being skipped rather than a step being fast.
+	test("holds out the remainder when the line just appeared", () => {
+		expect(loadingHoldMs(1_000_000, 1_000_080)).toBe(520);
+	});
+
+	test("no hold once the line has had its full time", () => {
+		expect(loadingHoldMs(1_000_000, 1_000_600)).toBe(0);
+		expect(loadingHoldMs(1_000_000, 1_005_000)).toBe(0);
+	});
+
+	// A slow plan is the case the line exists for — it has been readable for
+	// ages, so landing the results must be instant, not delayed again.
+	test("never delays a genuinely slow plan", () => {
+		expect(loadingHoldMs(1_000_000, 1_008_000)).toBe(0);
 	});
 });


### PR DESCRIPTION
## What

The plugin now opens the web `/link` page with the device code already in the URL — RFC 8628 `verification_uri_complete`:

```
http://…/link?code=ENGR-7X4K
```

## Why

`device-link-page.tsx` has read `?code=` since it was written, but nothing ever set it: the backend returns a bare page URL and the plugin opened exactly that. So every user retyped an 8-character code their own machine already knew.

Both halves are in hand right here, so this is where they get joined. No backend change needed.

Click-to-copy on the code stays as the manual fallback for when the browser doesn't open.

## Security

This is the spec-blessed shape (RFC 8628 §3.3.1) and what GitHub/Google/Azure device flows do.

The real device-flow attack is the reverse direction — getting a victim to approve an *attacker's* code. That works by hand-typing the URL today; appending the param in our own plugin doesn't create it. The defense is the consent screen, not URL secrecy, so the paired frontend PR auto-runs only the **verify** step (which lists vaults) and leaves authorization as an explicit Sync click on a screen that names the vault. It also scrubs the param out of browser history on arrival.

The code itself is ~39 bits, 300s TTL, single-use, and authorizing requires an already-signed-in user.

## Testing

- 4 new tests on `verificationUrlWithCode` — append, preserve an existing query string, overwrite a stale `code`, and fall back to the bare URL on an unparseable input
- Full suite: 2569 pass, 1 skip
- `tsc -noEmit` clean, biome + eslint + stylelint clean

## Paired with

engram-app/Engram — `feat/link-auto-verify-url-code` (the `/link` page side). Either can merge first: this PR is inert until the page auto-verifies, and that PR is inert until something sets `?code=`.

No version bump here — release-please owns `manifest.json`/`package.json`. This `feat:` should move the pending release PR from 1.22.1 to 1.23.0.