### PR TITLE
fix(privacy): delete the unquoted-path regex, redact the known path exactly

### DIFF
--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -256,7 +256,7 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 				.catch((e) =>
 					rlog().warn(
 						"crdt",
-						`strand-heal flush failed for ${noteRef(path)}: ${errMsg(e)} — retained in Y.Doc`,
+						`strand-heal flush failed for ${noteRef(path)}: ${errMsg(e, path)} — retained in Y.Doc`,
 					),
 				);
 		}
@@ -357,7 +357,7 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 		onPersistError: (noteId, err) => {
 			rlog().warn(
 				"crdt",
-				`IndexedDB persist error for ${noteRef(noteIdMap.pathForId(noteId))} (id=${noteId}) — sync continues in-memory: ${errMsg(err)}`,
+				`IndexedDB persist error for ${noteRef(noteIdMap.pathForId(noteId))} (id=${noteId}) — sync continues in-memory: ${errMsg(err, noteIdMap.pathForId(noteId))}`,
 			);
 		},
 		// Convergence commit (idempotent; no-op when nothing staged). The text-verify

--- a/src/error-util.ts
+++ b/src/error-util.ts
@@ -72,6 +72,25 @@ const BARE_PATH = new RegExp(
  *   * a vault file with an extension outside `VAULT_EXT`, or none at all
  *   * a path split across interpolations before it ever reaches here
  *
+ * All three require the path to be UNQUOTED. Every quoted form is already
+ * clean regardless of extension, because `QUOTED_PATH` keys on the separator
+ * and not the suffix — verified against quoted weird-extension, quoted
+ * no-extension and quoted folder-only inputs.
+ *
+ * That is why they are left open rather than chased. Node quotes the path in
+ * every fs error, Obsidian's adapter surfaces Node's, and our own code cannot
+ * produce the unquoted form because the source guard forces `noteRef` at the
+ * call site. The remaining shape needs a third party to write a vault path
+ * into prose with no quotes — which nothing we depend on has been observed to
+ * do. Closing it would mean scrubbing ANY token holding a separator, which
+ * certainly destroys `application/json`, `src/sync.ts:412` and every URL, in
+ * exchange for a disclosure nobody has seen.
+ *
+ * If a path IS ever observed in client logs, the fix is exact rather than
+ * broader: give `errMsg` the known path as a second argument and redact that
+ * literal string. The ~40 sites that matter already hold it — they sit beside
+ * a `noteRef(path)` call. Do that, not a greedier regex.
+ *
  * Paths in logs are prevented at the CALL SITES (`noteRef`, enforced by the
  * source guard) and in the anomaly path (slug validation). This function is
  * the backstop for text we do not author, not the primary control.

--- a/src/error-util.ts
+++ b/src/error-util.ts
@@ -1,107 +1,106 @@
 /**
- * A quoted run containing a separator — the shape a filesystem error uses to
- * name the file it failed on. Deliberately requires the separator: `'read'` and
- * `"note.md"` are not paths, and blanking them would cost the diagnostic for
- * nothing.
+ * A quoted run holding a path separator — the shape a filesystem error uses to
+ * name the file it failed on.
+ *
+ * One alternative PER DELIMITER, each excluding only its OWN quote character.
+ * A single class excluding all three (`[^'"`]*`) cannot match a double-quoted
+ * path containing an apostrophe, and `Medical/Tom's notes.md` is an entirely
+ * ordinary Obsidian title — so the previous version leaked the common case
+ * while its tests, which used apostrophe-free names, reported it clean.
+ *
+ * Spans are length-bounded. They are anchored by their delimiter so they were
+ * never the runaway that `BARE_PATH` was, but an unbounded class in a scrub
+ * that runs synchronously on the renderer thread is not worth the argument.
  */
-const QUOTED_PATH = /(['"`])[^'"`]*[/\\][^'"`]*\1/g;
+const QUOTED_PATH =
+	/'[^']{0,512}[/\\][^']{0,512}'|"[^"]{0,512}[/\\][^"]{0,512}"|`[^`]{0,512}[/\\][^`]{0,512}`/g;
 
 /**
  * A Node filesystem error rendered as a message:
  *   ENOENT: no such file or directory, open '/home/t/vault/Medical/biopsy.md'
- * Group 1 is the code, group 2 the human half. Everything from the syscall
- * onward is the path and is dropped.
+ * Group 1 is the code, group 2 the human half.
  */
 const FS_ERROR = /^([A-Z][A-Z0-9]{2,}):\s*(.*?),\s*\w+\s+['"`].*$/s;
 
 /**
- * An UNQUOTED path, anchored on a vault file extension.
- *
- * `QUOTED_PATH` only sees a path a library was polite enough to quote. A
- * message like `failed to index Medical/2026 biopsy results.md after retry`
- * has the same disclosure with no quotes anywhere, and nothing above catches
- * it.
- *
- * Anchored on the EXTENSIONS a vault holds rather than on "any dotted token
- * with a slash", and that restraint is the point: `src/sync.ts:412` and
- * `https://cdn.example.com/lib.js` are the shapes an over-eager version eats,
- * and a stack frame is exactly the diagnostic you still want when the path is
- * gone. Vault extensions and source extensions do not overlap, so anchoring
- * here separates them cleanly.
- *
- * Spaces are allowed INSIDE the run (vault names have them constantly) but a
- * segment separator is still required, so a bare `note.md` with no folder is
- * left alone — it names no folder, which is the part that discloses.
- */
-const VAULT_EXT =
-	"md|canvas|base|txt|pdf|png|jpe?g|gif|svg|webp|bmp|mp[34]|m4a|wav|ogg|webm|mov|zip|docx|xlsx|pptx";
-
-const BARE_PATH = new RegExp(
-	`(?:[A-Za-z]:)?[^\\s'"\`,;:()\\[\\]]*[/\\\\][^'"\`,;:()\\[\\]]*?\\.(?:${VAULT_EXT})\\b`,
-	"gi",
-);
-
-/**
  * Coerce an unknown caught value to a printable string, WITHOUT the path.
  *
- * This function is the reason the rest of the privacy work holds. `errMsg(e)`
- * is interpolated into ~85 places, around forty of them log lines that sit
- * directly beside a `noteRef()` — and Obsidian's vault adapter surfaces raw
- * Node errors, whose messages end in the absolute path:
+ * `errMsg(e)` is interpolated into ~85 places, around forty of them log lines
+ * sitting directly beside a `noteRef()`. Obsidian's vault adapter surfaces raw
+ * Node errors whose messages end in the absolute path, so without this those
+ * lines shipped the path they had just taken care to wrap — into `client_logs`,
+ * CloudWatch and Loki, outside the per-user encryption boundary.
  *
- *   ENOENT: no such file or directory, open '/home/t/vault/Medical/biopsy.md'
+ * ## Pass `knownPath` wherever you have it
  *
- * So every one of those lines shipped the path it had just taken care to wrap.
- * Review caught it; the wrapped-ref work was cosmetic until this was fixed.
+ * The second argument is the mechanism that actually works. It redacts that
+ * exact string, so it is complete by construction: it does not care whether the
+ * path was quoted, what extension it has, whether it has one at all, or whether
+ * it is a folder. It cannot damage a diagnostic it was not given, and it cannot
+ * backtrack.
  *
- * Scrubbing HERE rather than at the call sites is deliberate: this is the one
- * seam all of them route through, so a new `${errMsg(e)}` is safe by default
- * instead of safe-if-remembered.
+ * The ~29 sites that log about a specific note already hold the path — they sit
+ * next to `noteRef(path)`. Pass it there. Everything below is the fallback for
+ * text where we genuinely do not know which note it concerns.
  *
- * The code and the human half are kept — `ENOENT: no such file or directory`
- * is the whole diagnostic; the path only ever said which note, which
- * `noteRef()` already says opaquely.
+ * ## Why there is no unquoted-path heuristic
  *
- * It is a scrub of KNOWN shapes, not a proof. Three are covered: the Node fs
- * rendering, any quoted run holding a separator, and an unquoted run ending in
- * a vault file extension. What is still NOT caught, stated plainly because a
- * comment that overstates its reach is what let this class survive seven
- * review rounds:
+ * There was one. `BARE_PATH` matched an unquoted run ending in a vault file
+ * extension, and review killed it on three independent counts:
  *
- *   * a folder with no file — `sync failed under Medical/` has no extension
- *   * a vault file with an extension outside `VAULT_EXT`, or none at all
- *   * a path split across interpolations before it ever reaches here
+ *   * **It was a ReDoS.** Greedy class, separator, then a LAZY class that did
+ *     not exclude whitespace, so the tail was rescanned per backtrack point —
+ *     roughly cubic. 6.4 KB of input took 57 SECONDS, synchronously, on the
+ *     renderer thread. A base64 attachment body or an HTML error page echoed
+ *     into a message reaches that size easily.
+ *   * **It leaked the common case anyway.** Both classes excluded `'`, `"`,
+ *     backtick, `,`, `;`, `:`, `(`, `)`, `[`, `]` — every one of which is legal
+ *     in a note title. `Medical/Tom's notes.md`, `Medical/Q&A (2026).md` and
+ *     `Medical/Notes, 2026.md` all passed through in clear.
+ *   * **It ate diagnostics.** Because the lazy class crossed spaces, any `/`
+ *     earlier in a message merged with any vault extension later:
+ *     `POST /api/notes returned 500 for note.md` became `POST <path>`.
  *
- * All three require the path to be UNQUOTED. Every quoted form is already
- * clean regardless of extension, because `QUOTED_PATH` keys on the separator
- * and not the suffix — verified against quoted weird-extension, quoted
- * no-extension and quoted folder-only inputs.
+ * A heuristic that leaks ordinary titles, destroys routes and freezes the UI is
+ * worse than no heuristic. `knownPath` covers the sites that matter, exactly.
  *
- * That is why they are left open rather than chased. Node quotes the path in
- * every fs error, Obsidian's adapter surfaces Node's, and our own code cannot
- * produce the unquoted form because the source guard forces `noteRef` at the
- * call site. The remaining shape needs a third party to write a vault path
- * into prose with no quotes — which nothing we depend on has been observed to
- * do. Closing it would mean scrubbing ANY token holding a separator, which
- * certainly destroys `application/json`, `src/sync.ts:412` and every URL, in
- * exchange for a disclosure nobody has seen.
+ * ## What is left uncovered, honestly
  *
- * If a path IS ever observed in client logs, the fix is exact rather than
- * broader: give `errMsg` the known path as a second argument and redact that
- * literal string. The ~40 sites that matter already hold it — they sit beside
- * a `noteRef(path)` call. Do that, not a greedier regex.
+ * With no `knownPath`, an UNQUOTED path in third-party prose survives. Node
+ * quotes the path in every fs error and Obsidian surfaces Node's, so the
+ * quoted rule covers what is actually produced — but this is a real gap, not a
+ * closed one, and the fix for any instance of it is to pass `knownPath` at that
+ * call site rather than to reach for another regex.
  *
- * Paths in logs are prevented at the CALL SITES (`noteRef`, enforced by the
- * source guard) and in the anomaly path (slug validation). This function is
- * the backstop for text we do not author, not the primary control.
+ * A path in a non-`message` field of an arbitrary object is JSON-encoded before
+ * it gets here, and the resulting `\"` escapes can confuse the quoted rule.
+ * `knownPath` is immune to that too.
  */
-export function errMsg(e: unknown): string {
-	return scrubPaths(rawMessage(e));
+type PathLike = string | { path: string } | null | undefined;
+
+export function errMsg(e: unknown, knownPath?: PathLike | PathLike[]): string {
+	const known = (Array.isArray(knownPath) ? knownPath : [knownPath]).map(pathOf).filter(Boolean);
+	return scrubPaths(rawMessage(e), known);
+}
+
+function pathOf(value: PathLike): string {
+	if (!value) return "";
+	return typeof value === "string" ? value : (value.path ?? "");
 }
 
 function rawMessage(e: unknown): string {
 	if (e instanceof Error) return e.message;
 	if (typeof e === "string") return e;
+
+	// Prefer a string `message` over JSON-encoding the whole object. A rejected
+	// `requestUrl()` hands back a plain object with one, and encoding it first
+	// turns `"` into `\"` — whose backslash then satisfies the quoted rule's
+	// separator test, so it matched the wrong span and left the path behind.
+	if (e && typeof e === "object") {
+		const message = (e as { message?: unknown }).message;
+		if (typeof message === "string") return message;
+	}
+
 	try {
 		return JSON.stringify(e) ?? String(e);
 	} catch {
@@ -109,10 +108,29 @@ function rawMessage(e: unknown): string {
 	}
 }
 
-function scrubPaths(message: string): string {
-	const fs = FS_ERROR.exec(message);
-	if (fs) return `${fs[1]}: ${fs[2]}`;
-	return message.replace(QUOTED_PATH, "'<path>'").replace(BARE_PATH, "<path>");
+function scrubPaths(message: string, knownPaths: string[]): string {
+	// Exact and first. `split`/`join` rather than a built regex so a path
+	// containing regex metacharacters — `Q&A (2026).md`, `[draft] plan.md` —
+	// is matched literally instead of blowing up or silently not matching.
+	//
+	// An array because a rename failure can legitimately name either side, and
+	// picking one would have left the other in clear. Longest first, so a path
+	// that is a prefix of another cannot redact half of it and strand the tail.
+	const exact = [...knownPaths]
+		.sort((a, b) => b.length - a.length)
+		.reduce((acc, path) => acc.split(path).join("<path>"), message);
+
+	const fs = FS_ERROR.exec(exact);
+	// The quoted rule runs over the human half as well. The early return used to
+	// skip every rule below it, so `ENOENT: cannot copy '/v/Medical/a.md', open
+	// '/v/x'` kept the first path in clear.
+	//
+	// This does NOT make the half safe on its own: an UNQUOTED path there is
+	// still the general unquoted gap, and only `knownPath` closes it. Said
+	// plainly because the first version of this comment implied otherwise.
+	if (fs) return `${fs[1]}: ${(fs[2] ?? "").replace(QUOTED_PATH, "'<path>'")}`;
+
+	return exact.replace(QUOTED_PATH, "'<path>'");
 }
 
 /** The HTTP status carried by a rejected Obsidian requestUrl() call, or

--- a/src/main.ts
+++ b/src/main.ts
@@ -1058,7 +1058,7 @@ export default class EngramSyncPlugin extends Plugin {
 						.catch((e) => {
 							rlog().warn(
 								"crdt",
-								`reconcileColdStart: failed to read ${noteRef(file.path)}: ${errMsg(e)}`,
+								`reconcileColdStart: failed to read ${noteRef(file.path)}: ${errMsg(e, file.path)}`,
 							);
 						});
 				}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -204,7 +204,7 @@ export async function reconcileColdStart(
 		// handshake will converge the state once connectivity is restored.
 		rlog().warn(
 			"crdt",
-			`reconcileColdStart: write failed for ${noteRef(file.path)}: ${errMsg(e)}`,
+			`reconcileColdStart: write failed for ${noteRef(file.path)}: ${errMsg(e, file.path)}`,
 		);
 	}
 	// A drifted note must always get a handshake: when the doc is history-less
@@ -895,7 +895,7 @@ export class SyncEngine {
 		try {
 			await this.crdt.flushHeldState(noteId);
 		} catch (e) {
-			rlog().warn("crdt", `create-ack flush failed for ${noteRef(path)}: ${errMsg(e)}`);
+			rlog().warn("crdt", `create-ack flush failed for ${noteRef(path)}: ${errMsg(e, path)}`);
 			this.crdtEnrollment?.reset(noteId);
 			this.crdtEnrollment?.enroll(noteId);
 		}
@@ -1181,7 +1181,7 @@ export class SyncEngine {
 				// self-heals on the note's next edit. Never fall back to REST.
 				rlog().warn(
 					"crdt",
-					`crdt_create (queued) body seed failed for ${noteRef(path)}: ${errMsg(e)}`,
+					`crdt_create (queued) body seed failed for ${noteRef(path)}: ${errMsg(e, path)}`,
 				);
 			}
 		}
@@ -1361,7 +1361,10 @@ export class SyncEngine {
 			// intentionally NOT reached here — a failed write must not mark the note
 			// synced. Best-effort callers (pull/materialize) ignore the return and
 			// keep today's log-and-continue behavior.
-			rlog().error("crdt", `flushFromCrdt: write failed for ${noteRef(path)}: ${errMsg(e)}`);
+			rlog().error(
+				"crdt",
+				`flushFromCrdt: write failed for ${noteRef(path)}: ${errMsg(e, path)}`,
+			);
 			return false;
 		}
 	}
@@ -1495,7 +1498,7 @@ export class SyncEngine {
 		} catch (e) {
 			rlog().warn(
 				"crdt",
-				`captureDiskDriftBeforeRemote: seed failed for ${noteRef(path)}: ${errMsg(e)}`,
+				`captureDiskDriftBeforeRemote: seed failed for ${noteRef(path)}: ${errMsg(e, path)}`,
 			);
 		}
 	}
@@ -1570,7 +1573,7 @@ export class SyncEngine {
 			} catch (e) {
 				rlog().error(
 					"conflict",
-					`history-less keep-both copy failed for ${noteRef(normalized)}: ${errMsg(e)}. Aborting apply to retain the local edit for retry`,
+					`history-less keep-both copy failed for ${noteRef(normalized)}: ${errMsg(e, normalized)}. Aborting apply to retain the local edit for retry`,
 				);
 				return "deferred";
 			}
@@ -2609,7 +2612,10 @@ export class SyncEngine {
 			}
 			// biome-ignore lint/suspicious/noConsole: error boundary
 			console.error("Engram Sync: failed to delete %s", file.path, e);
-			rlog().error("push", `Delete failed (queued): ${noteRef(file.path)} | ${errMsg(e)}`);
+			rlog().error(
+				"push",
+				`Delete failed (queued): ${noteRef(file.path)} | ${errMsg(e, file.path)}`,
+			);
 			await this.enqueueChange({
 				path: file.path,
 				action: "delete",
@@ -2719,7 +2725,7 @@ export class SyncEngine {
 					console.error("Engram Sync: failed to delete old path %s", oldPath, e);
 					rlog().error(
 						"push",
-						`Rename old-leg delete failed (queued): ${noteRef(oldPath)} | ${errMsg(e)}`,
+						`Rename old-leg delete failed (queued): ${noteRef(oldPath)} | ${errMsg(e, oldPath)}`,
 					);
 					await this.enqueueChange({
 						path: oldPath,
@@ -2779,7 +2785,7 @@ export class SyncEngine {
 			await this.explicitFolders.add(path);
 		} catch (e) {
 			devLog().log("push", `createFolder("${path}") failed: ${errMsg(e)}`);
-			rlog().warn("push", `createFolder("${noteRef(path)}") failed: ${errMsg(e)}`);
+			rlog().warn("push", `createFolder("${noteRef(path)}") failed: ${errMsg(e, path)}`);
 		}
 	}
 
@@ -2799,7 +2805,7 @@ export class SyncEngine {
 			await this.api.deleteFolder(path);
 		} catch (e) {
 			devLog().log("push", `deleteFolder("${path}") failed: ${errMsg(e)}`);
-			rlog().warn("push", `deleteFolder("${noteRef(path)}") failed: ${errMsg(e)}`);
+			rlog().warn("push", `deleteFolder("${noteRef(path)}") failed: ${errMsg(e, path)}`);
 		} finally {
 			await this.explicitFolders.delete(path);
 		}
@@ -2830,7 +2836,10 @@ export class SyncEngine {
 				await this.explicitFolders.add(path);
 			} catch (e) {
 				devLog().log("push", `seedEmptyFolders("${path}") failed: ${errMsg(e)}`);
-				rlog().warn("push", `seedEmptyFolders("${noteRef(path)}") failed: ${errMsg(e)}`);
+				rlog().warn(
+					"push",
+					`seedEmptyFolders("${noteRef(path)}") failed: ${errMsg(e, path)}`,
+				);
 			}
 		}
 	}
@@ -4503,7 +4512,7 @@ export class SyncEngine {
 							failed += 1;
 							rlog().error(
 								"crdt",
-								`seq-replay: skipped ${noteRef(c.path)} — ${errMsg(e)}`,
+								`seq-replay: skipped ${noteRef(c.path)} — ${errMsg(e, c.path)}`,
 							);
 						}
 					}
@@ -4597,7 +4606,10 @@ export class SyncEngine {
 			// content and can never pend (unlike the retired crdt_catchup_delta).
 			await this.catchupViaSeqReplay();
 		} catch (e) {
-			rlog().warn("crdt", `discoverAnnouncedNote failed for ${noteRef(path)}: ${errMsg(e)}`);
+			rlog().warn(
+				"crdt",
+				`discoverAnnouncedNote failed for ${noteRef(path)}: ${errMsg(e, path)}`,
+			);
 		}
 	}
 
@@ -4689,7 +4701,7 @@ export class SyncEngine {
 			} catch (e) {
 				rlog().error(
 					"crdt",
-					`Live-bound fan-out apply failed for ${noteRef(path)}: ${errMsg(e)}`,
+					`Live-bound fan-out apply failed for ${noteRef(path)}: ${errMsg(e, path)}`,
 					e instanceof Error ? e.stack : undefined,
 				);
 				return "deferred";
@@ -4744,7 +4756,7 @@ export class SyncEngine {
 			devLog().log("crdt", `applyPushedNoteUpdate: ${path} failed — ${errMsg(e)}`);
 			rlog().warn(
 				"crdt",
-				`Vault-channel update apply failed for ${noteRef(path)}: ${errMsg(e)}`,
+				`Vault-channel update apply failed for ${noteRef(path)}: ${errMsg(e, path)}`,
 			);
 			return "deferred";
 		}
@@ -4856,7 +4868,7 @@ export class SyncEngine {
 			} catch (e) {
 				rlog().warn(
 					"queue",
-					`CRDT delivery settle failed for ${noteRef(queued.path)}: ${errMsg(e)}`,
+					`CRDT delivery settle failed for ${noteRef(queued.path)}: ${errMsg(e, queued.path)}`,
 				);
 			}
 		}
@@ -4933,7 +4945,7 @@ export class SyncEngine {
 		} catch (e) {
 			rlog().warn(
 				"crdt",
-				`socket converge: commit failed for ${noteRef(path)} note_id=${noteId}: ${errMsg(e)}`,
+				`socket converge: commit failed for ${noteRef(path)} note_id=${noteId}: ${errMsg(e, path)}`,
 			);
 		}
 		this.releaseHealRoom(noteId, path);
@@ -5001,7 +5013,7 @@ export class SyncEngine {
 			if (!this.isLiveBound(normalized)) return; // idle confirmed notes heal on reconnect (#5)
 			this.socketConverge(normalized, noteId);
 		} catch (e) {
-			rlog().warn("crdt", `healNoteOnOpen ${noteRef(path)}: ${errMsg(e)}`);
+			rlog().warn("crdt", `healNoteOnOpen ${noteRef(path)}: ${errMsg(e, path)}`);
 		}
 	}
 
@@ -5466,7 +5478,7 @@ export class SyncEngine {
 				} catch (e) {
 					rlog().warn(
 						"conflict",
-						`received-delete drift check failed for ${noteRef(normalized)}: ${errMsg(e)}`,
+						`received-delete drift check failed for ${noteRef(normalized)}: ${errMsg(e, normalized)}`,
 					);
 				}
 				// trashRemotelyDeleted marks remotelyDeleted, so this device's own
@@ -5677,7 +5689,7 @@ export class SyncEngine {
 				// Sync-critical failure — must reach Loki, not just the local console.
 				rlog().error(
 					"ws",
-					`Apply failed: ${event.event_type} ${noteRef(event.path)} | ${errMsg(e)}`,
+					`Apply failed: ${event.event_type} ${noteRef(event.path)} | ${errMsg(e, event.path)}`,
 					e instanceof Error ? e.stack : undefined,
 				);
 			}
@@ -5863,7 +5875,7 @@ export class SyncEngine {
 			} catch (e) {
 				rlog().warn(
 					"pull",
-					`Id-keyed move file ops failed (old file vanished mid-flight?): ${noteRef(priorPath)} -> ${noteRef(newPath)} — ${errMsg(e)}`,
+					`Id-keyed move file ops failed (old file vanished mid-flight?): ${noteRef(priorPath)} -> ${noteRef(newPath)} — ${errMsg(e, [priorPath, newPath])}`,
 				);
 				// No disk content to flush here, and the caller's isSynced-gated
 				// materializeRelocated backstop may ALSO decline (fresh-boot
@@ -6072,7 +6084,7 @@ export class SyncEngine {
 				} catch (e) {
 					rlog().error(
 						"pull",
-						`Reconcile trash failed (retried next run): ${noteRef(file.path)} — ${errMsg(e)}`,
+						`Reconcile trash failed (retried next run): ${noteRef(file.path)} — ${errMsg(e, file.path)}`,
 						e instanceof Error ? e.stack : undefined,
 					);
 				}
@@ -6208,7 +6220,10 @@ export class SyncEngine {
 				}
 				poked++;
 			} catch (e) {
-				rlog().warn("crdt", `live-bound heal failed for ${noteRef(path)}: ${errMsg(e)}`);
+				rlog().warn(
+					"crdt",
+					`live-bound heal failed for ${noteRef(path)}: ${errMsg(e, path)}`,
+				);
 			}
 		}
 		return poked;
@@ -6300,7 +6315,7 @@ export class SyncEngine {
 						} catch (e) {
 							rlog().error(
 								"pull",
-								`Resurrection push failed: ${noteRef(change.path)} | err=${errMsg(e)}`,
+								`Resurrection push failed: ${noteRef(change.path)} | err=${errMsg(e, change.path)}`,
 							);
 						}
 						return false;
@@ -6320,7 +6335,7 @@ export class SyncEngine {
 						} catch (e) {
 							rlog().warn(
 								"conflict",
-								`CRDT tombstone drift capture failed for ${noteRef(normalized)}: ${errMsg(e)}`,
+								`CRDT tombstone drift capture failed for ${noteRef(normalized)}: ${errMsg(e, normalized)}`,
 							);
 						}
 					} else {
@@ -6682,7 +6697,7 @@ export class SyncEngine {
 							} catch (e) {
 								rlog().warn(
 									"conflict",
-									`drift-copy capture failed for ${noteRef(normalized)}: ${errMsg(e)}`,
+									`drift-copy capture failed for ${noteRef(normalized)}: ${errMsg(e, normalized)}`,
 								);
 							}
 							if (copy === null) {

--- a/tests/error-util.test.ts
+++ b/tests/error-util.test.ts
@@ -175,3 +175,28 @@ describe("errMsg — unquoted vault paths", () => {
 		expect(errMsg(new Error("could not parse note.md"))).toBe("could not parse note.md");
 	});
 });
+
+/**
+ * Why the remaining gaps are left open.
+ *
+ * The scrub does not catch an UNQUOTED path with an unusual extension, no
+ * extension, or a folder with no file. Those are documented as open, and this
+ * is the evidence behind that call: every QUOTED form is clean regardless of
+ * suffix, because the quoted rule keys on the separator rather than the
+ * extension. Node quotes the path in every fs error and Obsidian surfaces
+ * Node's, so the covered set is the set that actually occurs.
+ *
+ * If this ever goes red, the covered set shrank and the decision needs
+ * revisiting — that is the entire point of pinning it.
+ */
+describe("errMsg — quoted paths are clean whatever the suffix", () => {
+	test.each([
+		["an extension outside the vault set", "failed on '/vault/Medical/data.xyz'"],
+		["no extension at all", "failed on '/vault/Medical/untitled'"],
+		["a folder with no file", "EEXIST: file already exists, mkdir '/vault/Medical'"],
+		["a relative path, no extension", "cannot read 'Medical/notes'"],
+	])("%s", (_name, raw) => {
+		expect(raw).toContain("Medical"); // the leak, before the scrub
+		expect(errMsg(new Error(raw))).not.toContain("Medical");
+	});
+});

--- a/tests/error-util.test.ts
+++ b/tests/error-util.test.ts
@@ -109,94 +109,164 @@ describe("errMsg — the path does not survive", () => {
 });
 
 /**
- * Unquoted paths.
+ * `knownPath` — the mechanism that actually works.
  *
- * `QUOTED_PATH` only catches a path a library was polite enough to quote. A
- * message that names the file mid-sentence discloses exactly the same folder
- * with no quotes anywhere. Both directions are asserted: the vault path must
- * go, and a stack frame must NOT — an over-eager scrub that eats
- * `src/sync.ts:412` trades one diagnostic for another and gets reverted.
+ * Every case here is one the deleted `BARE_PATH` heuristic got WRONG, either by
+ * leaking it or by eating a diagnostic. Exact redaction is complete by
+ * construction: it does not care about quoting, extension, or whether the
+ * target is a file at all.
  */
-describe("errMsg — unquoted vault paths", () => {
-	test("a bare path mid-sentence is blanked", () => {
-		const raw = "failed to index Medical/2026 biopsy results.md after 3 retries";
-		expect(raw).toContain("Medical"); // the leak, before the fix
+describe("errMsg — exact redaction via knownPath", () => {
+	// Ordinary Obsidian titles. Every one of these leaked through the previous
+	// regex, because its character classes excluded the very punctuation that
+	// note titles are full of.
+	test.each([
+		["an apostrophe", "Medical/Tom's notes.md"],
+		["parentheses and an ampersand", "Medical/Q&A (2026).md"],
+		["a comma", "Medical/Notes, 2026.md"],
+		["a semicolon", "Medical/a;b.md"],
+		["a colon", "Medical/re: chemo.md"],
+		["square brackets", "Medical/[draft] plan.md"],
+		["no extension", "Medical/untitled"],
+		["a folder, no file", "Medical/"],
+		["an extension we do not enumerate", "Medical/data.xyz"],
+	])("%s", (_name, path) => {
+		const raw = `failed to index ${path} after retry`;
+		expect(raw).toContain("Medical"); // the leak, before redaction
 
-		const out = errMsg(new Error(raw));
-
-		expect(out).toBe("failed to index <path> after 3 retries");
-		expect(out).not.toContain("Medical");
-		expect(out).not.toContain("biopsy");
+		expect(errMsg(new Error(raw), path)).not.toContain("Medical");
 	});
 
-	test("an absolute path with no quotes is blanked", () => {
-		const out = errMsg(new Error("cannot open /home/t/vault/Divorce 2026/settlement.md now"));
-
-		expect(out).not.toContain("Divorce");
-		expect(out).toContain("<path>");
-	});
-
-	test("a windows path is blanked", () => {
-		const out = errMsg(new Error("read failed C:\\Users\\t\\Vault\\Therapy\\session.md"));
-
-		expect(out).not.toContain("Therapy");
-		expect(out).toContain("<path>");
-	});
-
-	test("attachments count too", () => {
-		for (const path of ["Medical/scan.png", "Medical/report.pdf", "Medical/board.canvas"]) {
-			expect(errMsg(new Error(`upload failed for ${path}`))).not.toContain("Medical");
-		}
-	});
-
-	// The restraint half. Vault extensions and source extensions do not
-	// overlap, which is what makes anchoring on the former safe.
-	test("a stack frame survives", () => {
-		const out = errMsg(new Error("boom at src/sync.ts:412 in flushToDisk"));
-
-		expect(out).toBe("boom at src/sync.ts:412 in flushToDisk");
-	});
-
-	test("a URL to a script survives", () => {
-		const out = errMsg(new Error("failed to load https://cdn.example.com/lib.js"));
-
-		expect(out).toContain("lib.js");
-	});
-
-	test("an api route survives", () => {
-		expect(errMsg(new Error("POST /api/notes returned 500"))).toBe(
-			"POST /api/notes returned 500",
+	test("a file-like is accepted, like noteRef", () => {
+		expect(errMsg(new Error("boom Medical/x.md"), { path: "Medical/x.md" })).toBe(
+			"boom <path>",
 		);
 	});
 
-	// A filename with no folder names no folder — nothing to disclose, and
-	// blanking it would cost the one clue about WHICH kind of file failed.
-	test("a bare filename with no folder is left alone", () => {
-		expect(errMsg(new Error("could not parse note.md"))).toBe("could not parse note.md");
+	// A rename names two paths and either can appear in the failure.
+	test("both sides of a rename are redacted", () => {
+		const out = errMsg(new Error("EXDEV: Medical/old.md -> Divorce 2026/new.md"), [
+			"Medical/old.md",
+			"Divorce 2026/new.md",
+		]);
+
+		expect(out).not.toContain("Medical");
+		expect(out).not.toContain("Divorce");
+	});
+
+	// A path that is a prefix of another must not redact half the longer one.
+	test("a prefix path does not strand the longer one's tail", () => {
+		const out = errMsg(new Error("copy Medical/a.md to Medical/a.md.bak failed"), [
+			"Medical/a.md",
+			"Medical/a.md.bak",
+		]);
+
+		expect(out).toBe("copy <path> to <path> failed");
+	});
+
+	test("redaction reaches the human half of an fs error", () => {
+		const out = errMsg(
+			new Error("ENOENT: cannot copy Medical/a.md, open '/v/x'"),
+			"Medical/a.md",
+		);
+
+		expect(out).toBe("ENOENT: cannot copy <path>");
+	});
+
+	// Same site, WITHOUT knownPath — which is what actually pins the quoted
+	// scrub of the human half. The test above passes either way: exact
+	// redaction runs before FS_ERROR, so it never exercises the branch it
+	// appears to be about. Verified by reverting the fix and watching only this
+	// one fail.
+	test("the human half is scrubbed with no knownPath at all", () => {
+		const raw = "ENOENT: cannot copy '/v/Medical/a.md', open '/v/x'";
+		expect(raw).toContain("Medical");
+
+		expect(errMsg(new Error(raw))).toBe("ENOENT: cannot copy '<path>'");
+	});
+
+	test("no knownPath behaves exactly as before", () => {
+		expect(errMsg(new Error("Request timed out"))).toBe("Request timed out");
 	});
 });
 
 /**
- * Why the remaining gaps are left open.
+ * Diagnostics the previous heuristic destroyed.
  *
- * The scrub does not catch an UNQUOTED path with an unusual extension, no
- * extension, or a folder with no file. Those are documented as open, and this
- * is the evidence behind that call: every QUOTED form is clean regardless of
- * suffix, because the quoted rule keys on the separator rather than the
- * extension. Node quotes the path in every fs error and Obsidian surfaces
- * Node's, so the covered set is the set that actually occurs.
- *
- * If this ever goes red, the covered set shrank and the decision needs
- * revisiting — that is the entire point of pinning it.
+ * These are not hypothetical: review produced each one against `BARE_PATH`,
+ * where a `/` early in the message merged with a vault extension later and
+ * swallowed everything between. They are pinned because the temptation to
+ * re-add an unquoted-path regex will recur.
  */
-describe("errMsg — quoted paths are clean whatever the suffix", () => {
+describe("errMsg — diagnostics survive", () => {
 	test.each([
-		["an extension outside the vault set", "failed on '/vault/Medical/data.xyz'"],
-		["no extension at all", "failed on '/vault/Medical/untitled'"],
-		["a folder with no file", "EEXIST: file already exists, mkdir '/vault/Medical'"],
-		["a relative path, no extension", "cannot read 'Medical/notes'"],
+		["a route and its status", "POST /api/notes returned 500 for note.md"],
+		[
+			"a URL beside a note",
+			"failed to load https://cdn.example.com/lib.js while saving Inbox/note.md",
+		],
+		["a stack frame", "boom at src/sync.ts:412 in flushToDisk"],
+		["a mime type", "unexpected content-type application/json for note.md"],
 	])("%s", (_name, raw) => {
-		expect(raw).toContain("Medical"); // the leak, before the scrub
+		expect(errMsg(new Error(raw))).toBe(raw);
+	});
+});
+
+/**
+ * The quoted rule, which is the fallback when no `knownPath` is available.
+ *
+ * The apostrophe case is the reason this block exists: the previous interior
+ * class excluded ALL THREE quote characters rather than just its own
+ * delimiter, so a double-quoted path containing `'` could never match — and
+ * apostrophes in note titles are entirely ordinary. The old tests missed it by
+ * using apostrophe-free names.
+ */
+describe("errMsg — quoted paths, no knownPath", () => {
+	test.each([
+		["an apostrophe inside double quotes", `failed to read "Medical/Tom's notes.md"`],
+		["an extension outside any list", "failed on '/vault/Medical/data.xyz'"],
+		["no extension at all", "failed on '/vault/Medical/untitled'"],
+		["a relative path", "cannot read 'Medical/notes'"],
+		// Deliberately NOT an fs-shaped message. The previous version of this row
+		// used `EEXIST: ..., mkdir '/vault/Medical'`, which FS_ERROR matched and
+		// returned before the quoted rule ever ran — so it passed with the quoted
+		// rule disabled entirely and proved nothing about it.
+		["a folder with no file", "cannot create '/vault/Medical'"],
+	])("%s", (_name, raw) => {
+		expect(raw).toContain("Medical");
 		expect(errMsg(new Error(raw))).not.toContain("Medical");
+	});
+
+	// A rejected requestUrl() hands back a plain object. Encoding it to JSON
+	// first turned `"` into `\"`, whose backslash satisfied the separator test,
+	// so the rule matched the wrong span and left the path behind.
+	test("an object carrier with a message is not JSON-mangled", () => {
+		const out = errMsg({ message: `mkdir "/v/Medical" failed` });
+
+		expect(out).toBe("mkdir '<path>' failed");
+		expect(out).not.toContain("Medical");
+	});
+});
+
+/**
+ * ReDoS regression.
+ *
+ * The deleted heuristic was roughly cubic: 6.4 KB of input took 57 SECONDS,
+ * synchronously, on Obsidian's renderer thread. `errMsg` has ~87 call sites, so
+ * that was a UI freeze reachable from any error carrying a base64 body or an
+ * HTML error page. The bound is deliberately loose — it is catching a
+ * complexity class, not measuring a machine.
+ */
+describe("errMsg — cannot be made to hang", () => {
+	test.each([
+		["separator-dense, 12 KB", "a/".repeat(6400)],
+		["base64-like with slashes", "SGVsbG8vV29ybGQ+PDw/Pz8vLy8vYWJjZGVm".repeat(60)],
+		["quote-dense", `"a/b" `.repeat(4000)],
+		["72 KB", "x/".repeat(36000)],
+	])("%s", (_name, input) => {
+		const started = performance.now();
+		errMsg(new Error(input));
+
+		expect(performance.now() - started).toBeLessThan(500);
 	});
 });

--- a/tests/source-compliance.test.ts
+++ b/tests/source-compliance.test.ts
@@ -470,7 +470,13 @@ describe("privacy — no content retention for export", () => {
 		// previous `includes("noteRef(")` test exempted the whole expression on
 		// the strength of one safe call inside it, so concatenating a raw path
 		// onto a wrapped one was a free pass.
-		const WRAPPED_ONLY = /^(noteRef|beaconRoute)\((?:[^()]|\([^()]*\))*\)$/;
+		//
+		// `errMsg` is here because its SECOND argument is a path handed over to
+		// be redacted: `errMsg(e, path)` removes that exact string from the
+		// error text. Passing a path there is the fix, not the violation, and a
+		// guard that flags the fix gets switched off. Still whole-expression,
+		// so `errMsg(e) + path` is caught.
+		const WRAPPED_ONLY = /^(noteRef|beaconRoute|errMsg)\((?:[^()]|\([^()]*\))*\)$/;
 
 		const findings: Finding[] = [];
 		let inspected = 0;


### PR DESCRIPTION
**Supersedes the decision this branch originally recorded.** Adversarial review refuted it: the "disclosure nobody has seen" was already happening for ordinary note titles, and the heuristic defending against it was a UI-freeze bug.

### `BARE_PATH` (shipped in #437) is deleted

| | |
|---|---|
| **ReDoS** | 6.4 KB input took **57 seconds** synchronously on Obsidian's renderer thread (roughly cubic — lazy class that didn't exclude whitespace rescanned the tail per backtrack point). Now **0.06 ms**; 72 KB in 0.16 ms. |
| **Leaked the common case** | Both classes excluded `' " ` , ; : ( ) [ ]` — all legal in note titles. `Medical/Tom's notes.md`, `Medical/Q&A (2026).md`, `Medical/Notes, 2026.md` all went out in clear. |
| **Ate diagnostics** | `POST /api/notes returned 500 for note.md` → `POST <path>`. |

### Replaced with exact redaction

`errMsg(e, knownPath)` removes that literal string. Complete by construction — indifferent to quoting, extension, or whether the target is a file at all; can't damage a diagnostic it wasn't given; can't backtrack. Wired through all **29** sites that log about a specific note (they already held the path, next to `noteRef(path)`). Takes an array so a rename redacts both sides, longest-first so a prefix can't strand the longer path's tail.

### Two more leaks found by the same review

- `QUOTED_PATH` excluded all three quote chars from its interior, not just its delimiter — a double-quoted path containing an apostrophe could never match.
- `FS_ERROR`'s early return skipped every rule below it, so a quoted path in the human half survived.
- Non-Error carriers were JSON-encoded first; the resulting `\"` escapes satisfied the separator test and matched the wrong span.

### Verification

Every mechanism guard-proven by reverting it: knownPath redaction (13 fail), QUOTED_PATH (9), the apostrophe fix (1), fs human half (1), JSON carrier (1). That exercise caught one of my own new tests being **vacuous** — exact redaction ran before `FS_ERROR`, so the human-half test passed with the fix reverted; it now has a no-knownPath twin that actually pins the branch.

2659 tests, lint, obsidian lint, build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSkffYPSctocGCCMPdrorC