### PR TITLE
fix(privacy): scrub unquoted vault paths from error messages

### DIFF
--- a/src/error-util.ts
+++ b/src/error-util.ts
@@ -15,6 +15,33 @@ const QUOTED_PATH = /(['"`])[^'"`]*[/\\][^'"`]*\1/g;
 const FS_ERROR = /^([A-Z][A-Z0-9]{2,}):\s*(.*?),\s*\w+\s+['"`].*$/s;
 
 /**
+ * An UNQUOTED path, anchored on a vault file extension.
+ *
+ * `QUOTED_PATH` only sees a path a library was polite enough to quote. A
+ * message like `failed to index Medical/2026 biopsy results.md after retry`
+ * has the same disclosure with no quotes anywhere, and nothing above catches
+ * it.
+ *
+ * Anchored on the EXTENSIONS a vault holds rather than on "any dotted token
+ * with a slash", and that restraint is the point: `src/sync.ts:412` and
+ * `https://cdn.example.com/lib.js` are the shapes an over-eager version eats,
+ * and a stack frame is exactly the diagnostic you still want when the path is
+ * gone. Vault extensions and source extensions do not overlap, so anchoring
+ * here separates them cleanly.
+ *
+ * Spaces are allowed INSIDE the run (vault names have them constantly) but a
+ * segment separator is still required, so a bare `note.md` with no folder is
+ * left alone — it names no folder, which is the part that discloses.
+ */
+const VAULT_EXT =
+	"md|canvas|base|txt|pdf|png|jpe?g|gif|svg|webp|bmp|mp[34]|m4a|wav|ogg|webm|mov|zip|docx|xlsx|pptx";
+
+const BARE_PATH = new RegExp(
+	`(?:[A-Za-z]:)?[^\\s'"\`,;:()\\[\\]]*[/\\\\][^'"\`,;:()\\[\\]]*?\\.(?:${VAULT_EXT})\\b`,
+	"gi",
+);
+
+/**
  * Coerce an unknown caught value to a printable string, WITHOUT the path.
  *
  * This function is the reason the rest of the privacy work holds. `errMsg(e)`
@@ -35,10 +62,19 @@ const FS_ERROR = /^([A-Z][A-Z0-9]{2,}):\s*(.*?),\s*\w+\s+['"`].*$/s;
  * is the whole diagnostic; the path only ever said which note, which
  * `noteRef()` already says opaquely.
  *
- * It is a scrub of KNOWN shapes, not a proof. A library that embeds a path
- * mid-sentence with no quotes and no separator is not caught. Paths in logs
- * are prevented at the call sites (`noteRef`) and in the anomaly path
- * (slug validation); this closes the shape that actually occurred.
+ * It is a scrub of KNOWN shapes, not a proof. Three are covered: the Node fs
+ * rendering, any quoted run holding a separator, and an unquoted run ending in
+ * a vault file extension. What is still NOT caught, stated plainly because a
+ * comment that overstates its reach is what let this class survive seven
+ * review rounds:
+ *
+ *   * a folder with no file — `sync failed under Medical/` has no extension
+ *   * a vault file with an extension outside `VAULT_EXT`, or none at all
+ *   * a path split across interpolations before it ever reaches here
+ *
+ * Paths in logs are prevented at the CALL SITES (`noteRef`, enforced by the
+ * source guard) and in the anomaly path (slug validation). This function is
+ * the backstop for text we do not author, not the primary control.
  */
 export function errMsg(e: unknown): string {
 	return scrubPaths(rawMessage(e));
@@ -57,7 +93,7 @@ function rawMessage(e: unknown): string {
 function scrubPaths(message: string): string {
 	const fs = FS_ERROR.exec(message);
 	if (fs) return `${fs[1]}: ${fs[2]}`;
-	return message.replace(QUOTED_PATH, "'<path>'");
+	return message.replace(QUOTED_PATH, "'<path>'").replace(BARE_PATH, "<path>");
 }
 
 /** The HTTP status carried by a rejected Obsidian requestUrl() call, or

--- a/tests/error-util.test.ts
+++ b/tests/error-util.test.ts
@@ -107,3 +107,71 @@ describe("errMsg — the path does not survive", () => {
 		expect(errMsg(`cannot stat '/v/${SECRET}'`)).not.toContain("Medical");
 	});
 });
+
+/**
+ * Unquoted paths.
+ *
+ * `QUOTED_PATH` only catches a path a library was polite enough to quote. A
+ * message that names the file mid-sentence discloses exactly the same folder
+ * with no quotes anywhere. Both directions are asserted: the vault path must
+ * go, and a stack frame must NOT — an over-eager scrub that eats
+ * `src/sync.ts:412` trades one diagnostic for another and gets reverted.
+ */
+describe("errMsg — unquoted vault paths", () => {
+	test("a bare path mid-sentence is blanked", () => {
+		const raw = "failed to index Medical/2026 biopsy results.md after 3 retries";
+		expect(raw).toContain("Medical"); // the leak, before the fix
+
+		const out = errMsg(new Error(raw));
+
+		expect(out).toBe("failed to index <path> after 3 retries");
+		expect(out).not.toContain("Medical");
+		expect(out).not.toContain("biopsy");
+	});
+
+	test("an absolute path with no quotes is blanked", () => {
+		const out = errMsg(new Error("cannot open /home/t/vault/Divorce 2026/settlement.md now"));
+
+		expect(out).not.toContain("Divorce");
+		expect(out).toContain("<path>");
+	});
+
+	test("a windows path is blanked", () => {
+		const out = errMsg(new Error("read failed C:\\Users\\t\\Vault\\Therapy\\session.md"));
+
+		expect(out).not.toContain("Therapy");
+		expect(out).toContain("<path>");
+	});
+
+	test("attachments count too", () => {
+		for (const path of ["Medical/scan.png", "Medical/report.pdf", "Medical/board.canvas"]) {
+			expect(errMsg(new Error(`upload failed for ${path}`))).not.toContain("Medical");
+		}
+	});
+
+	// The restraint half. Vault extensions and source extensions do not
+	// overlap, which is what makes anchoring on the former safe.
+	test("a stack frame survives", () => {
+		const out = errMsg(new Error("boom at src/sync.ts:412 in flushToDisk"));
+
+		expect(out).toBe("boom at src/sync.ts:412 in flushToDisk");
+	});
+
+	test("a URL to a script survives", () => {
+		const out = errMsg(new Error("failed to load https://cdn.example.com/lib.js"));
+
+		expect(out).toContain("lib.js");
+	});
+
+	test("an api route survives", () => {
+		expect(errMsg(new Error("POST /api/notes returned 500"))).toBe(
+			"POST /api/notes returned 500",
+		);
+	});
+
+	// A filename with no folder names no folder — nothing to disclose, and
+	// blanking it would cost the one clue about WHICH kind of file failed.
+	test("a bare filename with no folder is left alone", () => {
+		expect(errMsg(new Error("could not parse note.md"))).toBe("could not parse note.md");
+	});
+});


### PR DESCRIPTION
Follow-up to #436, closing the residual gap I flagged there.

`errMsg` caught the Node fs rendering and quoted paths — both require the thrower to have quoted the path. An unquoted mention discloses the same folder:

```
failed to index Medical/2026 biopsy results.md after 3 retries
```

Anchored on **vault** extensions rather than "any dotted token with a slash". That restraint is the point: the greedy version also eats `src/sync.ts:412` and `https://cdn.example.com/lib.js`, and a stack frame is exactly what you still want once the path is gone. Tests assert both directions.

The moduledoc now enumerates what is still not caught instead of implying the class is closed.

Verified by reverting the scrub: 4 tests fail. Full suite 2638 pass, lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC