### PR TITLE
fix(plan): drop the plan verdict when the server changes

### DIFF
--- a/src/auth-state.ts
+++ b/src/auth-state.ts
@@ -131,6 +131,16 @@ const CLEARED_AUTH_VALUES = {
 	accessToken: undefined,
 	accessTokenExpiresAt: undefined,
 	accessTokenVaultId: undefined,
+	// Not a credential, but a VERDICT the old backend issued about this user —
+	// and pointing the same mode at a different server is exactly when it stops
+	// applying. A mode switch stashes it (switching back to Cloud restores the
+	// Cloud plan); a URL change to a different backend must WIPE it, because the
+	// new server has said nothing yet. Leaving it set carried a Cloud Free-tier
+	// "notes only" verdict onto a self-hosted server, where `preGateAttachment`
+	// then skipped every image and PDF client-side without ever asking — the
+	// server would have accepted them. Null is the safe value: an unknown plan
+	// makes preGateAttachment fall through and let the backend decide.
+	planState: null,
 } as const satisfies Partial<Record<BackendScopedField, unknown>>;
 
 /** Returns a copy of settings with all backend-scoped auth state cleared.

--- a/src/plan-state.ts
+++ b/src/plan-state.ts
@@ -17,7 +17,18 @@ export function parsePlanState(raw: unknown, now: number): PlanState | null {
 		// Validate, don't cast: an unknown backend tier ("team", a typo) must
 		// degrade to the most restrictive plan, not launder through the union.
 		tier: r.tier === "starter" || r.tier === "pro" ? r.tier : "free",
-		attachmentsTextOnly: r.attachments_text_only === true,
+		// MIGRATE step. The backend renamed this to the grant-shaped
+		// `attachments_all_types` (true == allowed) because the old
+		// restriction-shaped spelling inverted the meaning of "no limits" and
+		// silently blocked attachments on self-hosted servers. Prefer the new
+		// field; fall back to the legacy one so this build still works against
+		// a backend older than the rename. Falls back to permissive when
+		// NEITHER field is present, matching preGateAttachment's "unknown plan
+		// → let the backend decide" direction.
+		attachmentsTextOnly:
+			typeof r.attachments_all_types === "boolean"
+				? r.attachments_all_types === false
+				: r.attachments_text_only === true,
 		maxFileBytes: typeof r.max_file_bytes === "number" ? r.max_file_bytes : 0,
 		attachmentBytesCap:
 			typeof r.attachment_bytes_cap === "number" ? r.attachment_bytes_cap : null,

--- a/tests/auth-state.test.ts
+++ b/tests/auth-state.test.ts
@@ -181,6 +181,27 @@ describe("withClearedAuth", () => {
 		expect(cleared.accessTokenVaultId).toBeUndefined();
 	});
 
+	test("clears the plan verdict — it belongs to the backend that issued it", () => {
+		// A tier verdict is scoped to the server that sent it. Carrying a Cloud
+		// Free-tier "notes only" plan onto a self-hosted server made
+		// preGateAttachment skip every image and PDF client-side, with no
+		// network call, on a server that would have accepted them. Null (not
+		// false) is required: unknown plan is what makes the pre-gate fall
+		// through and let the backend decide.
+		const cleared = withClearedAuth(
+			fullSettings({
+				planState: {
+					tier: "free",
+					attachmentsTextOnly: true,
+					maxFileBytes: 10_485_760,
+					attachmentBytesCap: null,
+					updatedAt: 1,
+				},
+			}),
+		);
+		expect(cleared.planState).toBeNull();
+	});
+
 	test("preserves apiUrl, clientId, and unrelated settings", () => {
 		const before = fullSettings({
 			apiUrl: "http://engram.ax",

--- a/tests/plan-state.test.ts
+++ b/tests/plan-state.test.ts
@@ -74,3 +74,40 @@ describe("tier validation (repo-review 2026-08)", () => {
 		expect(parsePlanState({ tier: "free" }, 1)?.tier).toBe("free");
 	});
 });
+
+describe("parsePlanState — attachments_all_types migration", () => {
+	const base = { tier: "free", max_file_bytes: 10, attachment_bytes_cap: null };
+
+	test("reads the grant-shaped field: true means non-text allowed", () => {
+		const p = parsePlanState({ ...base, attachments_all_types: true }, 1);
+		expect(p?.attachmentsTextOnly).toBe(false);
+	});
+
+	test("reads the grant-shaped field: false means text-only", () => {
+		const p = parsePlanState({ ...base, attachments_all_types: false }, 1);
+		expect(p?.attachmentsTextOnly).toBe(true);
+	});
+
+	test("the new field WINS over the legacy one while both ship", () => {
+		// The backend dual-emits during expand. If they ever disagreed, the
+		// grant-shaped field is the one derived from the single source of truth.
+		const p = parsePlanState(
+			{ ...base, attachments_all_types: true, attachments_text_only: true },
+			1,
+		);
+		expect(p?.attachmentsTextOnly).toBe(false);
+	});
+
+	test("falls back to the legacy field against an older backend", () => {
+		const p = parsePlanState({ ...base, attachments_text_only: true }, 1);
+		expect(p?.attachmentsTextOnly).toBe(true);
+	});
+
+	test("neither field present → permissive, so the backend decides", () => {
+		// Fail-open matches preGateAttachment's "unknown plan → do not pre-gate".
+		// Failing closed here would silently skip every attachment, which is the
+		// bug this whole change exists to remove.
+		const p = parsePlanState(base, 1);
+		expect(p?.attachmentsTextOnly).toBe(false);
+	});
+});


### PR DESCRIPTION
Pairs with engram-app/Engram#1439.

A self-hosted server accepted attachments. The plugin refused to send them, because it was pre-gating on a plan verdict issued by a **different backend**.

## The gap

`planState` is already in `BACKEND_SCOPED_FIELDS`, so a cloud ↔ selfhost **mode switch** stashes and restores it correctly. That was fixed before, and the comment there documents it.

The hole is a URL change **within** a mode. Pointing selfhost at a different server runs `applyApiUrlChange` → `withClearedAuth`, which wipes every credential:

```
apiKey, refreshToken, userEmail, authMethod, vaultId,
accessToken, accessTokenExpiresAt, accessTokenVaultId
```

and leaves `planState` untouched. The old server's "Free tier, notes only" then applied to the new one, and `preGateAttachment` skipped every image and PDF **client-side with no network call**, on a server that would have accepted them.

## Changes

**1. `planState: null` joins `CLEARED_AUTH_VALUES`.**

`null`, not `false`: an unknown plan is what makes `preGateAttachment` fall through and let the backend decide, which is the correct failure direction. A mode switch still stashes and restores, so switching back to Cloud keeps the Cloud plan.

It typechecks against the existing `satisfies Partial<Record<BackendScopedField, unknown>>` drift guard, and the runtime guard in `backend-mode.test.ts` (fields cleared but not stashed) is satisfied because `planState` is already stashed.

**2. Migrate step for the backend rename.**

`parsePlanState` prefers the grant-shaped `attachments_all_types` and falls back to the legacy `attachments_text_only`, so this build works against a backend on **either** side of the rename.

With **neither** field present it resolves permissive, matching the pre-gate's fail-open direction. Failing closed there would reintroduce exactly this bug against an unrecognised payload, so there's a test pinning it.

## Verification

**2818 pass / 1 skip / 0 fail** · `tsc --noEmit` clean · `biome check src tests` clean.

New tests cover: the new field read both ways, the new field winning over the legacy one while both ship, the legacy fallback, the no-field permissive default, and `withClearedAuth` nulling the plan.

## Note for whoever merges

Existing installs already carrying a stale plan are only cleared on the *next* backend change. Anything currently parked shows in Sync Center as an informational issue and re-uploads via `resyncSkippedAttachments()`, which bypasses the pre-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp