### PR TITLE
fix(sync): close pushFile's TOCTOU reentrancy race

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3564,6 +3564,19 @@ export class SyncEngine {
 		// server-sanitized-rename check) must be made against the path we
 		// actually pushed, not wherever the file lives by reply time (#245).
 		const pushedPath = file.path;
+		// Re-check the guard HERE, not just at entry (line ~3494): two awaits sit
+		// between that check and this claim (the echo-hash read, acquirePushSlot),
+		// so two overlapping pushFile calls for the same path — e.g. two
+		// overlapping fullSync() sweeps, which nothing serializes — can both pass
+		// the stale check before either claims the slot, and both push. For a
+		// brand-new CRDT note that means two independent genesis lineages landing
+		// on the same server row. Nothing async happens between this check and the
+		// claim below, so this pairing IS atomic (single-threaded JS).
+		if (this.pushing.has(pushedPath)) {
+			this.releasePushSlot();
+			devLog().log("push", `skip (already pushing, lost the race): ${pushedPath}`);
+			return false;
+		}
 		this.pushing.add(pushedPath);
 		this.lastError = "";
 		this.emitStatus();

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -2628,6 +2628,40 @@ describe("push concurrency limit", () => {
 
 		expect(completedCount).toBe(10);
 	});
+
+	// The reentrancy guard (`this.pushing.has(path)`) is checked once at entry,
+	// but two `await`s (the echo-hash read, `acquirePushSlot`) sit between that
+	// check and `this.pushing.add(path)`. Two overlapping pushFile calls for the
+	// SAME path — e.g. from two overlapping fullSync() sweeps, which is exactly
+	// the shape test_77/test_97/test_98/test_100's own retry loops produce
+	// (`while (...) { await trigger_full_sync(); ... }` never awaits the
+	// PREVIOUS call's completion) — can both pass the stale check before either
+	// claims the slot, so the file gets pushed twice concurrently. For a
+	// brand-new CRDT note that means two independent genesis lineages landing on
+	// the same server row (the 2026-08-24 main regression: test_97/98/100).
+	test("two concurrent pushFile calls for the SAME file push exactly once", async () => {
+		const engine = createEngine({ debounceMs: 10 });
+
+		let pushNoteCalls = 0;
+		(mockApi.pushNote as jest.Mock).mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					// Resolve on a later microtask so both racing calls are genuinely
+					// in flight together, not serialized by a same-tick resolution.
+					setTimeout(() => {
+						pushNoteCalls++;
+						resolve({ note: {}, chunks_indexed: 1 });
+					}, 5);
+				}),
+		);
+
+		(mockApp.vault.cachedRead as jest.Mock).mockResolvedValue("a".repeat(5 * 1024 * 1024));
+		const file = new TFile("Notes/Raced.md", Date.now());
+
+		await Promise.all([(engine as any).pushFile(file), (engine as any).pushFile(file)]);
+
+		expect(pushNoteCalls).toBe(1);
+	});
 });
 
 describe("SyncEngine.pushAll echo suppression fix", () => {


### PR DESCRIPTION
## Summary
- `main` on the backend repo is currently broken: `test_97_first_sync_single_lineage`, `test_98_resync_to_fresh_vault_single_lineage`, and `test_100_frontmatter_echo_single_lineage` fail deterministically on every CI run since Engram#1455 merged (2026-08-24), each showing notes with multiple independent Yjs lineages ("worst: 7 clients").
- Traced it to `pushFile`'s reentrancy guard: `this.pushing.has(path)` is checked once at entry, but two `await`s (the echo-hash read, `acquirePushSlot`) sit between that check and `this.pushing.add(path)`. Two overlapping `fullSync()` sweeps for the same never-before-synced file — nothing serializes `fullSync()` calls — can both pass the stale check before either claims the slot, and both push. `test_77`/`97`/`98`/`100`'s own retry loops produce exactly this shape (`while (...) { await trigger_full_sync(); ... }`, never awaiting the previous call's completion).
- For a brand-new CRDT note, two concurrent pushes means two independent throwaway-Y.Doc genesis lineages can land on the same server row — the doubling these tests catch.
- Fix: re-check the guard immediately before the claim, with nothing async in between (single-threaded JS makes that pairing atomic).
- This is likely also a contributing factor to #1409's residual "handshake" room storm (a losing racer's registry entry being torn down mid-flight can throw inside `flushHeldState`, which is what Engram-obsidian#466 separately hardened) — related but independently scoped fix.

## Test plan
- [x] New test: two concurrent `pushFile` calls for the same file push exactly once (fails pre-fix at 2 calls, passes post-fix)
- [x] `bun test`: 2878 pass / 0 fail
- [x] `tsc -noEmit` + `esbuild` clean
- [x] `biome check` clean
- [ ] Confirm against the actual `test_97`/`98`/`100` E2E suite once this lands — that's the real proof; the unit test only proves the reentrancy gap is closed, not that it's the *sole* cause of the observed doubling