### PR TITLE
fix(sync): a freshly minted note_id is never server-known

### DIFF
--- a/docs/context/path-keyed-oracle-id-keyed-wire.md
+++ b/docs/context/path-keyed-oracle-id-keyed-wire.md
@@ -1,0 +1,102 @@
+# Context Doc: a path-keyed oracle must not gate an id-keyed wire
+
+_Last verified: 2026-08-18 (release-v0.17.0 e2e-clerk, 2/2 attempts)_
+
+## Status
+Fixed. Found by e2e `test_27_empty_note_sync` blocking the prod deploy gate,
+not by a user report — but the same shape was already reaching users.
+
+## The one-line rule
+
+**`hasServerNote(id)` answers a question about a PATH.** If you use it to decide
+whether the SERVER knows an ID, you will send frames the backend drops.
+
+```ts
+hasServerNote(noteId) {
+  const path = this.noteIdMap?.pathForId(noteId);  // id -> path
+  if (!path) return false;
+  return this.getCrdtHead(path) != null;           // ...but this is a PATH fact
+}
+```
+
+`getCrdtHead` reads `syncState.get(path)?.crdtHead`, and `setCrdtHead`'s own
+comment says it: *"crdtHead persists under the vault path."* The CRDT wire is
+keyed by `note_id`. Those are different keys, and nothing reconciles them.
+
+## How it fails
+
+A path keeps its head across an id change. So an id minted *seconds ago* for a
+path whose server row already exists inherits that path's "the server knows
+this" verdict:
+
+```
+route: n90 ... server=false id=01a0145d-cd61-…   create — server row keyed cd61
+modify path=E2E/EmptyNote.md bytes=44
+route: n90 ... server=true  id=01a0145d-d1a9-…   id-map entry lost -> fresh mint
+CRDT push ok: n90
+crdt_msg dropped by server (note_not_found): 01a0145d-d1a9-…
+```
+
+`server=true` for `d1a9` is the lie. The backend never issued `d1a9`, so it
+drops the frame and the 44 bytes are gone.
+
+**Reading uuid7 as a clock is what proved it.** The first 48 bits are the mint
+timestamp in ms: `0x01a0145dd1a9 - 0x01a0145dcd61 = 17480` — `d1a9` was minted
+17.5 s after `cd61`. That is a *second id for a note that already had one*, not
+a redelivery. Do this before theorising; it is free and it is decisive.
+
+## Why the retry never saved it
+
+`recordCrdtBaseline` banks the transmitted content as the echo baseline the
+instant `routeModify` consumes it into the local Y.Doc — **before any server
+ack**, because normally the live channel carries it from there. A dropped frame
+walks nothing back, so the hoisted echo gate in `pushFile` hash-matches those
+exact bytes and skips every retry:
+
+```
+Echo skip: n90 | hash=1821472990
+Echo skip: n90 | hash=1821472990   ...forever
+```
+
+A recoverable drop becomes permanent content loss. **Success recorded before
+delivery is confirmed is not bookkeeping, it is a lie the guard then enforces.**
+
+## The trigger
+
+The mint only happens because the id-map answered `null` for a claimed path —
+the hiding-layer class in [[crdt-sync-store-hiding-layers]]. That doc covers
+why the entry goes missing. This one covers what the engine does next, which
+was wrong independently: even with a correct map, any future id divergence
+would have produced the same dropped frame.
+
+## The fix
+
+Two guards, both mutation-proven:
+
+1. `mintedNow` — an id minted by *this* push cannot be one the server issued,
+   whatever the path-keyed oracle says. It falls through to the genesis
+   `crdt_create` branch, whose **ADOPT** case already returns the authoritative
+   id for a path the server owns and re-keys the map. The recovery existed; the
+   stale path-keyed head was gating it out.
+2. `clearPushedBaselineForId` — `onCrdtNoteNotFound` un-banks the echo baseline
+   before healing the map, so the retry actually re-sends.
+
+## Testing traps hit while writing this
+
+- **A stub that echoes its input passes by construction.** The first
+  `setCrdtCreate` double was `async (id) => id`, which can never model ADOPT —
+  the test went green against the bug. Model the server (`Map<path, id>`),
+  don't stub it. Same lesson as `modelVaultFs` in #441.
+- **An assertion that loops over `mock.calls` is vacuous when the array is
+  empty.** The first version passed because the push never ran at all. Pair any
+  `for (const call of …)` with an explicit `.length` assertion.
+- **`shouldDeferMint` only covers engine-flushed files.** A locally authored
+  note (the field case, and test_27) is not flushed, so that guard does not
+  apply — a repro built on `applySyncChange` is caught by it and proves nothing.
+
+## Don't do this again
+
+Before using any oracle to gate a transport, check that **the oracle's key and
+the wire's key are the same key**. Prior art in this repo, same shape:
+`do_bare_insert` writes global / reads vault-scoped; content-keyed workers
+reading the facade instead of `authoritative_content`.

--- a/src/crdt/wiring.ts
+++ b/src/crdt/wiring.ts
@@ -19,6 +19,7 @@ type WiringSyncEngine = Pick<
 	| "reconcileNoteIdMapFromManifest"
 	| "isSyncBlocked"
 	| "ensureNoteIdMapped"
+	| "clearPushedBaselineForId"
 	| "applyPushedNoteUpdate"
 	| "discoverAnnouncedNote"
 	| "applyLiveOpWithSeq"
@@ -466,6 +467,12 @@ export function createCrdtWiring(deps: CrdtWiringDeps): CrdtWiring {
 	// and we gate here too, matching the sibling onCrdtDocReady.
 	const onCrdtNoteNotFound = (docId: string): void => {
 		if (syncEngine.isSyncBlocked()) return;
+		// Healing the map is only half of it: the dropped frame's content was
+		// already banked as the echo baseline when routeModify consumed it, so a
+		// re-mapped note would still echo-skip its own undelivered bytes forever.
+		// Un-bank first — the reconcile below can re-key the map out from under
+		// the lookup this needs.
+		syncEngine.clearPushedBaselineForId(docId);
 		syncEngine.ensureNoteIdMapped(docId);
 	};
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1629,6 +1629,26 @@ export class SyncEngine {
 		});
 	}
 
+	/** Un-bank the echo baseline for a frame the server DROPPED (note_not_found).
+	 *
+	 *  `recordCrdtBaseline` stamps the transmitted content the instant
+	 *  `routeModify` consumes it into the local Y.Doc — before any server ack,
+	 *  because the live channel normally carries it from there. When the backend
+	 *  instead drops the frame, nothing walks that stamp back, so the hoisted
+	 *  echo gate in `pushFile` hash-matches those exact bytes and skips every
+	 *  retry: the content is stranded for the life of the vault, not merely
+	 *  delayed. Seen in CI as `Echo skip: <note> | hash=1821472990` repeating
+	 *  forever after a `note_not_found` drop (e2e test_27).
+	 *
+	 *  Resetting to the `hash: 0` no-baseline default is the honest state: we do
+	 *  not know the server has this content, so the next push must re-send it.
+	 *  Never touches crdtHead/version — only the claim about what was delivered. */
+	clearPushedBaselineForId(docId: string): void {
+		const path = this.noteIdMap?.pathForId(docId);
+		if (!path) return;
+		this.patchSyncedRow(normalizePath(path), { hash: 0 });
+	}
+
 	/** Refresh a LIVE-BOUND note's baseline from the autosave that just landed.
 	 *  Fire-and-forget from handleModify's editor-owns-the-file gate (which is
 	 *  synchronous): the read is the same `cachedRead` the push path would have
@@ -3311,6 +3331,10 @@ export class SyncEngine {
 				// or a concurrent push for the same path reuses the same id rather
 				// than minting a second one.
 				let noteId = this.noteIdMap?.get(file.path) ?? null;
+				// An id minted by THIS push cannot be one the server has ever issued,
+				// whatever the path-keyed oracle says. See the `mintedNow` gate on the
+				// CRDT-ops branch below.
+				let mintedNow = false;
 				if (!noteId && this.noteIdMap) {
 					// MINT REFUSAL (issue #972, e2e test_34) — see shouldDeferMint.
 					// Skip the push: the relocation/pull owns this path's fate.
@@ -3323,6 +3347,7 @@ export class SyncEngine {
 					}
 					noteId = uuid7();
 					this.noteIdMap.set(file.path, noteId);
+					mintedNow = true;
 				}
 
 				// Routing observability: which inputs decide CRDT-vs-REST for this
@@ -3362,7 +3387,21 @@ export class SyncEngine {
 				// Live-vs-durable-queue is decided by the post-await `crdtLiveNow`
 				// re-check below (Task 5) — the channel can drop during the awaited
 				// `routeModify` seed.
-				if (this.crdt && noteId && this.hasServerNote(noteId)) {
+				// `!mintedNow`: hasServerNote is PATH-keyed — it resolves the id to a
+				// path and asks whether that PATH has a crdtHead (recorded under the
+				// vault path; see setCrdtHead). The wire is ID-keyed. So an id minted
+				// moments ago for a path whose server row already exists inherits that
+				// path's "the server knows this" verdict and sends an op under an id
+				// the backend never issued, which it drops as note_not_found — the
+				// bytes are gone, and the echo baseline banked below means no retry
+				// ever re-sends them. Traced in CI (e2e test_27, release-v0.17.0):
+				//   route: … server=false id=…cd61   (create, row keyed cd61)
+				//   route: … server=true  id=…d1a9   (id-map entry lost, fresh mint)
+				//   crdt_msg dropped by server (note_not_found): …d1a9
+				// A fresh mint therefore falls through to the genesis crdt_create
+				// branch, which ADOPTS the server's authoritative id for a path it
+				// already owns and re-keys the map — the recovery that already exists.
+				if (this.crdt && noteId && !mintedNow && this.hasServerNote(noteId)) {
 					const consumed = await routeModify(
 						{
 							crdtEligible: this.isCrdtEligible(file),
@@ -3479,7 +3518,12 @@ export class SyncEngine {
 					this.crdt &&
 					noteId &&
 					this.isCrdtEligible(file) &&
-					!this.hasServerNote(noteId) &&
+					// `mintedNow ||`: same path-vs-id keying trap as the ops branch
+					// above. A fresh mint on a path the server already owns must reach
+					// crdt_create precisely SO THAT the ADOPT branch can hand back the
+					// authoritative id; gating it out on the path's stale head is what
+					// left the note with no route at all.
+					(mintedNow || !this.hasServerNote(noteId)) &&
 					(this.crdtLive?.() ?? true) &&
 					!exceedsCrdtNoteLimit(content, MAX_CRDT_NOTE_BYTES)
 				) {

--- a/tests/sync-note-id.test.ts
+++ b/tests/sync-note-id.test.ts
@@ -1962,3 +1962,129 @@ describe("the origin survives a move the store never announced", () => {
 		expect(mockApp.vault.rename).not.toHaveBeenCalled();
 	});
 });
+
+describe("a re-minted id must never be treated as server-known (e2e test_27, note_not_found content loss)", () => {
+	// Root cause, traced from CI client logs (release-v0.17.0, e2e-clerk):
+	//
+	//   route: n90 ... server=false id=01a0145d-cd61-…   <- create, server row keyed cd61
+	//   modify path=E2E/EmptyNote.md bytes=44
+	//   route: n90 ... server=true  id=01a0145d-d1a9-…   <- FRESH id, minted by pushFile
+	//   CRDT push ok: n90
+	//   crdt_msg dropped by server (note_not_found): 01a0145d-d1a9-…
+	//
+	// `hasServerNote(id)` resolves the id to a PATH and asks whether that PATH
+	// has a crdtHead. The head is recorded under the vault path (see
+	// setCrdtHead's own comment), so an id minted seconds ago for a path that
+	// already has a server row inherits that path's "the server knows this"
+	// verdict — and routes over the id-keyed CRDT ops branch, which the backend
+	// drops as note_not_found because it never issued that id. The oracle is
+	// path-keyed; the wire is id-keyed.
+	//
+	// Asserts the INVARIANT (which id reaches the wire), not the mechanism, so
+	// it survives a change in how the id is recovered.
+	test("a lost id-map entry on a server-known path must not send a freshly minted id", async () => {
+		const engine = createEngine();
+		const noteIdMap = new NoteIdMap();
+		engine.setNoteIdMap(noteIdMap);
+		const applyLocalEdit = mock(async (_id: string, c: string) => c);
+		engine.setCrdtManager({ applyLocalEdit } as any);
+		engine.setCrdtEnrollment({ enroll: mock(() => {}) } as any);
+		engine.setCrdtLiveCheck(() => true);
+		// Model the server's crdt_create, not a stub that echoes: a path the
+		// server already owns comes back with the AUTHORITATIVE id (the ADOPT
+		// branch), which is the whole recovery mechanism under test. An echoing
+		// stub would hand back the client's fresh mint and pass by construction.
+		const serverRows = new Map<string, string>();
+		engine.setCrdtCreate(async (id: string, p: string) => {
+			const existing = serverRows.get(p);
+			if (existing) return existing;
+			serverRows.set(p, id);
+			return id;
+		});
+
+		// Device A authors the note itself: an EMPTY note takes the socket-native
+		// genesis path, which creates the server row under the client's mint and
+		// flips the hasServerNote oracle for the PATH. Nothing marks the file
+		// engine-flushed, so shouldDeferMint (which covers only engine-written
+		// files) does not apply here — this is the field shape.
+		const path = "Notes/Empty.md";
+		const file = new TFile(path, Date.now());
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue("");
+		await (engine as any).pushFile(file);
+
+		const serverId = noteIdMap.get(path);
+		expect(serverId).toBeTruthy(); // genesis really did run and claim an id
+
+		// The id-map entry is lost. In the field this is a SyncStore hiding layer
+		// that never expired (docs/context/crdt-sync-store-hiding-layers.md); the
+		// engine cannot tell that apart from a path it has never seen.
+		noteIdMap.delete(path);
+
+		// The note's first real content lands on disk.
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(
+			"# No Longer Empty\nThis note has content now.",
+		);
+		applyLocalEdit.mockClear();
+		await (engine as any).pushFile(file);
+
+		// An id-keyed CRDT op may only be sent under an id the server issued.
+		// Sending under a fresh mint is the bug: the backend drops the frame as
+		// note_not_found and the bytes are gone.
+		for (const call of applyLocalEdit.mock.calls) {
+			expect(call[0]).toBe(serverId);
+		}
+		// And the push must not have silently done nothing, which would strand
+		// the content just as surely (guards the assertion above against being
+		// vacuous).
+		expect(applyLocalEdit.mock.calls.length).toBeGreaterThan(0);
+	});
+
+	// Second defect, independent of the first: the echo-hash baseline is banked
+	// the instant routeModify consumes the edit into the local Y.Doc
+	// (sync.ts recordCrdtBaseline, "CRDT push ok"), with no server ack. When the
+	// server then drops the frame, nothing un-banks it — so every later push of
+	// that same content is `Echo skip` and the bytes are stranded for good.
+	// Observed in CI as `Echo skip: n90 | hash=1821472990` repeating after the
+	// note_not_found drop.
+	test("a frame the server dropped must not leave the content echo-skipped forever", async () => {
+		const engine = createEngine();
+		const noteIdMap = new NoteIdMap();
+		engine.setNoteIdMap(noteIdMap);
+		const applyLocalEdit = mock(async (_id: string, c: string) => c);
+		engine.setCrdtManager({ applyLocalEdit } as any);
+		engine.setCrdtEnrollment({ enroll: mock(() => {}) } as any);
+		engine.setCrdtLiveCheck(() => true);
+
+		await engine.applySyncChange({
+			id: "id-dropped",
+			path: "Notes/Dropped.md",
+			title: "Dropped",
+			content: "",
+			folder: "",
+			tags: [],
+			mtime: 1,
+			updated_at: "2026-01-01T00:00:00Z",
+			deleted: false,
+			version: 1,
+		} as any);
+		(engine as unknown as { setCrdtHead(p: string, h: string): void }).setCrdtHead(
+			"Notes/Dropped.md",
+			"server-head",
+		);
+
+		const body = "# No Longer Empty\nThis note has content now.";
+		(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockResolvedValue(body);
+		const file = new TFile("Notes/Dropped.md", Date.now());
+		await (engine as any).pushFile(file);
+		expect(applyLocalEdit).toHaveBeenCalled();
+
+		// The server rejects the frame: it never issued this note_id.
+		(engine as any).clearPushedBaselineForId(noteIdMap.get("Notes/Dropped.md"));
+
+		// The same bytes are still on disk and still undelivered. A retry must
+		// actually re-send them rather than hash-match the banked baseline.
+		applyLocalEdit.mockClear();
+		await (engine as any).pushFile(file);
+		expect(applyLocalEdit).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## What

`hasServerNote(id)` resolves the id to a **path** and asks whether that PATH has a `crdtHead`. The head is recorded under the vault path — `setCrdtHead`'s own comment says so. The CRDT wire is **id-keyed**. Those are different keys, and nothing reconciles them.

So an id minted moments ago for a path whose server row already exists inherits that path's "the server knows this" verdict, routes over the id-keyed ops branch, and the backend drops the frame as `note_not_found`.

## Evidence

Traced from CI client logs on `release-v0.17.0`, e2e-clerk `test_27_empty_note_sync`, **2/2 consecutive attempts** (this is what refused the prod deploy):

```
route: n90 ... server=false id=01a0145d-cd61-…   create — server row keyed cd61
modify path=E2E/EmptyNote.md bytes=44
route: n90 ... server=true  id=01a0145d-d1a9-…   id-map entry lost -> fresh mint
CRDT push ok: n90
crdt_msg dropped by server (note_not_found): 01a0145d-d1a9-…
```

uuid7's leading 48 bits are the mint clock: `0x01a0145dd1a9 - 0x01a0145dcd61 = 17480` ms. `d1a9` was minted 17.5 s after `cd61` — a second id for a note that already had one, not a redelivery.

## Two defects

**1 — the false-positive oracle.** A fresh mint now falls through to the genesis `crdt_create` branch, whose **ADOPT** case already returns the server's authoritative id for a path it owns and re-keys the map. The recovery existed; the stale path-keyed head was gating it out.

**2 — success banked before the ack.** `recordCrdtBaseline` stamps the transmitted content as the echo baseline the instant `routeModify` consumes it locally. A dropped frame walks nothing back, so every retry hash-matches and is echo-skipped — `Echo skip: n90 | hash=1821472990`, forever. That turns a recoverable drop into **permanent content loss**. `onCrdtNoteNotFound` now un-banks before healing the map.

The mint itself only happens because the id-map answered `null` for a claimed path — the hiding-layer class in `docs/context/crdt-sync-store-hiding-layers.md`. That's the trigger; both defects above are wrong independently of it.

## Testing

Tests assert the **invariant** (which id reaches the wire), not the mechanism. Three mutations, each kills exactly one test:

| Mutation | Result |
|---|---|
| drop `!mintedNow` from the ops gate | 1 fail |
| `clearPushedBaselineForId` → no-op | 1 fail |
| drop `mintedNow \|\|` from the genesis gate | 1 fail |

Traps hit and written down in the new context doc: an echoing `crdt_create` stub passes by construction (modelled the server instead); a `for (const call of mock.calls)` assertion is vacuous on an empty array; `shouldDeferMint` only covers engine-flushed files, so an `applySyncChange`-based repro proves nothing.

Full gauntlet: tsc, biome, `lint:obsidian`, **2784 pass / 1 skip / 0 fail**.

## Why this matters now

1.23.0 was published and has been demoted to pre-release — `/releases/latest` serves 1.22.0 again — because this strands a note's content silently, with no user-visible error. Backend `release-v0.17.0` is tagged but undeployed; prod is still on 0.16.0.

Refs #355