### PR TITLE
fix(sync): stop offering freshly pulled notes back as uploads

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -8521,7 +8521,26 @@ export class SyncEngine {
 		// is not "new" — the tombstone branch owns it (delete-wins; pushing would
 		// fight the <60s recreate refusal).
 		for (const path of localNotes) {
-			if (!serverNotes.has(path)) toPushNotes.push(path);
+			if (serverNotes.has(path)) continue;
+			// ...nor is a path the server DEMONSTRABLY holds, however stale the
+			// enumeration above is. `crdtHead` is written only by a server-delivered
+			// head or a confirmed create (see `markServerKnown`), so a non-null head
+			// means the row exists server-side and this snapshot is merely older than
+			// the pull that just landed the file.
+			//
+			// Without this, any re-plan DURING a sync — and a reconnect fires one —
+			// offers the freshly downloaded vault straight back as an upload. That is
+			// the "N files to upload" symptom (prod 2026-08-13; seen again 2026-08-19
+			// as the preview flipping mid-run to upload what it had just downloaded).
+			//
+			// #424 fixed the WRITE-ROUTING half of this (pushFile consults
+			// `hasServerNote`) and left the planner classifying on the snapshot alone:
+			// one question asked of two predicates, only one of them wired up. That
+			// split is why `test_90` stayed green — it asserts `pushed == 0`,
+			// downstream of the miscount — while the number the modal renders stayed
+			// wrong. Keep these two reading the same oracle.
+			if (this.getCrdtHead(path) != null) continue;
+			toPushNotes.push(path);
 		}
 
 		// Categorise server attachment rows

--- a/tests/sync-plan.test.ts
+++ b/tests/sync-plan.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, jest, mock, test } from "bun:test";
 import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
-import { fnv1a, SyncEngine } from "../src/sync";
+import { CRDT_HEAD_CREATED, fnv1a, SyncEngine } from "../src/sync";
 import type { SyncProgress } from "../src/types";
 import { DEFAULT_SETTINGS } from "../src/types";
 
@@ -401,6 +401,44 @@ describe("SyncEngine.computeSyncPlan", () => {
 		expect(plan.toPush.notes).toContain("Notes/another.md");
 		expect(plan.toPull.notes).toEqual([]);
 		expect(plan.localNoteCount).toBe(2);
+	});
+
+	// A re-plan mid-run (a reconnect fires one) enumerates a server snapshot that
+	// can predate the pull that just landed these files. Classifying on the
+	// snapshot ALONE then offers the freshly-downloaded vault straight back as an
+	// upload — the "N files to upload" symptom, reported again 2026-08-19 as the
+	// preview flipping to uploading what it had just downloaded.
+	//
+	// `crdtHead` is the second half of the answer and the pull path already
+	// records it (`markServerKnown`), but `computeSyncPlan` never consulted it:
+	// one question, two predicates, and only one of them was wired up. The
+	// 2026-08-13 fix taught the WRITE-ROUTING leg (`hasServerNote`) and left the
+	// planner reading the snapshot alone, which is why `test_90` stayed green
+	// (it asserts `pushed == 0`, downstream of the miscount) while the number the
+	// modal renders stayed wrong.
+	test("a freshly PULLED note is not offered back as an upload when the server snapshot lags", async () => {
+		const engine = createEngine();
+		mockApp.vault.getFiles.mockReturnValue([makeTFile("Notes/pulled.md")]);
+		// Snapshot predates the pull: the op-log knows nothing about this path.
+		wireFeed(engine, [[]]);
+		// What the pull path leaves behind for a note the server demonstrably holds.
+		(engine as any).syncState.set("Notes/pulled.md", { crdtHead: CRDT_HEAD_CREATED });
+
+		const plan = await engine.computeSyncPlan("full");
+
+		expect(plan.toPush.notes).not.toContain("Notes/pulled.md");
+	});
+
+	// The fence above must not swallow genuinely local-only notes: absent a
+	// recorded head, an unknown path is still new and still uploads.
+	test("a local-only note with no recorded head still counts as toPush", async () => {
+		const engine = createEngine();
+		mockApp.vault.getFiles.mockReturnValue([makeTFile("Notes/brand-new.md")]);
+		wireFeed(engine, [[]]);
+
+		const plan = await engine.computeSyncPlan("full");
+
+		expect(plan.toPush.notes).toContain("Notes/brand-new.md");
 	});
 
 	test("server rows not present locally are counted as toPull", async () => {


### PR DESCRIPTION
## The bug

`computeSyncPlan` classifies a local path as "to push" whenever the enumerated server snapshot does not contain it:

```ts
for (const path of localNotes) {
  if (!serverNotes.has(path)) toPushNotes.push(path);
}
```

A re-plan **during** a sync, and a reconnect fires one, runs against a snapshot that can predate the pull that just landed those files. So the freshly downloaded vault gets offered straight back as an upload.

Reported again 2026-08-19: mid-import the preview flipped to uploading the files it had just downloaded. Staging logs for that run show 3 channel reconnects, which is what triggers the re-plan.

## Why the existing fence did not catch it

The pull path already records `crdtHead` for every note the server demonstrably holds (`markServerKnown`). The planner never consulted it. **One question asked of two predicates, with only one of them wired up.**

#424 fixed the *write-routing* half (`pushFile` consults `hasServerNote`) and left the planner classifying on the snapshot alone. That split is exactly why `test_90_first_sync_pull_no_phantom_push` stayed green: it asserts `pushed == 0`, which is downstream of the miscount and correctly suppressed. The number the modal renders is computed upstream, in the leg that was never fixed. The fence and the symptom sit on opposite sides of the defect.

This is the third instance of the "two predicates that both claim to count the notes" trap already generalised in `first-sync-anatomy.md`.

## The fix

Consult the same oracle the write path uses. `crdtHead` is written only by a server-delivered head or a confirmed create, so a non-null head means the row exists server-side and the snapshot is merely older than the pull.

## Tests

- `a freshly PULLED note is not offered back as an upload when the server snapshot lags` (fails on `main`, verified red first)
- `a local-only note with no recorded head still counts as toPush` (guards the fence against swallowing genuine uploads)

## Verification

- `bun test`: **2802 pass, 1 skip, 0 fail**
- `tsc --noEmit`: clean
- `biome ci`: clean

## Known gap

`toPushAttachments` has the same shape, but attachments carry no server-known oracle, so they are untouched here and remain exposed to the same phantom-upload class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp