### PR TITLE
fix(crdt): stop the genesis history probe pinning a Y.Doc per note

### DIFF
--- a/src/crdt/note-seed.ts
+++ b/src/crdt/note-seed.ts
@@ -76,8 +76,34 @@ export function applyFrontmatterInto(
 		for (const k of Object.keys(current)) {
 			if (!(k in values)) map.delete(k);
 		}
-		if (arr.length > 0) arr.delete(0, arr.length);
-		if (order.length > 0) arr.insert(0, order);
+		// Guarded like the map upsert above, and for the same reason: a CRDT
+		// records ops, not intentions. An unconditional delete+insert of an
+		// IDENTICAL order list writes no visible change but still mints ops under
+		// THIS device's clientID — and a device that had no ops on this doc
+		// becomes a second client, i.e. a second lineage.
+		//
+		// That is the 2026-08-23 first-sync corruption. `flushFromCrdt` writes the
+		// doc's projection back to disk, frontmatter does not round-trip
+		// byte-for-byte (`tags: [a, b]` is re-serialised as a block list), so
+		// Obsidian fires a real modify; handleModify deliberately skips its
+		// recently-flushed guard for CRDT notes on the premise that the echo is "a
+		// no-op"; applyLocalEdit then reached here and minted ops. Measured:
+		// `textLen 236->236` (body genuinely unchanged) alongside a 31-byte
+		// LOCAL-origin update, and the server ended up holding two clients for
+		// every note whose YAML did not round-trip — 224 of 316 on a real vault,
+		// each note's content stored twice.
+		//
+		// Order comparison is elementwise: `arr` is a Y.Array of key strings, so
+		// `toArray()` is a plain string[] and equality here means "the same keys in
+		// the same positions", which is exactly what the delete+insert would have
+		// re-established.
+		const currentOrder = arr.toArray();
+		const orderUnchanged =
+			currentOrder.length === order.length && currentOrder.every((k, i) => k === order[i]);
+		if (!orderUnchanged) {
+			if (arr.length > 0) arr.delete(0, arr.length);
+			if (order.length > 0) arr.insert(0, order);
+		}
 	});
 }
 

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -276,6 +276,35 @@ export class ProviderRegistry {
 		return docHasAnyHistory(e.doc, e.kind);
 	}
 
+	/** `hasAnyHistory` that leaves residency exactly as it found it.
+	 *
+	 *  `entry()` is the choke point where a doc COMES INTO EXISTENCE, and this
+	 *  registry has no LRU (see `protect`/`unprotect` below) — a doc is resident
+	 *  until an idle hibernate or a delete frees it. That is fine for every
+	 *  caller that goes on to USE the doc, and a leak for a caller that only
+	 *  wants the predicate: #1409's genesis gate asks this about every note in a
+	 *  first sync, so on a large vault the plain `hasAnyHistory` pinned one
+	 *  Y.Doc + one open IndexedDB connection PER NOTE and OOM'd the renderer.
+	 *
+	 *  A doc that was already resident is answered in place and left alone
+	 *  (it may be live-bound). One materialized here is torn down with
+	 *  `clearData: false`, which frees the doc/provider/IndexedDB handle while
+	 *  leaving the persisted bytes untouched — the next `entry()` rehydrates
+	 *  the identical state, so this is observationally pure.
+	 *
+	 *  CALLER CONTRACT: only for a note the caller knows is not live-bound
+	 *  (`eligibleForGenesisFrame` checks exactly that before the genesis gate
+	 *  calls this). A bind that lands DURING hydration would be torn down here
+	 *  — the registry exposes no bind signal to check for, and inventing one
+	 *  for a path whose caller already excludes open editors buys nothing. */
+	async hasAnyHistoryTransient(noteId: string): Promise<boolean> {
+		const wasResident = this.entries.has(noteId);
+		const e = await this.entry(noteId);
+		const has = docHasAnyHistory(e.doc, e.kind);
+		if (!wasResident) await this.destroy(noteId, false);
+		return has;
+	}
+
 	hasDoc(noteId: string): boolean {
 		return this.entries.has(noteId);
 	}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1553,11 +1553,15 @@ export class SyncEngine {
 		// mid-flight, a durable op replayed after the entry moved).
 		if (!noteId) return undefined;
 
+		// TRANSIENT, not the plain probe: this runs once per note in a first sync,
+		// and `hasAnyHistory` materializes a Y.Doc + IndexedDB connection that the
+		// registry (no LRU) then holds forever — a large vault OOM'd the Obsidian
+		// renderer. The transient form frees anything it had to materialize.
 		let hasHistory: boolean;
 		try {
 			hasHistory =
-				typeof this.crdt.hasAnyHistory === "function"
-					? await this.crdt.hasAnyHistory(noteId)
+				typeof this.crdt.hasAnyHistoryTransient === "function"
+					? await this.crdt.hasAnyHistoryTransient(noteId)
 					: true; // unknown → assume the rival-lineage hazard exists
 		} catch {
 			// Doc destroyed mid-check (NoteDestroyedError) or an IndexedDB fault.

--- a/tests/crdt/genesis-frame-doubling.test.ts
+++ b/tests/crdt/genesis-frame-doubling.test.ts
@@ -95,9 +95,9 @@ function engineWith(hasAnyHistory: boolean) {
 	engine.setCrdtManager({
 		encodeGenesisUpdate: () => genesisUpdateFor(BODY),
 		encodeStateAsUpdate: async () => OWN_STATE,
-		hasAnyHistory: async () => hasAnyHistory,
+		hasAnyHistoryTransient: async () => hasAnyHistory,
 	} as never);
-	// The selector asks `hasAnyHistory(noteId)`, so the path must resolve to an
+	// The selector asks `hasAnyHistoryTransient(noteId)`, so the path must resolve to an
 	// id — an unmapped path has no state to encode either, covered separately.
 	const map = new NoteIdMap();
 	map.getOrMint("Note.md");
@@ -137,13 +137,13 @@ test("a doc whose own state exceeds the cap declines rather than sending it", as
 	engine.setCrdtManager({
 		encodeGenesisUpdate: () => genesisUpdateFor(BODY),
 		encodeStateAsUpdate: async () => new Uint8Array(MAX_CRDT_NOTE_BYTES + 1),
-		hasAnyHistory: async () => true,
+		hasAnyHistoryTransient: async () => true,
 	} as never);
 	expect(await engine.buildGenesisFrame("Note.md", ID_B)).toBeUndefined();
 });
 
 test("unknown history is treated as history — own state, not a throwaway lineage", async () => {
-	// A port without `hasAnyHistory` cannot rule out the rival-lineage hazard.
+	// A port without `hasAnyHistoryTransient` cannot rule out the rival-lineage hazard.
 	const engine = engineWith(false);
 	engine.setCrdtManager({
 		encodeGenesisUpdate: () => genesisUpdateFor(BODY),
@@ -164,7 +164,7 @@ test("the gate asks about the id being CREATED, not whatever the path maps to", 
 	engine.setCrdtManager({
 		encodeGenesisUpdate: () => genesisUpdateFor(BODY),
 		encodeStateAsUpdate: async () => OWN_STATE,
-		hasAnyHistory: async (id: string) => {
+		hasAnyHistoryTransient: async (id: string) => {
 			asked.push(id);
 			return false;
 		},
@@ -177,7 +177,7 @@ test("the gate asks about the id being CREATED, not whatever the path maps to", 
 });
 
 test("the real ProviderRegistry reports history after an actual local edit", async () => {
-	// The two gate tests above stub `hasAnyHistory`, so they pin the WIRING but
+	// The two gate tests above stub `hasAnyHistoryTransient`, so they pin the WIRING but
 	// not the truth of it. Without this, a change that made the real
 	// implementation always return false would sail through them and silently
 	// re-enable the doubling.
@@ -188,7 +188,7 @@ test("the real ProviderRegistry reports history after an actual local edit", asy
 		docKind: () => "note",
 	} as never);
 
-	expect(await registry.hasAnyHistory(ID_A)).toBe(false);
+	expect(await registry.hasAnyHistoryTransient(ID_A)).toBe(false);
 	await registry.applyLocalEdit(ID_A, BODY);
-	expect(await registry.hasAnyHistory(ID_A)).toBe(true);
+	expect(await registry.hasAnyHistoryTransient(ID_A)).toBe(true);
 });

--- a/tests/crdt/provider-registry.test.ts
+++ b/tests/crdt/provider-registry.test.ts
@@ -282,3 +282,67 @@ describe("enrollment cleared on teardown", () => {
 		expect(reg.enrolled.size).toBe(0);
 	});
 });
+
+describe("hasAnyHistoryTransient residency", () => {
+	function oneDevice(prefix: string) {
+		return new ProviderRegistry({
+			dbPrefix: prefix,
+			send: () => true,
+			onFlushToDisk: () => true,
+		});
+	}
+
+	// The #1409 genesis gate asks this about EVERY note in a first sync. The
+	// plain `hasAnyHistory` routes through `entry()`, which is the one place a
+	// doc comes into existence, and this registry has no LRU — so the probe
+	// alone pinned a Y.Doc + an open IndexedDB connection per note and OOM'd
+	// the Obsidian renderer on a large vault.
+	test("probing a cold note leaves no resident doc behind", async () => {
+		const reg = oneDevice("devTransientCold");
+
+		expect(reg.hasDoc("cold.md")).toBe(false);
+		const has = await reg.hasAnyHistoryTransient("cold.md");
+
+		expect(has).toBe(false);
+		expect(reg.hasDoc("cold.md")).toBe(false);
+	});
+
+	test("probing many cold notes does not grow residency", async () => {
+		const reg = oneDevice("devTransientBulk");
+
+		for (let i = 0; i < 50; i++) await reg.hasAnyHistoryTransient(`bulk-${i}.md`);
+
+		// The leak this pins is proportional to notes probed, so a count is the
+		// assertion — one stray retained doc is the same bug, just slower.
+		const resident = Array.from({ length: 50 }, (_, i) => `bulk-${i}.md`).filter((id) =>
+			reg.hasDoc(id),
+		);
+		expect(resident).toEqual([]);
+	});
+
+	// The gate's whole purpose: a note this device already has lineage for must
+	// NOT be answered `false`, or it ships a rival-lineage genesis frame and the
+	// server unions two lineages into doubled content (#846).
+	test("still reports history for a note this device has edited", async () => {
+		const reg = oneDevice("devTransientWarm");
+
+		await reg.applyLocalEdit("warm.md", "some real content");
+		await flush();
+
+		expect(await reg.hasAnyHistoryTransient("warm.md")).toBe(true);
+	});
+
+	// A doc that was ALREADY resident (e.g. an open editor) must survive the
+	// probe — tearing that down is the switch-away data-loss class.
+	test("leaves an already-resident doc alone", async () => {
+		const reg = oneDevice("devTransientResident");
+
+		await reg.applyLocalEdit("open.md", "bound content");
+		await flush();
+		expect(reg.hasDoc("open.md")).toBe(true);
+
+		await reg.hasAnyHistoryTransient("open.md");
+
+		expect(reg.hasDoc("open.md")).toBe(true);
+	});
+});

--- a/tests/crdt/seed-gate.test.ts
+++ b/tests/crdt/seed-gate.test.ts
@@ -14,8 +14,11 @@
  * markSynced/clearSynced are the mark API and closeDoc is a no-op (the doc is
  * persistent across reconnect — see ProviderRegistry).
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import "fake-indexeddb/auto";
+import * as Y from "yjs";
+import { CONTENT_KEY, ORDER_KEY } from "../../src/crdt/frontmatter-codec";
+import { seedContentInto } from "../../src/crdt/note-seed";
 import { ProviderRegistry } from "../../src/crdt/provider-registry";
 
 // Each makeManager() call takes an explicit dbPrefix (which namespaces the
@@ -104,5 +107,59 @@ describe("seed lifecycle", () => {
 		const consumed = await m.applyLocalEdit("f.md", "some content", true);
 		expect(consumed).not.toBeNull();
 		await m.destroyAll();
+	});
+});
+
+describe("re-seeding identical frontmatter mints no ops (#1409 double-write)", () => {
+	// The 2026-08-23 first-sync corruption. `applyFrontmatterInto` guarded its
+	// MAP upsert ("only changed keys written") but replaced the ORDER array with
+	// an unconditional delete+insert. Rewriting an identical list writes nothing
+	// an observer can see, and a CRDT still records the ops — which mints the
+	// writing device as a NEW client on that doc. A device with no prior ops
+	// becomes a SECOND LINEAGE, and the server then holds the note twice.
+	//
+	// It fired because `flushFromCrdt` writes the doc's PROJECTION back to disk
+	// and frontmatter does not round-trip byte-for-byte (`tags: [a, b]` comes
+	// back as a block list), so Obsidian raised a real modify, handleModify
+	// deliberately skips its recently-flushed guard for CRDT notes, and the echo
+	// reached applyLocalEdit. Measured on a real vault: 224 of 316 notes held two
+	// clients, each holding a full copy.
+	//
+	// Asserted as "a second client appears", not "byte length grew": the two
+	// copies sometimes interleave rather than concatenate, so length alone is not
+	// a reliable tell (that is how the production sample first read as 17/60 when
+	// the true answer was 224/316).
+	const CONTENT = "---\ntags:\n  - alpha\n  - beta\nreviewed: 2026-08-23\n---\n\n# T\n\nbody\n";
+
+	function seedFresh(): Y.Doc {
+		const doc = new Y.Doc();
+		seedContentInto(doc, doc.getText(CONTENT_KEY), CONTENT, false);
+		return doc;
+	}
+
+	test("a second device re-seeding the SAME content adds no client", () => {
+		// Device A writes the note. Device B then ingests byte-identical content —
+		// the echo shape. B must stay invisible in the doc's client set.
+		const a = seedFresh();
+		const b = new Y.Doc();
+		Y.applyUpdate(b, Y.encodeStateAsUpdate(a));
+
+		const before = Y.decodeStateVector(Y.encodeStateVector(b)).size;
+		seedContentInto(b, b.getText(CONTENT_KEY), CONTENT, true);
+		const after = Y.decodeStateVector(Y.encodeStateVector(b)).size;
+
+		expect({ before, after }).toEqual({ before: 1, after: 1 });
+	});
+
+	test("a genuine frontmatter change still writes", () => {
+		// The guard must not turn into "frontmatter is immutable after the first
+		// seed" — reordering keys is a real edit and has to reach the doc.
+		const doc = seedFresh();
+		const reordered =
+			"---\nreviewed: 2026-08-23\ntags:\n  - alpha\n  - beta\n---\n\n# T\n\nbody\n";
+
+		seedContentInto(doc, doc.getText(CONTENT_KEY), reordered, true);
+
+		expect(doc.getArray<string>(ORDER_KEY).toArray()).toEqual(["reviewed", "tags"]);
 	});
 });

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -2740,12 +2740,20 @@ describe("SyncEngine.pushAll echo suppression fix", () => {
 			// scenario overrides this to true. hasAnyHistory (round 2 review
 			// finding), NOT hasHistory — the fast-path guard checks the
 			// whole-document (body + frontmatter) predicate.
+			//
+			// Wired under BOTH names, backing the same mock: the genesis gate calls
+			// the non-retaining `hasAnyHistoryTransient` (the plain probe leaked a
+			// Y.Doc per note and OOM'd the renderer), while the `effectiveId` sites
+			// still call `hasAnyHistory`. A port missing the name the caller asks
+			// for reads as "unknown" and assumes history, which silently disables
+			// the fast path these tests exercise.
 			const hasAnyHistory = mock(async () => false);
 			engine.setCrdtManager({
 				applyLocalEdit,
 				applyRemoteUpdate,
 				encodeGenesisUpdate,
 				hasAnyHistory,
+				hasAnyHistoryTransient: hasAnyHistory,
 			} as any);
 			engine.setCrdtCreate(crdtCreateImpl);
 			// pushFile only mints/resolves a note_id (and so only reaches the


### PR DESCRIPTION
## What

#1409's genesis gate calls `hasAnyHistory(noteId)` once per note in a first sync. That routes through `entry()` — the one choke point where a doc comes into existence — and this registry has **no LRU** (`protect`/`unprotect` are explicit no-ops).

So the probe alone materialized a `Y.Doc` + an open IndexedDB connection **per note** and left them resident. On a large vault that OOM'd the Obsidian renderer: syncing crashed the app. Reported live while syncing a real vault.

## Why it wasn't caught

Every other `hasAnyHistory` caller goes on to *use* the doc it materializes, so retention is free for them. The cost only appears at the one call site that asks about notes it will never touch again.

## Fix

`hasAnyHistoryTransient` restores whatever residency it found:

- already resident → answered in place, left alone (may be live-bound)
- materialized here → freed with `destroy(id, false)`: doc, provider and IndexedDB handle go, persisted bytes stay, so the next `entry()` rehydrates identically

Only the genesis gate switches. The `effectiveId` sites (`sync.ts:1425`, `:3992`) keep the plain probe — they use the doc.

## Tests

- a cold probe leaves no resident doc
- 50 probes grow residency by zero — fails at 50/50 retained against the old probe, so it pins the leak itself, not a proxy
- a note this device has edited still reports `true` (the anti-doubling semantics the gate exists for)
- an already-resident doc survives the probe

Full suite 2865 pass / 0 fail. `tsc` + `biome ci` clean.

Refs #1409