### PR TITLE
fix(vault): stop one sync creating two vaults

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -426,17 +426,6 @@ export class EngramApi {
 		return resp.json as VaultRegistrationResponse;
 	}
 
-	/** Create a brand-new, distinct vault for the current user. Unlike
-	 *  registerVault (idempotent by client_id), this always makes a new vault.
-	 *  Throws with status 402 if the user has reached their vault limit, or 422
-	 *  on validation errors. */
-	async createVault(name: string): Promise<VaultInfo> {
-		const resp = await this.request("POST", "/vaults", { name });
-		const vault = (resp.json as { vault?: VaultInfo }).vault;
-		if (!vault) throw new Error("Malformed /vaults response: missing vault");
-		return vault;
-	}
-
 	/** Fetch all vaults accessible by the current user. Throws the underlying
 	 *  request error (with `.status` for HTTP responses) so callers can render
 	 *  401/timeout/5xx distinctly from "successful empty list". */

--- a/src/main.ts
+++ b/src/main.ts
@@ -2740,7 +2740,19 @@ export default class EngramSyncPlugin extends Plugin {
 					attachmentsTextOnly:
 						this.syncEngine.getPlanState()?.attachmentsTextOnly ?? false,
 					listVaults: () => this.api.listVaults(),
-					createVault: (name) => this.api.createVault(name),
+					// registerVault, NOT createVault: it is idempotent by client_id, so
+					// a retried or double-submitted create resolves to the SAME vault
+					// instead of making another one. createVault always makes a new
+					// vault, which is how one sync produced two vaults on 2026-08-20
+					// (292 notes orphaned in the first, 319 re-uploaded into the
+					// second). The modal mints one client_id per form visit.
+					createVault: async (name, clientId) => {
+						const reg = await this.api.registerVault(name, clientId);
+						// /vaults/register returns the vault flat, without created_at.
+						// The picker only reads id/name/slug/is_default; created_at is
+						// filled so the shape stays a VaultInfo for every consumer.
+						return { ...reg, created_at: new Date().toISOString() };
+					},
 					applyVaultChange: async (id, name) => {
 						// The picker lists EVERY vault including the active one, so a
 						// user can "change" to the vault they are already on. That is

--- a/src/sync-preview-modal.ts
+++ b/src/sync-preview-modal.ts
@@ -36,6 +36,12 @@ export class SyncPreviewState {
 	/** Within the vault-picker, true while the "make a new vault" form is shown
 	 *  instead of the list of existing vaults. */
 	creatingVault = false;
+	/** Stable across retries of ONE create-vault form session — see
+	 *  enterCreateVault. Null when not on the form. */
+	createVaultClientId: string | null = null;
+	/** Guards against a second submit landing while the first POST is still in
+	 *  flight. `vaultsLoading` is a RENDER flag, not a lock. */
+	createVaultInFlight = false;
 	/** Whether the "advanced sync options" accordion (push/pull grid) is
 	 *  expanded. Collapsed by default so the modal leads with the Sync action. */
 	advancedOpen = false;
@@ -98,11 +104,18 @@ export class SyncPreviewState {
 		if (this.resolved) return;
 		this.creatingVault = true;
 		this.vaultsError = null;
+		// Minted ONCE per visit to the form, not per submit. That is what makes a
+		// retry idempotent: the same client_id resolves to the same vault
+		// server-side, so a double-submit returns the first vault instead of
+		// creating a second one.
+		this.createVaultClientId = crypto.randomUUID();
 	}
 
 	exitCreateVault(): void {
 		this.creatingVault = false;
 		this.vaultsError = null;
+		this.createVaultClientId = null;
+		this.createVaultInFlight = false;
 	}
 
 	onVaultsLoaded(vaults: VaultInfo[]): void {
@@ -312,7 +325,7 @@ export interface SyncPreviewOptions {
 	/** Creates a brand-new vault and returns it. When provided, the picker shows
 	 *  a "Make new vault" affordance. The created vault is then selected via
 	 *  applyVaultChange so the preview recalculates against the empty remote. */
-	createVault?: (name: string) => Promise<VaultInfo>;
+	createVault?: (name: string, clientId: string) => Promise<VaultInfo>;
 	/** Initial view the modal opens on. Defaults to "preview". Set to
 	 *  "vault-picker" when the user entered the modal via a "Change vault"
 	 *  affordance on the settings page. */
@@ -1125,12 +1138,23 @@ export class SyncPreviewModal extends Modal {
 			this.render();
 			return;
 		}
+		// A second submit while the first POST is still open creates a SECOND
+		// vault: observed 2026-08-20, one sync producing two vaults (292 notes
+		// orphaned, 319 re-uploaded into the replacement). vaultsLoading only
+		// drives rendering, so it cannot serve as the lock.
+		if (this.state.createVaultInFlight) return;
+		this.state.createVaultInFlight = true;
+
+		const clientId = this.state.createVaultClientId ?? crypto.randomUUID();
+		this.state.createVaultClientId = clientId;
+
 		this.state.vaultsLoading = true;
 		this.render();
 		let created: VaultInfo;
 		try {
-			created = await this.opts.createVault(trimmed);
+			created = await this.opts.createVault(trimmed, clientId);
 		} catch (e: unknown) {
+			this.state.createVaultInFlight = false;
 			this.state.vaultsLoading = false;
 			this.state.onVaultsError(describeCreateVaultError(e));
 			this.state.creatingVault = true; // remain on the form so the user can retry

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -555,53 +555,6 @@ describe("EngramApi", () => {
 		});
 	});
 
-	describe("createVault", () => {
-		test("sends POST to /vaults with the name and returns the created vault", async () => {
-			mockRequestUrl.mockResolvedValueOnce({
-				status: 201,
-				json: {
-					vault: {
-						id: "vault-9",
-						name: "Fresh",
-						slug: "fresh",
-						is_default: false,
-						created_at: "2026-01-01T00:00:00Z",
-					},
-				},
-			} as any);
-			const result = await api.createVault("Fresh");
-			expect(mockRequestUrl).toHaveBeenCalledWith(
-				expect.objectContaining({
-					url: `${TEST_API_BASE}/vaults`,
-					method: "POST",
-					body: JSON.stringify({ name: "Fresh" }),
-				}),
-			);
-			expect(result).toEqual({
-				id: "vault-9",
-				name: "Fresh",
-				slug: "fresh",
-				is_default: false,
-				created_at: "2026-01-01T00:00:00Z",
-			});
-		});
-
-		test("throws LimitExceededError on 402", async () => {
-			mockRequestUrl.mockRejectedValueOnce({
-				status: 402,
-				json: {
-					error: "limit_exceeded",
-					reason: "vaults_cap_exceeded",
-					limit_key: "vaults_cap",
-					limit: 1,
-					current: 1,
-					upgrade_url: "https://app.engram.page/settings/billing",
-				},
-			});
-			await expect(api.createVault("Over limit")).rejects.toBeInstanceOf(LimitExceededError);
-		});
-	});
-
 	// -------------------------------------------------------------------------
 	// 402 standardization — see spec §4.6
 	// All write paths returning 402 must surface a LimitExceededError carrying

--- a/tests/sync-preview-modal.test.ts
+++ b/tests/sync-preview-modal.test.ts
@@ -494,3 +494,41 @@ describe("emptyPlanDismiss — the nothing-to-sync screen", () => {
 		expect(emptyPlanDismiss(false)).toEqual({ label: "Close", accept: false });
 	});
 });
+
+describe("SyncPreviewState — duplicate-vault guard (2026-08-20)", () => {
+	// One sync produced TWO vaults: 292 notes orphaned in the first, 319
+	// re-uploaded into the second created two minutes later. Both had
+	// client_id=nil, the signature of POST /vaults (always creates) rather than
+	// POST /vaults/register (idempotent by client_id).
+	test("entering the form mints a client id, exiting clears it", () => {
+		const s = new SyncPreviewState();
+		expect(s.createVaultClientId).toBeNull();
+		s.enterCreateVault();
+		expect(typeof s.createVaultClientId).toBe("string");
+		s.exitCreateVault();
+		expect(s.createVaultClientId).toBeNull();
+	});
+
+	// The whole point: a retry after a failed submit must reuse the SAME id, so
+	// the server resolves it to the vault the first attempt may already have
+	// created instead of making another.
+	test("the client id survives an error so a retry is idempotent", () => {
+		const s = new SyncPreviewState();
+		s.enterCreateVault();
+		const first = s.createVaultClientId;
+		s.onVaultsError("boom");
+		expect(s.createVaultClientId).toBe(first);
+	});
+
+	test("the in-flight flag is a real lock, not the render flag", () => {
+		const s = new SyncPreviewState();
+		s.enterCreateVault();
+		expect(s.createVaultInFlight).toBe(false);
+		s.createVaultInFlight = true;
+		// vaultsLoading drives rendering only; it must not double as the lock.
+		s.vaultsLoading = false;
+		expect(s.createVaultInFlight).toBe(true);
+		s.exitCreateVault();
+		expect(s.createVaultInFlight).toBe(false);
+	});
+});


### PR DESCRIPTION
## What happened

One user action — create a vault and sync — produced **two vaults**, two minutes apart:

```
b87e6c7a  created 08:37:32  →  292 notes  (abandoned mid-sync)
32f46dbb  created 08:43:34  →  319 notes  (completed)
```

Four vaults were created locally today, **every one with `client_id = nil`**. That is the signature of `POST /vaults`, not `POST /vaults/register`.

The first vault's 292 uploads were orphaned and the whole vault re-uploaded into the replacement.

## Two causes, both client-side

**1. No in-flight lock.** `applyCreateVault` sets `vaultsLoading` and re-renders, but that is a *render* flag. A second submit landing while the first POST is still open runs the entire path again and creates another vault. Adds `createVaultInFlight`, cleared on both the error path and on exit.

**2. The wrong endpoint.** The picker called `api.createVault` — whose own docstring says *"Unlike registerVault (idempotent by client_id), this always makes a new vault."* `api.registerVault` already existed and nothing was using it, which is exactly why every vault has `client_id = nil`.

The picker now registers, with a `client_id` minted **once per visit to the form** rather than per submit — so a retry after a failure resolves to the vault the first attempt may already have created, instead of making a second one.

## Server needs no change

It offers both endpoints and behaves correctly. The plugin was choosing the wrong one.

## Why this matters beyond a stray vault

- An interrupted first sync **abandons its uploads and redoes them** — double the work, double the server load
- The user is left with a duplicate vault in the picker
- It silently inflates any per-note measurement taken against these vaults

## Tests

Three covering the state contract that makes retries idempotent: the id is minted on entry, **survives an error** (the retry case), and is cleared on exit along with the lock.

## Verification

`bun test`: **2815 pass, 1 skip, 0 fail** · `tsc --noEmit` clean · `biome ci` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp