### PR TITLE
fix(crdt): #1409 — room-free cold-note convergence, per-vault identity, and two path consolidations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,6 +168,7 @@ Required status checks on `main`: `build-and-test`, `version-check / version-che
 - Community-scanner `no-unsafe-*` false-positive flood / outside contributors can't `bun install` (registry-poisoned lockfile; `scripts/check-lockfile-registry.mjs` guard) → `docs/context/scanner-type-resolution.md`
 
 **Sync / CRDT architecture & bug classes**
+- Adding a `Map`/`Set` field to `SyncEngine`, or state survived a vault switch and addressed the new vault with the old vault's ids → `docs/context/sync-engine-sweep-registry.md`
 - 3-way merge conflict-resolution algorithm → `docs/context/three-way-merge.md`
 - Logging architecture (dev-log categories, remote-log thresholds) → `docs/context/logging-architecture.md`
 - V8 OOM prevention on large-vault operations → `docs/context/v8-oom-prevention.md`

--- a/docs/context/sync-engine-sweep-registry.md
+++ b/docs/context/sync-engine-sweep-registry.md
@@ -1,0 +1,93 @@
+# Adding state to SyncEngine: the sweep registry
+
+**Read this before adding any `Map` or `Set` field to `SyncEngine`.**
+
+## The rule
+
+Collections are registered at their declaration with the teardowns they die in:
+
+```ts
+private fileForNote = this.track(["vault", "destroy"], new Map<string, string>());
+private syncState  = this.track(["vault"], new Map<string, FileSyncState>());
+private pushing    = this.track(["destroy"], new Set<string>());
+```
+
+Maps holding timers pass a dispose hook, which runs per value before the clear:
+
+```ts
+private recentlyDeleted = this.track(
+  ["vault", "destroy"],
+  new Map<string, { timer: number; path: string }>(),
+  ({ timer }) => this.time.clearTimeout(timer),
+);
+```
+
+`destroy()` and `wipePerVaultState()` both call `sweep(event)` and enumerate
+nothing. There is no list to remember to update.
+
+`tests/sync-sweep-registry.test.ts` reflects over a live engine and fails on any
+untracked `Map`/`Set` field, naming it. You cannot forget silently.
+
+## The two events are independent, not a severity ladder
+
+This is the part that is easy to get wrong.
+
+| field | `vault` | `destroy` | why |
+|---|---|---|---|
+| `syncState` | yes | **no** | the persisted sync baseline; blanking it on unload forces a full re-scan next load |
+| `debounceTimers` | **no** | yes | a debounce pending across a switch still describes a real local edit to a file that still exists, and still deserves its push |
+| `pushing` | **no** | yes | clearing an in-flight push guard re-admits a second concurrent push of the same path |
+| `seqReplayFileListeners` | **no** | yes | in-flight replay callbacks that already deregister in a `finally`; sweeping would drop a listener out from under a replay still unwinding |
+| everything else keyed by path or note_id | yes | yes | |
+
+If you find yourself wanting "vault implies destroy", re-read the first two rows.
+
+## Why this exists
+
+`SyncEngine` used to carry two hand-written teardown enumerations:
+
+- `destroy()` swept the transient per-note maps, deliberately sparing `syncState`
+- `wipePerVaultState()` swept `syncState` + cursors + identity, and left the
+  per-note maps alone
+
+Each was correct for its own job. Nothing owned their **intersection** — state
+that is both vault-scoped *and* transient — so twelve note_id- and path-keyed
+collections survived a vault switch and went on addressing the NEW vault with
+the OLD vault's ids.
+
+Six unrelated bug fixes each added a field to one list and not the other:
+
+| field | commit | date |
+|---|---|---|
+| `pendingPostPullPushes` | 884b38f | 2026-03-15 pushAll echo suppression |
+| `manifestPathOwners`, `pendingOrphanSweep` | b93d9a4 | 2026-07-07 cross-wired note ids |
+| `crdtRehandshakeAttempts` | 88649bf | 2026-07-09 catch-up loop |
+| `pendingQueueDeliveries` | f78ae97 | 2026-07-22 REST transport deletion |
+| `pendingConvergence`, `crdtHealCooldown` | 0007287 | 2026-07-22 socket-native converge |
+| `fileForNote`, `recentlyDeleted`, `relocatedFrom` | 3ff7038 | 2026-08-18 remote rename |
+
+None of those authors were careless. A declaration three thousand lines from
+either list carries no hint that a decision is owed, and forgetting was silent.
+
+## What the leak actually cost
+
+Measured on a real 423-item vault import (Engram #1409):
+
+- **225 CRDT rooms opened for 317 notes**, every one `source=edit`, with zero
+  `crdt_update_log` rows — all redundant, since the roomless genesis seed had
+  already stored the state
+- **16 duplicate note rows created by the vault switch itself** (each of v5, v6,
+  v7 held exactly 317 rows before the next switch and 333 after)
+
+Stale ids are the mechanism: `crdt_create` proposes a foreign vault's note_id,
+the server cannot reuse it (the #1318 collision class) and answers with a fresh
+one, `serverId !== noteId` fails the seeded fast path, and the fallback
+broadcasts a `sync_update` that opens a room per note.
+
+## Related
+
+- `crdt-sync-store-hiding-layers.md` — the sibling rule for local-hide Sets in
+  `SyncStore`; every hiding layer needs a named clearing event. Same failure
+  shape, different class.
+- `path-keyed-oracle-id-keyed-wire.md` — why note_ids are unique only *within*
+  a vault, which is what makes carrying one across a switch dangerous.

--- a/src/auth-state.ts
+++ b/src/auth-state.ts
@@ -163,6 +163,12 @@ export interface ApiUrlSwitchTarget {
 	 *  would replay it against the new origin until reload. Resetting it makes a
 	 *  backend switch behave like a fresh load. */
 	resetAuthProvider: () => void;
+	/** Wipe the state scoped to the outgoing VAULT (note-id map + its provenance,
+	 *  cursors, sync gate, index room). `withClearedAuth` nulls `vaultId`, so a
+	 *  backend change is also a vault change — and clearing the credentials while
+	 *  keeping the map left the next backend inheriting note_ids that are unique
+	 *  only within the vault that issued them (#1409 review). */
+	discardVaultScopedState: (vaultId: string | null) => Promise<void>;
 }
 
 /** The ApiUrlSwitchTarget for the live plugin instance. One construction site
@@ -172,11 +178,13 @@ export function pluginSwitchTarget(plugin: {
 	api: ApiUrlSwitchTarget["api"];
 	noteStream: ApiUrlSwitchTarget["noteStream"];
 	authProvider: { dispose?: () => void } | null;
+	discardVaultScopedState: ApiUrlSwitchTarget["discardVaultScopedState"];
 }): ApiUrlSwitchTarget {
 	return {
 		settings: plugin.settings,
 		api: plugin.api,
 		noteStream: plugin.noteStream,
+		discardVaultScopedState: (id) => plugin.discardVaultScopedState(id),
 		resetAuthProvider: () => {
 			// Dispose before dropping the reference: an undisposed OAuthAuth with
 			// a refresh in flight would later persist rotated tokens back into
@@ -220,6 +228,10 @@ export async function applyApiUrlChange(
 		// Mutate in place — withClearedAuth is the single source of truth for
 		// which fields are backend-scoped, so any future addition stays one-place.
 		Object.assign(target.settings, withClearedAuth(target.settings));
+		// `withClearedAuth` just nulled `vaultId`. Awaited before the save below
+		// so the persisted data.json reflects the wiped map rather than the old
+		// backend's.
+		await target.discardVaultScopedState(target.settings.vaultId ?? null);
 		target.api.setAuthProvider(null);
 		target.resetAuthProvider();
 		target.noteStream?.disconnect();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -164,11 +164,27 @@ function wsOrigin(baseUrl: string): string {
  *  return-type annotation carries no `;` between its two members right next
  *  to the wire-send statement the source-compliance privacy guard
  *  (tests/source-compliance.test.ts) exempts by exact text. */
-export type CrdtCreateResult = { docId: string; seeded: boolean };
+export type CrdtCreateResult = {
+	docId: string;
+	seeded: boolean;
+	genesisOutcome: GenesisOutcome;
+};
+
+/** What the server did with our genesis frame (#476).
+ *
+ *  `seeded: boolean` could not express this: it reported false BOTH when the
+ *  server holds nothing (push the body) and when the server declined because
+ *  the row already holds a different one (pushing mints a rival lineage and
+ *  doubles the note). Those need opposite actions, so the outcome is named.
+ *
+ *  `null` means an older backend that only sends `seeded` — see
+ *  `seedBodyAfterCreate`, which then confirms the server's doc is empty before
+ *  pushing rather than assuming it. */
+export type GenesisOutcome = "stored" | "absent" | "occupied" | null;
 
 /** Raw server reply shape for `crdt_create`, before the docId/seeded rename —
  *  same "no inline `;`" reasoning as CrdtCreateResult above. */
-type CrdtCreateReply = { doc_id: string; seeded?: boolean };
+type CrdtCreateReply = { doc_id: string; seeded?: boolean; genesis?: string };
 
 export class NoteChannel {
 	private ws: WebSocket | null = null;
@@ -541,10 +557,11 @@ export class NoteChannel {
 	 *  `b64` is an optional genesis frame (#1409). When present the server applies
 	 *  it to a detached Y.Doc and checkpoints it WITHOUT opening a room, which is
 	 *  what keeps a full-vault import from allocating one OTP process per file.
-	 *  `seeded` reports whether the body is durably readable server-side; it is
-	 *  false on adopt, on a live room, on a malformed frame, and on any checkpoint
-	 *  skip. A false ALWAYS means "fall back to the crdt_msg seed", never "retry
-	 *  the create". */
+	 *  `genesisOutcome` reports WHICH thing happened — stored / absent / occupied
+	 *  — because the caller has to act differently on each. `seeded` is kept as
+	 *  the lossy legacy view (`stored` only) and must not be the sole input to a
+	 *  decision about whether to transmit a body (#476). No outcome ever means
+	 *  "retry the create". */
 	async crdtCreate(docId: string, path: string, b64?: string): Promise<CrdtCreateResult> {
 		// This literal is a THIRD legitimate wire-send the source-compliance
 		// privacy guard (tests/source-compliance.test.ts) allowlists by exact
@@ -558,7 +575,15 @@ export class NoteChannel {
 			path,
 			...(b64 === undefined ? {} : { b64 }),
 		})) as CrdtCreateReply;
-		return { docId: res.doc_id, seeded: res.seeded === true };
+		const outcome = res.genesis;
+		return {
+			docId: res.doc_id,
+			seeded: res.seeded === true,
+			genesisOutcome:
+				outcome === "stored" || outcome === "absent" || outcome === "occupied"
+					? outcome
+					: null,
+		};
 	}
 
 	/** Delete a note over the socket, AWAITING the server ack (idempotent). The

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -591,6 +591,22 @@ export class NoteChannel {
 	 *  resolve means the delete is durably applied; a reject carries a retryable
 	 *  (rate_limited / not-joined / disconnect) or terminal (bad_doc_id) reason.
 	 *  Routed through the durable CrdtOpQueue; there is no REST delete fallback. */
+	/** #1409: tell the server this device is DONE with a note's room.
+	 *
+	 *  A room is `auto_exit: true` — it dies when its last observer leaves — but
+	 *  the channel becomes an observer on first contact and the only thing that
+	 *  ever released it was the room's own idle drain, five minutes later. On a
+	 *  bulk first sync each note needs its room for milliseconds and held it for
+	 *  minutes.
+	 *
+	 *  Fire-and-forget: the release is an optimisation, and a note whose release
+	 *  is lost simply falls back to the idle timer that governed everything
+	 *  before. Never let it fail a sync.
+	 */
+	crdtRelease(docId: string): void {
+		void this.sendRequest("crdt_release", { doc_id: docId }).catch(() => {});
+	}
+
 	async crdtDeleteAcked(docId: string): Promise<{ doc_id: string }> {
 		return (await this.sendRequest("crdt_delete", { doc_id: docId })) as {
 			doc_id: string;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -572,6 +572,31 @@ export class NoteChannel {
 		};
 	}
 
+	/** Full Yjs state for `docId`, read WITHOUT starting a server room (#1409).
+	 *
+	 *  The alternative — a syncStep1 `crdt_msg` — routes through the backend's
+	 *  `ensure_room`, so every cold note that needed converging allocated a room
+	 *  for a note nobody has open. The server answers this one off the persisted
+	 *  snapshot + update-log tail (`CrdtTransport.read_delta`), which spawns
+	 *  nothing.
+	 *
+	 *  Returns base64 Yjs v1 update bytes. Applying them is a MERGE, so a
+	 *  checkpoint-lagged snapshot converges without reverting anything — the
+	 *  property that makes this a legal substitute for STEP2, and that the
+	 *  catch-up feed's plaintext `content` snapshot does NOT have.
+	 *
+	 *  Rejects carry the same reasons as a handshake: `rate_limited` (retryable),
+	 *  `note_not_found` (the caller's id-map is stale), `bad_doc_id` (terminal).
+	 *  Callers fall back to the room re-handshake — including on an
+	 *  `unmatched_topic`-shaped reject from a backend too old to know the
+	 *  frame, so a new plugin against an old server still converges. */
+	async crdtDocState(docId: string): Promise<{ b64: string; head: string }> {
+		return (await this.sendRequest("crdt_doc_state", { doc_id: docId })) as {
+			b64: string;
+			head: string;
+		};
+	}
+
 	/** Seq-ordered op-log page after `cursorSeq` (single-path catch-up). Each op
 	 *  carries FULL content (a SyncNoteChange or SyncAttachmentChange — the
 	 *  merged notes+attachments feed), so it is causally complete and can

--- a/src/crdt-op-dispatch.ts
+++ b/src/crdt-op-dispatch.ts
@@ -128,6 +128,11 @@ export type CrdtSendHooks = {
 		genesis?: GenesisFrame,
 		genesisOutcome?: GenesisOutcome,
 	) => void | Promise<void>;
+	/** A post-ack step (`onCreated`) threw. The create is NOT retried — the row
+	 *  already exists — but the failure must be visible: that same step confirms
+	 *  the id and flushes edits held by the `canSendLive` gate, so a silent
+	 *  throw strands keystrokes the user already typed. */
+	onPostAckError?: (docId: string, path: string, error: unknown) => void;
 	/** A terminally-failed op about to be dropped. surface it (error log). */
 	onTerminal: (op: CrdtOp, reason: string) => void;
 	/** A retryable PLAN-LIMIT reject (e.g. notes_cap_reached). Surface to the user
@@ -164,11 +169,18 @@ export function makeCrdtOpSend(hooks: CrdtSendHooks): (op: CrdtOp) => Promise<Se
 						genesis,
 						genesisOutcome,
 					);
-				} catch {
+				} catch (e) {
 					// crdt_create already ACKED: the row exists (possibly remapped).
-					// A post-ack step (body seed) throwing must NOT retry the create:
-					// that would duplicate/misroute the row. The body self-heals on the
-					// note's next edit.
+					// A post-ack step throwing must NOT retry the create — that would
+					// duplicate/misroute the row.
+					//
+					// It must not be SILENT either. `onCreated` also runs
+					// `adoptCreateAck`, which sets the id map, flips the
+					// has-server-note oracle, confirms the id, and flushes edits held
+					// by the `canSendLive` gate. A throw loses all of that, including
+					// keystrokes the user already typed, and the bare `catch {}` wrote
+					// nothing anywhere — unobservable by construction (#1409 review).
+					hooks.onPostAckError?.(op.docId, path, e);
 				}
 			} else if (op.kind === "delete") {
 				await ch.crdtDeleteAcked(op.docId);

--- a/src/crdt-op-dispatch.ts
+++ b/src/crdt-op-dispatch.ts
@@ -26,6 +26,7 @@
  * MAX_ATTEMPTS (onDrop "max-attempts") or OP_TTL_MS, so nothing retries forever.
  */
 
+import type { GenesisOutcome } from "./channel";
 import type { CrdtOp, SendResult } from "./crdt-op-queue";
 
 /** Server reasons where a retry cannot succeed. remove the op (surfaced).
@@ -69,7 +70,7 @@ export type CrdtOpChannel = {
 		docId: string,
 		path: string,
 		b64?: string,
-	): Promise<{ docId: string; seeded: boolean }>;
+	): Promise<{ docId: string; seeded: boolean; genesisOutcome: GenesisOutcome }>;
 	crdtDeleteAcked(docId: string): Promise<{ doc_id: string }>;
 };
 
@@ -110,6 +111,8 @@ export type CrdtSendHooks = {
 	 *  note whose real doc has history. */
 	buildGenesisFrame?: (path: string, noteId: string) => Promise<GenesisFrame | undefined>;
 	/** A create acked: serverId is the AUTHORITATIVE id (differs on ADOPT).
+	 *  `genesisOutcome` says what the server DID with the frame — the caller must
+	 *  not decide whether to transmit a body from `seeded` alone (#476).
 	 *  `seeded` + `genesis` (present only when a frame was actually sent) let
 	 *  the caller apply the SAME bytes locally instead of re-seeding from
 	 *  disk over crdt_msg — which would open the very room #1409 exists to
@@ -123,6 +126,7 @@ export type CrdtSendHooks = {
 		path: string,
 		seeded: boolean,
 		genesis?: GenesisFrame,
+		genesisOutcome?: GenesisOutcome,
 	) => void | Promise<void>;
 	/** A terminally-failed op about to be dropped. surface it (error log). */
 	onTerminal: (op: CrdtOp, reason: string) => void;
@@ -144,11 +148,22 @@ export function makeCrdtOpSend(hooks: CrdtSendHooks): (op: CrdtOp) => Promise<Se
 			if (op.kind === "create") {
 				const path = (op.payload as { path?: string })?.path ?? "";
 				const genesis = await hooks.buildGenesisFrame?.(path, op.docId);
-				const { docId: serverId, seeded } = genesis
+				const {
+					docId: serverId,
+					seeded,
+					genesisOutcome,
+				} = genesis
 					? await ch.crdtCreate(op.docId, path, genesis.b64)
 					: await ch.crdtCreate(op.docId, path);
 				try {
-					await hooks.onCreated(op.docId, serverId, path, seeded, genesis);
+					await hooks.onCreated(
+						op.docId,
+						serverId,
+						path,
+						seeded,
+						genesis,
+						genesisOutcome,
+					);
 				} catch {
 					// crdt_create already ACKED: the row exists (possibly remapped).
 					// A post-ack step (body seed) throwing must NOT retry the create:

--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -402,11 +402,21 @@ export class ProviderRegistry {
 	}
 
 	/** Apply a raw Yjs update (vault-channel fan-out) as a remote merge, awaiting
-	 *  its disk flush so a write failure can be surfaced (#235). */
-	async applyRemoteUpdate(noteId: string, update: Uint8Array): Promise<void> {
-		if (this.removed.has(noteId)) return; // deleted — a late fan-out must not resurrect
+	 *  its disk flush so a write failure can be surfaced (#235).
+	 *
+	 *  Returns whether the update actually reached a doc. The two refusals below
+	 *  are correct but were INVISIBLE, and two callers read the resolved promise
+	 *  as proof of a merge: `adoptServerLineage` then reported "adopted server
+	 *  lineage" for a doc that never received it and pushed the body into an
+	 *  empty doc — the #476 rival mint — while `convergeColdNoteRoomFree`
+	 *  called `markSynced` and recorded a note as converged that had merged
+	 *  nothing, so every later catch-up compared equal hashes and skipped it
+	 *  forever. A dropped update is not a failure worth throwing over; it just
+	 *  cannot be reported as success. */
+	async applyRemoteUpdate(noteId: string, update: Uint8Array): Promise<boolean> {
+		if (this.removed.has(noteId)) return false; // deleted — a late fan-out must not resurrect
 		const e = await this.entry(noteId);
-		if (!e.lifetime.active) return; // destroyed while we awaited hydration
+		if (!e.lifetime.active) return false; // destroyed while we awaited hydration
 		// Apply with the PROVIDER as origin (NOT a distinct REMOTE symbol): the
 		// provider's update handler suppresses its own origin, so a fanned-out update
 		// is NOT re-broadcast to the server. Applying it as a foreign origin (the old
@@ -420,6 +430,7 @@ export class ProviderRegistry {
 			e.pendingFlush = null;
 			await flush;
 		}
+		return true;
 	}
 
 	// --- Yjs encoding helpers (handshake / genesis) -----------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -297,21 +297,14 @@ export default class EngramSyncPlugin extends Plugin {
 	 *  vault — a no-op "switch" to the vault you are already on must not wipe
 	 *  anything. */
 	async switchVault(id: string, name?: string): Promise<void> {
-		this.settings.vaultId = id;
 		if (name !== undefined) this.settings.remoteVaultName = name;
-		this.api.setVaultId(id);
 		this.syncEngine.updateSettings(this.settings);
-		// Per-file hashes, lastSync, cursors AND the note-id map are scoped to
-		// the previous server vault.
-		await this.syncEngine.resetForVaultChange();
-		// The accepted-gate fingerprint covers (auth + vault); a new vault must
-		// re-prompt rather than inherit the old vault's consent.
-		this.syncGateAcceptedFor = null;
-		// New vault = new id/path space; re-reconcile on next connect (bypass
-		// the throttle — this isn't a storm, it's a real swap).
-		this.lastMapReconcileAt = 0;
-		// Strand-heal retry counts are keyed by the PREVIOUS vault's note_ids.
-		this.crdtWiring?.clearStrandHealAttempts();
+		// Per-file hashes, lastSync, cursors, the note-id map, the accepted-gate
+		// fingerprint, the reconcile throttle and the strand-heal counts are ALL
+		// scoped to the outgoing vault. This method used to spell out its own
+		// copy of that list, which is how the auth paths and this one drifted
+		// apart in the first place — one list, one owner.
+		await this.discardVaultScopedState(id);
 		this.syncEngine.setSyncBlocked(true);
 	}
 
@@ -1291,19 +1284,31 @@ export default class EngramSyncPlugin extends Plugin {
 		if (!isHttpStatus(e, 404) || !this.settings.vaultId) return;
 		this.healingVault = true;
 		try {
-			const vaults = await this.api.listVaults();
+			// ONLY the probe is allowed to fail silently — it is the one step whose
+			// failure means "nothing to conclude". The catch used to wrap the heal
+			// too, so a throw anywhere in it left the vault half-cleared with no
+			// log at all: the id stayed set, sync stayed unblocked, and the next
+			// 404 re-entered and failed the same way forever.
+			let vaults: Awaited<ReturnType<typeof this.api.listVaults>>;
+			try {
+				vaults = await this.api.listVaults();
+			} catch {
+				// listVaults itself failed (offline?) — the next sync error re-runs
+				// this check.
+				return;
+			}
 			if (vaults.some((v) => v.id === this.settings.vaultId)) return;
 			rlog().warn(
 				"lifecycle",
 				`Active vault ${this.settings.vaultId} no longer exists server-side — clearing and reopening the picker`,
 			);
-			this.settings.vaultId = null;
 			this.settings.remoteVaultName = undefined;
-			// Finding 10: EngramApi keeps its OWN vault id and stamps it on every
-			// request — clearing only the settings field leaves non-sync requests
-			// (sync-center retries, attachment fetches) 404ing on the dead header.
-			this.api.setVaultId(null);
-			this.syncGateAcceptedFor = null;
+			// The vault is GONE, so every note_id in the map addresses a vault
+			// that no longer exists. Nulling the id alone left that map to be
+			// carried into whichever vault the picker lands on next — the same
+			// cross-vault identity leak `switchVault` exists to prevent, reached
+			// through a different door (#1409 review).
+			await this.discardVaultScopedState(null);
 			this.syncEngine.setSyncBlocked(true);
 			// Finding 9: a preview/picker already open sits on the now-nulled
 			// vault, and the syncPreviewGuard makes the reopen below a silent
@@ -1315,9 +1320,10 @@ export default class EngramSyncPlugin extends Plugin {
 				"Engram: this vault no longer exists on the server. Pick or create a vault to continue.",
 			);
 			await this.doSyncWithFirstSyncCheck({ startInVaultPicker: true });
-		} catch {
-			// listVaults itself failed (offline?) — nothing to conclude; the next
-			// sync error re-runs this check.
+		} catch (err) {
+			// The heal itself broke. Surfaced, not swallowed: sync is now in an
+			// undefined state and a silent failure here is unobservable.
+			rlog().error("lifecycle", `Dead-vault heal failed midway: ${errMsg(err)}`);
 		} finally {
 			this.healingVault = false;
 		}
@@ -1783,6 +1789,14 @@ export default class EngramSyncPlugin extends Plugin {
 		if (!this.settings.refreshToken && !this.settings.apiKey) return;
 		rlog().info("auth", `Clearing auth + prompting re-link (${reason})`);
 		Object.assign(this.settings, withClearedAuth(this.settings));
+		// `withClearedAuth` nulls `vaultId` — which makes this a vault change,
+		// and every one of those has to wipe the vault-scoped identity state.
+		// It did not, so a re-link that lands on a DIFFERENT vault (a different
+		// account, or the same account's second vault) inherited the previous
+		// vault's note-id map and proposed its ids there. Passed the already-
+		// nulled value rather than a literal so this stays true if the cleared
+		// set ever changes.
+		await this.discardVaultScopedState(this.settings.vaultId ?? null);
 		this.api.setAuthProvider(null);
 		this.replaceAuthProvider(null);
 		this.noteStream?.disconnect();
@@ -1925,8 +1939,13 @@ export default class EngramSyncPlugin extends Plugin {
 	 *  and the index room, or the new vault inherits ids that mean nothing on it.
 	 *
 	 *  Six of nine vault-changing paths used to skip all of this. */
-	private async discardVaultScopedState(vaultId: string | null): Promise<void> {
+	async discardVaultScopedState(vaultId: string | null): Promise<void> {
 		this.settings.vaultId = vaultId;
+		// EngramApi keeps its OWN copy and stamps it on every request. Setting it
+		// here rather than leaving it to a later `saveSettings` closes the window
+		// where the awaited reset below runs while requests still carry the
+		// OUTGOING vault's header.
+		this.api.setVaultId(vaultId);
 		await this.syncEngine.resetForVaultChange();
 		this.syncGateAcceptedFor = null;
 		this.lastMapReconcileAt = 0;
@@ -2403,10 +2422,16 @@ export default class EngramSyncPlugin extends Plugin {
 				channel.onVaultDeleted = () => {
 					new Notice("Engram: This vault has been deleted on the server.");
 					rlog().info("lifecycle", "Vault deleted on server — clearing vaultId");
-					this.settings.vaultId = null;
-					this.api.setVaultId(null);
-					// Use savePluginData instead of saveSettings to avoid triggering re-registration
-					void this.savePluginData(this.syncEngine.getLastSync());
+					// Same reasoning as healDeadVault: the vault is gone, so its
+					// note-id map, cursors and index room address nothing. Nulling
+					// only the id left them to be inherited by the next vault.
+					// Awaited before the save so the persisted data.json reflects
+					// the wipe rather than the pre-wipe map.
+					void this.discardVaultScopedState(null).then(() =>
+						// savePluginData, not saveSettings: the latter re-triggers
+						// registration.
+						this.savePluginData(this.syncEngine.getLastSync()),
+					);
 					this.noteStream?.disconnect();
 				};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -657,6 +657,15 @@ export default class EngramSyncPlugin extends Plugin {
 						genesis,
 						genesisOutcome,
 					),
+				onPostAckError: (docId, path, error) =>
+					// The row exists, so the create is not retried — but the ack's
+					// bookkeeping (id map, oracle, confirm, held-edit flush) did NOT
+					// complete, which can strand edits the user already typed. Logged
+					// at warn so it reaches Loki; info-level client logs do not.
+					rlog().warn(
+						"crdt",
+						`crdt_create post-ack step failed for ${docId} ${noteRef(path)}: ${errMsg(error, path)}`,
+					),
 				onTerminal: (op, reason) =>
 					// A create/delete that retrying cannot fix. Surface it (error log) so
 					// it never silently vanishes; the queue then drops it (no infinite retry).

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,12 @@ interface PluginData {
 	syncGateAcceptedFor?: string | null;
 	/** Path -> note_id sidecar (NoteIdMap.toJSON()). See src/crdt/note-id-map.ts. */
 	noteIds?: Record<string, string>;
+	/** The server vaultId `noteIds` was recorded under (#1409). Identity is
+	 *  per-vault, so seeding this cache into a DIFFERENT vault makes
+	 *  `crdt_create` propose foreign ids — see the seed site for the full
+	 *  chain. `syncState` has carried the same guard (`syncStateVaultId`)
+	 *  since it was added; `noteIds` was the one that never got it. */
+	noteIdsVaultId?: string | null;
 }
 
 /** Whether setupNoteStream() may keep the existing stream instead of
@@ -1338,7 +1344,38 @@ export default class EngramSyncPlugin extends Plugin {
 		// other devices and — through id-keyed removal — published DELETES of the
 		// paths those claims lived at. The cache is evidence about the past, and
 		// it is not allowed to make a claim.
-		this.noteIdMap.seed(data?.noteIds);
+		// #1409 ROOT CAUSE. This cache is per-VAULT identity, and it used to be
+		// seeded unconditionally. Reload the plugin (a BRAT update, an Obsidian
+		// restart) after the active vault changed and the PREVIOUS vault's
+		// path -> note_id entries came straight back, outliving every in-session
+		// wipe (`resetForVaultChange` -> `noteIdMap.clear()` -> the index-room
+		// replacement) because those all run against memory, not this file.
+		//
+		// `crdt_create` then proposes the old vault's ids. The server cannot
+		// reuse a foreign-vault id (the #1318 collision class), answers with a
+		// fresh one, `serverId !== noteId` fails the seeded fast path, and the
+		// fallback broadcasts a sync_update that opens a room PER NOTE.
+		// Measured on a real 423-item import: 225 rooms for 317 notes, all
+		// source=edit, ZERO crdt_update_log rows — every room redundant.
+		//
+		// A MISSING recorded id is adopted, not discarded: pre-upgrade data.json
+		// has no `noteIdsVaultId`, and dropping a valid cache on upgrade would
+		// force a needless re-mint of every note.
+		const cachedIdsVault = data?.noteIdsVaultId;
+		const activeVault = this.settings.vaultId ?? null;
+		if (
+			cachedIdsVault !== undefined &&
+			cachedIdsVault !== null &&
+			activeVault !== null &&
+			cachedIdsVault !== activeVault
+		) {
+			rlog().warn(
+				"lifecycle",
+				`Dropping cached note-id map from vault ${cachedIdsVault} — active vault is ${activeVault}`,
+			);
+		} else {
+			this.noteIdMap.seed(data?.noteIds);
+		}
 		// Migrate a stored Cloud apiUrl off the legacy SPA host (app.engram.page,
 		// which 405s API POSTs post-cutover) onto the canonical REST host. Same
 		// backend + credentials — only the edge hostname moved, so auth is kept.
@@ -1649,6 +1686,9 @@ export default class EngramSyncPlugin extends Plugin {
 			ignoredFiles: this.syncEngine.ignoredFiles.serialize(),
 			syncGateAcceptedFor: this.syncGateAcceptedFor,
 			noteIds: this.noteIdMap.toJSON(),
+			// Stamp the vault this identity cache belongs to, so a later load
+			// into a different vault can refuse it (#1409).
+			noteIdsVaultId: this.settings.vaultId ?? null,
 		});
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,9 +232,31 @@ export default class EngramSyncPlugin extends Plugin {
 		// warns that "a wipe that exists on only one path re-opens #200". Since
 		// clear() became local-only it cannot drop the committed doc, so it has
 		// to trigger the room replacement that can.
-		map.onReset = () => this.resetIndexRoomForVault();
+		map.onReset = () => {
+			// An emptied map is valid for whatever vault is active NOW, so this
+			// is the one moment its provenance legitimately changes. Every
+			// vault-change route funnels through clear() (the picker and the
+			// `invalidateIfVaultChanged` backstop), and both set `vaultId`
+			// before wiping, so `settings.vaultId` here is already the new one.
+			this.noteIdsOwner = this.settings.vaultId ?? null;
+			this.resetIndexRoomForVault();
+		};
 		return map;
 	}
+
+	/** Which vault `noteIdMap`'s entries were minted under — its PROVENANCE, not
+	 *  the vault that happens to be active.
+	 *
+	 *  This used to be read from `settings.vaultId` at save time, which made the
+	 *  load-time gate essentially unfireable: there are ~10 fire-and-forget
+	 *  `savePluginData` call sites, so the instant any path set `vaultId = B`
+	 *  while the map still held A's entries, the next save wrote A's map STAMPED
+	 *  B and the gate then compared `B !== B` and seeded the foreign map. The
+	 *  gate could only ever fire if the process died before any save — the
+	 *  narrowest window in the system (#1409 review).
+	 *
+	 *  It now changes at exactly one moment: when the map is emptied. */
+	private noteIdsOwner: string | null = null;
 
 	/** `?.` alone: before the first connectChannel there is no channel, and the
 	 *  provider correctly BUFFERS the frame for the next connect. */
@@ -1421,6 +1443,9 @@ export default class EngramSyncPlugin extends Plugin {
 			);
 		} else {
 			this.noteIdMap.seed(data?.noteIds);
+			// Carry the recorded provenance forward. An absent stamp (pre-upgrade
+			// data.json) adopts the active vault, matching the seed we just did.
+			this.noteIdsOwner = cachedIdsVault ?? activeVault;
 		}
 		// Migrate a stored Cloud apiUrl off the legacy SPA host (app.engram.page,
 		// which 405s API POSTs post-cutover) onto the canonical REST host. Same
@@ -1732,9 +1757,10 @@ export default class EngramSyncPlugin extends Plugin {
 			ignoredFiles: this.syncEngine.ignoredFiles.serialize(),
 			syncGateAcceptedFor: this.syncGateAcceptedFor,
 			noteIds: this.noteIdMap.toJSON(),
-			// Stamp the vault this identity cache belongs to, so a later load
-			// into a different vault can refuse it (#1409).
-			noteIdsVaultId: this.settings.vaultId ?? null,
+			// The map's PROVENANCE, so a later load into a different vault can
+			// refuse it (#1409). Deliberately NOT `settings.vaultId` — see
+			// `noteIdsOwner`.
+			noteIdsVaultId: this.noteIdsOwner,
 		});
 	}
 
@@ -1880,6 +1906,24 @@ export default class EngramSyncPlugin extends Plugin {
 		return null;
 	}
 
+	/** Drop every piece of state scoped to the OUTGOING vault and adopt `vaultId`.
+	 *
+	 *  The reset half of `switchVault`, split out because the auth paths reach a
+	 *  vault change through a different door: they are mid-credential-swap, so
+	 *  they must NOT re-enter the settings save or the sync gate that
+	 *  `switchVault` drives — they do their own, later in the same call. What
+	 *  they DO need is identical: the note-id map, its provenance, the cursors
+	 *  and the index room, or the new vault inherits ids that mean nothing on it.
+	 *
+	 *  Six of nine vault-changing paths used to skip all of this. */
+	private async discardVaultScopedState(vaultId: string | null): Promise<void> {
+		this.settings.vaultId = vaultId;
+		await this.syncEngine.resetForVaultChange();
+		this.syncGateAcceptedFor = null;
+		this.lastMapReconcileAt = 0;
+		this.crdtWiring?.clearStrandHealAttempts();
+	}
+
 	async saveOAuthTokens(refreshToken: string, vaultId: string, userEmail: string): Promise<void> {
 		// #283: mark the identity swap so an in-flight catch-up manifest fetch
 		// straddling this call refuses its destructive delete-reconcile (a stale
@@ -1888,7 +1932,13 @@ export default class EngramSyncPlugin extends Plugin {
 		this.settings.refreshToken = refreshToken;
 		this.settings.userEmail = userEmail;
 		this.settings.authMethod = "oauth";
-		this.settings.vaultId = vaultId;
+		// A device link or account swap moves us to a DIFFERENT vault, so the
+		// note-id map, cursors and index room must all be reset — note_ids are
+		// unique only WITHIN a vault. This used to be a raw assignment, so the
+		// install kept the previous vault's identity state and proposed foreign
+		// ids on the new one (#1409 review). Awaited before the settings save
+		// below, which rebuilds the note channel.
+		await this.discardVaultScopedState(vaultId);
 		// Fresh login — discard any stale persisted access token so the next
 		// request mints one against the new refresh token.
 		this.settings.accessToken = undefined;
@@ -1932,6 +1982,15 @@ export default class EngramSyncPlugin extends Plugin {
 		// on switch-back and trip reuse detection (revoking the whole family).
 		if (this.authProvider instanceof OAuthAuth) await this.authProvider.settle();
 		if (!switchMode(this.settings, target, ENGRAM_CLOUD_URL)) return false;
+
+		// `BACKEND_SCOPED_FIELDS` includes `vaultId`, so `switchMode` just moved
+		// us to a different vault on a different SERVER. Nothing here reset the
+		// identity state, so the install carried the outgoing backend's note-id
+		// map into the incoming one — and `setupNoteStream` below reconnected the
+		// SAME index-room Y.Doc, advertising vault A's `filemeta_v0` entries into
+		// vault B's room, which is verbatim what `resetIndexRoomForVault`'s own
+		// docstring warns about (#1409 review).
+		await this.discardVaultScopedState(this.settings.vaultId ?? null);
 		this.syncEngine.bumpAuthGeneration();
 		this.noteStream?.disconnect();
 		this.replaceAuthProvider(this.createAuthProvider());

--- a/src/main.ts
+++ b/src/main.ts
@@ -1494,6 +1494,42 @@ export default class EngramSyncPlugin extends Plugin {
 			this.settings.vaultId = result.id;
 			this.settings.remoteVaultName = result.name;
 			this.api.setVaultId(this.settings.vaultId);
+
+			// #1409 (root cause). Reaching here means `settings.vaultId` was
+			// FALSY, so this registration just bound the install to a vault it
+			// was not bound to a moment ago. Two live paths null the vaultId
+			// without touching identity state — the 404 "vault no longer exists"
+			// heal and `onVaultDeleted` — and neither runs
+			// `resetForVaultChange`, so the path -> note_id map survives into a
+			// vault that has no such notes.
+			//
+			// The consequence is not cosmetic: `crdt_create` then proposes the
+			// PREVIOUS vault's ids, the server cannot reuse a foreign-vault id
+			// and answers with a fresh one, `serverId !== noteId` fails the
+			// seeded fast path, and the else-leg's routeModify broadcasts a
+			// sync_update that opens a room PER NOTE. Measured on a real
+			// 423-item import: 225 rooms for 317 notes, all source=edit, with
+			// ZERO crdt_update_log rows written — every one of them redundant,
+			// because the roomless genesis seed had already stored the state.
+			// It is also the #1318 cross-vault collision class the SERVER had
+			// to grow a re-mint for.
+			//
+			// Wiping is unconditionally correct on THIS branch specifically: a
+			// vault we just registered into holds no notes of ours, so every
+			// entry in the map is provably about a different vault. Guarded on
+			// non-empty only to keep first-ever install a silent no-op — the
+			// wipe also clears lastSync/cursors, and doing that noisily on a
+			// fresh install would look like a bug.
+			const carried = Object.keys(this.noteIdMap.toJSON()).length;
+			if (carried > 0) {
+				rlog().warn(
+					"lifecycle",
+					`Registered a new vault (${result.id}) while holding ${carried} note-id ` +
+						`mappings from a previous vault — wiping per-vault identity state`,
+				);
+				await this.syncEngine.resetForVaultChange();
+			}
+
 			await this.saveSettings();
 			rlog().info("lifecycle", `Vault registered: id=${result.id} slug=${result.slug}`);
 			return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1614,9 +1614,7 @@ export default class EngramSyncPlugin extends Plugin {
 				this.app.vault.getName(),
 				this.settings.clientId,
 			);
-			this.settings.vaultId = result.id;
 			this.settings.remoteVaultName = result.name;
-			this.api.setVaultId(this.settings.vaultId);
 
 			// #1409 (root cause). Reaching here means `settings.vaultId` was
 			// FALSY, so this registration just bound the install to a vault it
@@ -1639,10 +1637,19 @@ export default class EngramSyncPlugin extends Plugin {
 			//
 			// Wiping is unconditionally correct on THIS branch specifically: a
 			// vault we just registered into holds no notes of ours, so every
-			// entry in the map is provably about a different vault. Guarded on
-			// non-empty only to keep first-ever install a silent no-op — the
-			// wipe also clears lastSync/cursors, and doing that noisily on a
-			// fresh install would look like a bug.
+			// entry in the map is provably about a different vault.
+			//
+			// The wipe used to be gated on `carried > 0` — a non-empty note-id
+			// map — which read as a cheap "first install is a silent no-op"
+			// optimisation and was a bug: the map is only ONE of the things
+			// `resetForVaultChange` clears. lastSync and the catch-up cursor are
+			// scoped to the vault too, and `onVaultDeleted` empties the map
+			// without touching them. Registering after that took the guard's
+			// false branch and inherited a watermark from a DIFFERENT vault, so
+			// the first catch-up resumed from a seq that means nothing here and
+			// skipped every note below it. The guard now covers only the log,
+			// which is all it was ever justified for — on a genuine first
+			// install the wipe is a no-op, not an optimisation worth a branch.
 			const carried = Object.keys(this.noteIdMap.toJSON()).length;
 			if (carried > 0) {
 				rlog().warn(
@@ -1650,8 +1657,11 @@ export default class EngramSyncPlugin extends Plugin {
 					`Registered a new vault (${result.id}) while holding ${carried} note-id ` +
 						`mappings from a previous vault — wiping per-vault identity state`,
 				);
-				await this.syncEngine.resetForVaultChange();
 			}
+			// The full transition, not just the map: the sync gate's accepted
+			// fingerprint, the reconcile throttle and the strand-heal counts are
+			// all keyed to the outgoing vault as well.
+			await this.discardVaultScopedState(result.id);
 
 			await this.saveSettings();
 			rlog().info("lifecycle", `Vault registered: id=${result.id} slug=${result.slug}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -626,8 +626,15 @@ export default class EngramSyncPlugin extends Plugin {
 				// back to the room-opening disk-seed on delivery.
 				buildGenesisFrame: (path, noteId) =>
 					this.syncEngine.buildGenesisFrame(path, noteId),
-				onCreated: (localId, serverId, path, seeded, genesis) =>
-					this.syncEngine.applyCrdtCreateAck(localId, serverId, path, seeded, genesis),
+				onCreated: (localId, serverId, path, seeded, genesis, genesisOutcome) =>
+					this.syncEngine.applyCrdtCreateAck(
+						localId,
+						serverId,
+						path,
+						seeded,
+						genesis,
+						genesisOutcome,
+					),
 				onTerminal: (op, reason) =>
 					// A create/delete that retrying cannot fix. Surface it (error log) so
 					// it never silently vanishes; the queue then drops it (no infinite retry).

--- a/src/main.ts
+++ b/src/main.ts
@@ -2260,6 +2260,15 @@ export default class EngramSyncPlugin extends Plugin {
 					// arg can't silently make the fix inert (TS bivariance accepts a
 					// shorter closure).
 					catchupSince: makeCrdtCatchupSender(channel, () => this.settings.vaultId),
+					// Room-free full-state read for a diverged COLD note (#1409).
+					// Same vault guard as catchupSince: a stale channel would
+					// answer out of the WRONG vault's rows (#314).
+					docState: (id) => {
+						if (channel.getVaultId() !== this.settings.vaultId) {
+							throw new Error("crdt_doc_state: channel vault mismatch");
+						}
+						return channel.crdtDocState(id);
+					},
 				});
 
 				// Wire CRDT transport through this channel.

--- a/src/main.ts
+++ b/src/main.ts
@@ -254,6 +254,45 @@ export default class EngramSyncPlugin extends Plugin {
 	 *
 	 *  A fresh doc has a fresh clientID and an empty clock, and a discarded doc
 	 *  nobody observes broadcasts nothing. */
+	/** THE one place the active vault changes (#1409 consolidation).
+	 *
+	 *  There were two implementations: this one (reached from the sync-preview
+	 *  modal's picker) and `applyVaultSwitch` in the self-hosted tab, reached
+	 *  from the Connection page dropdown. They agreed on ONE of eight steps.
+	 *  The dropdown runs on a first pick AND when the stored vault no longer
+	 *  exists server-side — a real vault change carrying a full stale map — so
+	 *  the seven it skipped were live bugs, not dead code. Chief among them the
+	 *  path -> note_id map, which is per-vault identity: carrying it over makes
+	 *  `crdt_create` propose the old vault's ids (the #1318 collision class).
+	 *
+	 *  Persistence and UI follow-ups stay with the callers on purpose: the
+	 *  picker uses `savePluginData` precisely to AVOID `saveSettings`
+	 *  re-firing the sync-gate chain and stacking a second modal, while the
+	 *  dropdown wants exactly that chain. That difference is intentional; the
+	 *  state transition below is not allowed to differ.
+	 *
+	 *  Caller must have already established that `id` differs from the active
+	 *  vault — a no-op "switch" to the vault you are already on must not wipe
+	 *  anything. */
+	async switchVault(id: string, name?: string): Promise<void> {
+		this.settings.vaultId = id;
+		if (name !== undefined) this.settings.remoteVaultName = name;
+		this.api.setVaultId(id);
+		this.syncEngine.updateSettings(this.settings);
+		// Per-file hashes, lastSync, cursors AND the note-id map are scoped to
+		// the previous server vault.
+		await this.syncEngine.resetForVaultChange();
+		// The accepted-gate fingerprint covers (auth + vault); a new vault must
+		// re-prompt rather than inherit the old vault's consent.
+		this.syncGateAcceptedFor = null;
+		// New vault = new id/path space; re-reconcile on next connect (bypass
+		// the throttle — this isn't a storm, it's a real swap).
+		this.lastMapReconcileAt = 0;
+		// Strand-heal retry counts are keyed by the PREVIOUS vault's note_ids.
+		this.crdtWiring?.clearStrandHealAttempts();
+		this.syncEngine.setSyncBlocked(true);
+	}
+
 	resetIndexRoomForVault(): void {
 		this.indexRoom.destroy();
 		this.indexRoom = this.makeIndexRoom();
@@ -2853,25 +2892,7 @@ export default class EngramSyncPlugin extends Plugin {
 						// saveSettings — that path would re-fire
 						// doSyncWithFirstSyncCheck for the closed gate and stack
 						// a second modal on top of this one.
-						this.settings.vaultId = id;
-						this.settings.remoteVaultName = name;
-						this.api.setVaultId(id);
-						this.syncEngine.updateSettings(this.settings);
-						// Last sync and per-file hashes are scoped to the previous
-						// server vault. Without this reset, fullSync compares
-						// local mtime to a stale lastSync and pushes nothing —
-						// even when the new vault is empty.
-						await this.syncEngine.resetForVaultChange();
-						this.syncGateAcceptedFor = null;
-						// New vault = new id/path space; re-reconcile on next connect
-						// (bypass the throttle — this isn't a storm, it's a real swap).
-						this.lastMapReconcileAt = 0;
-						// Strand-heal retry counts are scoped to the previous vault's
-						// note_ids (final review MINOR-6) — stale counts here could
-						// prematurely give up on a note_id that happens to be reused
-						// in the new vault.
-						this.crdtWiring?.clearStrandHealAttempts();
-						this.syncEngine.setSyncBlocked(true);
+						await this.switchVault(id, name);
 						await this.savePluginData(this.syncEngine.getLastSync());
 						// Re-render the settings tab so the vault name span and
 						// any other vault-derived UI pick up the switch.

--- a/src/main.ts
+++ b/src/main.ts
@@ -2494,6 +2494,14 @@ export default class EngramSyncPlugin extends Plugin {
 						}
 						return channel.crdtDocState(id);
 					},
+					// #1409: release the server's room as soon as this device is
+					// done with the note, instead of leaving it to the 5-minute
+					// idle drain. Same vault guard as the two above — releasing
+					// against a stale channel would drop ANOTHER vault's room.
+					release: (id) => {
+						if (channel.getVaultId() !== this.settings.vaultId) return;
+						channel.crdtRelease(id);
+					},
 				});
 
 				// Wire CRDT transport through this channel.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -485,11 +485,21 @@ export class SyncEngine {
 	 *  path-keyed TTL maps — `recentlyPushed`, `remotelyDeleted`,
 	 *  `recentlyFlushed` — with one object per file. See synced-file.ts for the
 	 *  meaning of each marker and why `flushed` must stay distinct from `pushed`.
-	 *  Unlike the maps it replaces, its timers are cancelled on destroy(). */
-	private readonly files = new SyncedFileTable({
-		setTimeout: (cb, ms) => this.time.setTimeout(cb, ms),
-		clearTimeout: (id) => this.time.clearTimeout(id),
-	});
+	 *  Unlike the maps it replaces, its timers are cancelled on teardown.
+	 *
+	 *  Vault-scoped: the markers are PATH-keyed, so one stranded from the old
+	 *  vault suppresses a real event for the same path in the new one — push
+	 *  `Notes/a.md` to vault A, switch within the 5s echo window, and vault B's
+	 *  DIFFERENT note at that path is dropped as an echo. `remotelyDeleted` has
+	 *  the same shape and swallows a genuine user delete. It escaped the
+	 *  registry only because it is a composed object rather than a Map. */
+	private readonly files = this.track(
+		["vault", "destroy"],
+		new SyncedFileTable({
+			setTimeout: (cb, ms) => this.time.setTimeout(cb, ms),
+			clearTimeout: (id) => this.time.clearTimeout(id),
+		}),
+	);
 	/** note_ids THIS device recently deleted. Both CRDT convergence paths
 	 *  (the op-log replay's `applyOp` and `applyPushedNoteUpdate`'s fan-out)
 	 *  refuse to resurrect an id in here for RECENT_DELETE_COOLDOWN_MS. A stale
@@ -918,15 +928,26 @@ export class SyncEngine {
 	 *  manifestOwnerOf. Used to verify the local map before DESTRUCTIVE ops
 	 *  (moveIfIdRelocated's trash) — the local map itself can be cross-wired,
 	 *  so it cannot vouch for itself. */
-	private manifestPathOwners: Map<string, string> | null = null;
-
-	/** Epoch ms of the last manifest fetch ATTEMPT (success or failure). A
-	 *  destructive verdict is only trusted from a snapshot younger than the
-	 *  TTL: a stale snapshot returns a false "absent" for any note created
-	 *  after it was taken, which would green-light trashing that note. The
-	 *  attempt stamp also negative-caches failures so a manifest-less backend
-	 *  doesn't get a fetch per relocation event. */
-	private manifestOwnersFetchedAt = 0;
+	/** The snapshot and its freshness stamp, as ONE sweepable unit.
+	 *
+	 *  They must move together. `owners` being null means "no trustworthy
+	 *  snapshot" (callers get `undefined` and refuse to destroy); an EMPTY but
+	 *  non-null map means "a fresh manifest says every path is absent", which
+	 *  authorizes trashing. So a bare `.clear()` on the map alone would be
+	 *  strictly worse than leaking it — which is exactly why this could not be
+	 *  a plain tracked Map, and why it was the one collection that survived the
+	 *  vault sweep (#1409 review). Encapsulated so it cannot be half-cleared.
+	 *
+	 *  `fetchedAt` stamps the last fetch ATTEMPT, success or failure, so a
+	 *  manifest-less backend negative-caches instead of refetching per event. */
+	private manifestOwners = this.track(["vault", "destroy"], {
+		owners: null as Map<string, string> | null,
+		fetchedAt: 0,
+		clear(): void {
+			this.owners = null;
+			this.fetchedAt = 0;
+		},
+	});
 	private static readonly MANIFEST_OWNERS_TTL_MS = 30_000;
 
 	/** Paths whose id-keyed-move trash was REFUSED (ownership unknowable or
@@ -943,14 +964,14 @@ export class SyncEngine {
 	 *  snapshot when older than the TTL; trash decisions are rare (renames),
 	 *  so the refresh cost lands only on that cold path. */
 	private async manifestOwnerOf(path: string): Promise<string | null | undefined> {
-		const age = Date.now() - this.manifestOwnersFetchedAt;
-		const fresh = this.manifestOwnersFetchedAt > 0 && age <= SyncEngine.MANIFEST_OWNERS_TTL_MS;
+		const age = Date.now() - this.manifestOwners.fetchedAt;
+		const fresh = this.manifestOwners.fetchedAt > 0 && age <= SyncEngine.MANIFEST_OWNERS_TTL_MS;
 		if (!fresh) {
-			this.manifestOwnersFetchedAt = Date.now();
+			this.manifestOwners.fetchedAt = Date.now();
 			// A failed/absent refresh leaves NO trustworthy snapshot: keeping a
 			// stale one would let its false "absent" answers authorize a wrong
 			// trash. Refusing (undefined) is always recoverable; a trash is not.
-			this.manifestPathOwners = null;
+			this.manifestOwners.owners = null;
 			try {
 				const manifest = await this.api.getManifest();
 				if (manifest) this.cacheManifestOwners(manifest);
@@ -958,15 +979,15 @@ export class SyncEngine {
 				// negative-cached by the attempt stamp above
 			}
 		}
-		if (!this.manifestPathOwners) return undefined;
-		return this.manifestPathOwners.get(path) ?? null;
+		if (!this.manifestOwners.owners) return undefined;
+		return this.manifestOwners.owners.get(path) ?? null;
 	}
 
 	private cacheManifestOwners(manifest: ManifestResponse): void {
-		this.manifestPathOwners = new Map(
+		this.manifestOwners.owners = new Map(
 			manifest.notes.filter((n) => n.id).map((n) => [normalizePath(n.path), n.id as string]),
 		);
-		this.manifestOwnersFetchedAt = Date.now();
+		this.manifestOwners.fetchedAt = Date.now();
 	}
 
 	/** Trash files whose refused id-keyed-move turned out to be a genuine
@@ -975,7 +996,7 @@ export class SyncEngine {
 	private async sweepPendingOrphans(): Promise<void> {
 		for (const p of [...this.pendingOrphanSweep]) {
 			this.pendingOrphanSweep.delete(p);
-			if (this.manifestPathOwners?.has(p)) continue; // live server-side note
+			if (this.manifestOwners.owners?.has(p)) continue; // live server-side note
 			if (this.noteIdMap?.get(p)) continue; // locally claimed again
 			const file = this.app.vault.getFileByPath(p);
 			if (!file) continue;
@@ -2321,6 +2342,16 @@ export class SyncEngine {
 	 *  queue for terminal failures (e.g. 413 Payload Too Large). */
 	readonly issues: IssueStore = new IssueStore();
 
+	/** `IssueStore` already owns `clear(path)`, so it cannot satisfy the
+	 *  sweepable shape directly — this adapter registers it without renaming a
+	 *  public API. Vault-scoped because plan-limit parks are per-vault: a Free
+	 *  vault's 402 attachments-disabled park must not suppress the same path on
+	 *  a Pro or self-host vault, where `pushFile` short-circuits BEFORE any
+	 *  request so nothing ever arrives to clear it (#1409 review). */
+	private readonly issuesSweeper = this.track(["vault", "destroy"], {
+		clear: () => this.issues.clearAll(),
+	});
+
 	/** Per-file explicit ignores (the Sync Center "Ignore" button). Honored by
 	 *  shouldIgnore so excluded files never enter push plans, isSyncable filters,
 	 *  or the Issues list. Distinct from settings.ignorePatterns (regex textarea). */
@@ -3116,12 +3147,9 @@ export class SyncEngine {
 	 *  without reverting a fresher local edit — the property that makes this a
 	 *  legal substitute, and the one the feed's plaintext `content` lacks.
 	 *
-	 *  Convergence is recorded on the SAME proof as the room path: not "the
-	 *  fetch resolved", but the doc verifiably projecting the row's content.
-	 *  We stage first and let the manager's remote-merge listener drive
-	 *  `commitCrdtConvergence` exactly as it does for a STEP2, so an apply that
-	 *  lands short (a snapshot genuinely older than this feed row) leaves the
-	 *  stage in place for the next catch-up rather than recording a lie.
+	 *  ONLY legal when this device holds no undelivered ops for the note — see
+	 *  the gate below. The frame is a read; it cannot carry anything upward, so
+	 *  a note with local work must take the room.
 	 *
 	 *  ANY failure falls back to the room handshake. An old backend rejects the
 	 *  unknown frame, a rate limit rejects it, a dropped socket rejects it — in
@@ -3147,8 +3175,23 @@ export class SyncEngine {
 			change.seq,
 		);
 
+		// THE PRECONDITION (adversarial review): `crdt_doc_state` is a READ. The
+		// room handshake it replaces is BIDIRECTIONAL — the server answers a
+		// syncStep1 with [syncStep2, syncStep1] and the client's reply to that
+		// second step1 IS the upload half. So this path can only converge a note
+		// the client has nothing to say about.
+		//
+		// Taken when the client DOES hold undelivered ops, it downloads, marks
+		// the note synced, and the local ops are never transmitted: complete on
+		// this device, blank everywhere else, and stamped as in-sync so every
+		// later catch-up compares equal hashes and skips it. Permanently.
+		//
+		// `hasUndeliveredOps` is the conservative question (a never-handshook doc
+		// reads as undelivered), which is the right bias here: the room is always
+		// CORRECT, just more expensive. Convergence is the invariant; saving the
+		// room is the optimization.
 		const fetchState = this.crdtDocState;
-		if (fetchState && this.crdt) {
+		if (fetchState && this.crdt && !this.crdt.hasUndeliveredOps(noteId)) {
 			try {
 				const { b64 } = await fetchState(noteId);
 				// Flushes disk on the merge and AWAITS that write, so a failed
@@ -9819,6 +9862,29 @@ export class SyncEngine {
 			// entries stay queued and drain when the gate reopens (re-auth →
 			// applySyncGate → fullSync → pushModifiedFiles → flushQueue).
 			if (this.syncBlocked) break;
+
+			// The entry was created under a DIFFERENT vault. `this.api` points at
+			// whichever vault is active now, so delivering it executes against the
+			// wrong one — and for a delete that is destructive: an offline delete
+			// of `Notes/x.md` queued in vault A fires `deleteNote("Notes/x.md")`
+			// against vault B once the consent gate reopens, destroying an
+			// unrelated note at the same path. The entries have always carried a
+			// `vaultId`, but it was used only as a DEDUP key, never to gate
+			// delivery. `CrdtOpQueue.dropIfForeignVault` already does exactly this
+			// for the CRDT outbox; the REST queue was the one that did not (#1409
+			// review).
+			const owner = this.entryVaultId(entry);
+			const active = this.settings.vaultId;
+			if (owner && active && owner !== active) {
+				rlog().warn(
+					"queue",
+					`Dropping queued op for ${noteRef(entry.path)} — queued under a different ` +
+						`vault (${owner.slice(0, 8)}), active is ${active.slice(0, 8)}`,
+				);
+				await this.queue.dequeue(entry.path, owner);
+				continue;
+			}
+
 			try {
 				if (entry.action === "delete") {
 					// FENCE (#416 review finding 0): the drain is a delete-push path

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2856,31 +2856,94 @@ export class SyncEngine {
 				: true;
 		opts.onHistoryResolved?.(effectiveIdHasHistory);
 
-		if (
-			seeded &&
-			sameId &&
-			opts.genesisUpdate &&
-			opts.genesisContent !== undefined &&
-			!effectiveIdHasHistory
-		) {
-			let preApplyDisk: string | null = null;
-			try {
-				preApplyDisk = await this.app.vault.cachedRead(file);
-			} catch {
-				// unreadable — proceed without drift protection
+		// THE INVARIANT (#476): a note's body reaches the server exactly ONCE per
+		// create. Writing the body into an EMPTY doc mints a brand-new lineage
+		// with a fresh clientID; if the server already stored our genesis bytes,
+		// that lineage is a RIVAL carrying identical text with no shared
+		// identity. Yjs unions rivals rather than deduplicating them, so the body
+		// doubles, the merge flushes to disk, and the next import reads the
+		// doubled file and doubles it again. Measured: a 34 KB note reached
+		// 4.9 MB with its 225 distinct lines repeated 144 times.
+		//
+		// `seeded === true` is the server's statement that it holds our bytes. So
+		// the three states below are exhaustive, and only ONE of them may push:
+		//
+		//   seeded + empty doc  -> ADOPT the server's lineage (pull, never push)
+		//   not seeded          -> the server has nothing; pushing is correct
+		//   doc has history     -> a real lineage exists; routeModify's `lca`
+		//                          makes it a minimal diff onto that lineage,
+		//                          not a second one
+		//
+		// Expressing it as "which state are we in" rather than a conjunction of
+		// four booleans is deliberate: the conjunction form let ANY false
+		// condition fall through to a silent second transmission, and nothing
+		// detected it — not a test, not an assertion, not a log.
+		if (seeded && !effectiveIdHasHistory) {
+			// Cheapest legal route: the server took OUR bytes under OUR id, so we
+			// already hold exactly what it stored. No round trip needed.
+			if (sameId && opts.genesisUpdate && opts.genesisContent !== undefined) {
+				let preApplyDisk: string | null = null;
+				try {
+					preApplyDisk = await this.app.vault.cachedRead(file);
+				} catch {
+					// unreadable — proceed without drift protection
+				}
+				await this.crdt.applyRemoteUpdate(effectiveId, opts.genesisUpdate);
+				let consumed: string | null = opts.genesisContent;
+				// M1: `genesisContent` was frozen before the create round-trip, and
+				// the apply above flushes it over disk. Anything that landed in that
+				// window survives only in `preApplyDisk`. Merged back as a minimal
+				// diff (the doc has history now). NO reread — it would read the
+				// just-reverted disk and discard the drift.
+				if (preApplyDisk !== null && preApplyDisk !== opts.genesisContent) {
+					const merged = await this.crdt.applyLocalEdit(effectiveId, preApplyDisk);
+					if (merged !== null) {
+						consumed = merged;
+						await this.flushFromCrdt(normalized, merged);
+					}
+				}
+				return consumed;
 			}
-			await this.crdt.applyRemoteUpdate(effectiveId, opts.genesisUpdate);
-			let consumed: string | null = opts.genesisContent;
-			if (preApplyDisk !== null && preApplyDisk !== opts.genesisContent) {
-				const merged = await this.crdt.applyLocalEdit(effectiveId, preApplyDisk);
-				if (merged !== null) {
-					consumed = merged;
-					await this.flushFromCrdt(normalized, merged);
+
+			// The server re-id'd us (#1409): it stored our body under a lineage we
+			// do not have. Pushing again is exactly how the doubling happens, so
+			// ADOPT its lineage instead — a room-free read (#1467). Applying is a
+			// monotonic merge, so this can only converge us toward the server.
+			const fetchState = this.crdtDocState;
+			if (fetchState) {
+				try {
+					const { b64 } = await fetchState(effectiveId);
+					await this.crdt.applyRemoteUpdate(effectiveId, fromB64(b64));
+					rlog().info(
+						"crdt",
+						`create: adopted server lineage for ${noteRef(normalized)} (re-id) — body not re-sent`,
+					);
+					return await this.crdt.projectedText(effectiveId);
+				} catch (e) {
+					rlog().warn(
+						"crdt",
+						`create: could not adopt server lineage for ${noteRef(normalized)}: ${errMsg(e, normalized)}`,
+					);
 				}
 			}
-			return consumed;
+
+			// No way to adopt (old backend, rate limit, dropped socket). Pushing
+			// here would double the body, so we deliberately do NOTHING: the
+			// server already holds the content, and this note is now an ordinary
+			// diverged COLD note that the catch-up receive path converges. Slower
+			// than seeding, and the ONLY option that cannot corrupt.
+			rlog().warn(
+				"crdt",
+				`create: server seeded ${noteRef(normalized)} under a different id and its state ` +
+					`is unavailable — deferring to catch-up rather than re-sending the body`,
+			);
+			return null;
 		}
 
+		// Either the server declined the seed (it has nothing — pushing is the
+		// only way it ever gets the body), or this doc already carries a real
+		// lineage (so `applyLocalEdit`'s `lca` diffs against it instead of
+		// minting a rival). Both are safe to transmit.
 		return await routeModify(
 			{
 				crdtEligible: true,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -394,14 +394,92 @@ class OpLogFetchError extends Error {
 	}
 }
 
+/** A collection the engine can sweep on teardown. Map and Set both satisfy it. */
+type Sweepable = { clear(): void };
+
+/**
+ * The two teardowns a collection can die in. They are INDEPENDENT, not a
+ * severity ladder: `syncState` is swept on a vault switch but must survive
+ * `destroy()` (it is the persisted sync baseline, and blanking it there would
+ * force a full re-scan), while `debounceTimers` is the exact inverse — a
+ * debounce pending across a vault switch still describes a real local edit
+ * that still deserves a push. Collapsing these into one axis is what let the
+ * two hand-written lists drift apart in the first place.
+ */
+type SweepEvent = "vault" | "destroy";
+
 export class SyncEngine {
-	private debounceTimers: Map<string, number> = new Map();
+	/**
+	 * Every collection that a teardown has to sweep, declared WITH its scope so
+	 * that neither teardown path enumerates anything by hand.
+	 *
+	 * This replaces two independently-maintained lists — `destroy()` and
+	 * `wipePerVaultState()` — that had been drifting apart since March 2026.
+	 * Each was correct for its own job: `destroy()` swept the transient
+	 * per-note maps and deliberately spared the persisted `syncState`, while
+	 * `wipePerVaultState()` swept `syncState` + cursors + identity and left the
+	 * per-note maps alone. Nothing owned their INTERSECTION — state that is both
+	 * vault-scoped and transient — so eleven note_id- and path-keyed maps
+	 * survived a vault switch and went on addressing the NEW vault with the OLD
+	 * vault's ids (#1409). Six separate bug fixes added a field to one list and
+	 * not the other, because a declaration 3,000 lines from either list carries
+	 * no hint that a decision is owed.
+	 *
+	 * `vault`   — describes the remote vault (paths, note_ids, cursors).
+	 *             Swept on a vault switch AND on destroy.
+	 * `install` — local operating state that legitimately outlives a vault
+	 *             switch (in-flight push guards, debounce timers). Destroy only.
+	 *
+	 * Declared FIRST: class field initializers run top-to-bottom, and every
+	 * `track()` call below pushes into this array.
+	 */
+	private readonly sweepable: Array<{
+		on: readonly SweepEvent[];
+		collection: Sweepable;
+		dispose?: (value: unknown) => void;
+	}> = [];
+
+	/**
+	 * Register a collection for teardown and return it, so the scope decision
+	 * lives at the declaration rather than in a list somewhere else.
+	 * `dispose` runs per map value before the clear — that is where a timer
+	 * gets cancelled, so sweeping can never strand one.
+	 */
+	private track<T extends Sweepable>(
+		on: readonly SweepEvent[],
+		collection: T,
+		dispose?: (value: T extends Map<unknown, infer V> ? V : never) => void,
+	): T {
+		this.sweepable.push({
+			on,
+			collection,
+			dispose: dispose as ((value: unknown) => void) | undefined,
+		});
+		return collection;
+	}
+
+	/** Dispose + clear every tracked collection registered for `event`. */
+	private sweep(event: SweepEvent): void {
+		for (const entry of this.sweepable) {
+			if (!entry.on.includes(event)) continue;
+			if (entry.dispose) {
+				for (const value of (entry.collection as Map<unknown, unknown>).values()) {
+					entry.dispose(value);
+				}
+			}
+			entry.collection.clear();
+		}
+	}
+
+	private debounceTimers = this.track(["destroy"], new Map<string, number>(), (timer) =>
+		this.time.clearTimeout(timer),
+	);
 	/** Paths that newly degraded (ok/none -> frontmatter issue) since the last
 	 *  flush, awaiting the debounced Notice below. */
-	private pendingDegraded: Set<string> = new Set();
+	private pendingDegraded = this.track(["destroy"], new Set<string>());
 	private degradedNoticeTimer: number | null = null;
 	private ignorePatterns: string[] = [];
-	private pushing: Set<string> = new Set();
+	private pushing = this.track(["destroy"], new Set<string>());
 	/** Per-path echo-suppression markers (#358). Replaces three parallel
 	 *  path-keyed TTL maps — `recentlyPushed`, `remotelyDeleted`,
 	 *  `recentlyFlushed` — with one object per file. See synced-file.ts for the
@@ -419,7 +497,11 @@ export class SyncEngine {
 	 *  applies. Keyed by note_id (the key both paths check by), unlike the
 	 *  path-keyed offline-queue `hasPendingDelete` guard which only covers a
 	 *  delete STILL queued (this covers one already sent/dequeued). */
-	private recentlyDeleted: Map<string, { timer: number; path: string }> = new Map();
+	private recentlyDeleted = this.track(
+		["vault", "destroy"],
+		new Map<string, { timer: number; path: string }>(),
+		({ timer }) => this.time.clearTimeout(timer),
+	);
 	private pulling = false;
 	private lastSync = "";
 	private lastError = "";
@@ -447,7 +529,7 @@ export class SyncEngine {
 	 *  Used to detect whether the user actually modified a file since
 	 *  the last sync (Obsidian sets mtime to "now" on vault.modify(),
 	 *  making mtime-based detection unreliable). */
-	private syncState: Map<string, FileSyncState> = new Map();
+	private syncState = this.track(["vault"], new Map<string, FileSyncState>());
 
 	/** The server vaultId that the current syncState belongs to. lastSync and
 	 *  per-file hashes are scoped to one server vault; if the active vault
@@ -665,7 +747,11 @@ export class SyncEngine {
 	 *  might still arrive. Bounded by a TTL: a note that is never materialized at
 	 *  the new path must not pin a stale origin forever, or a LATER genuine
 	 *  create at that path would be turned into a move of an unrelated file. */
-	private relocatedFrom = new Map<string, { from: string; timer: number }>();
+	private relocatedFrom = this.track(
+		["vault", "destroy"],
+		new Map<string, { from: string; timer: number }>(),
+		({ timer }) => this.time.clearTimeout(timer),
+	);
 
 	/** note_id -> where THIS engine last put that note's file.
 	 *
@@ -684,7 +770,7 @@ export class SyncEngine {
 	 *
 	 *  Best-effort by nature -- an in-memory record of what this process did, not
 	 *  an authority. Consumers verify against the disk before acting on it. */
-	private fileForNote = new Map<string, string>();
+	private fileForNote = this.track(["vault", "destroy"], new Map<string, string>());
 
 	/** Record that `path` currently holds whichever note claims it. Called after
 	 *  this engine puts a note's bytes somewhere: a create, a move, a local
@@ -847,7 +933,7 @@ export class SyncEngine {
 	 *  refusal leaves a duplicate file no id references — nothing else would
 	 *  ever clean it. Swept by the next reconcile against a fresh manifest:
 	 *  absent from the manifest + unclaimed by the local map -> trash then. */
-	private pendingOrphanSweep = new Set<string>();
+	private pendingOrphanSweep = this.track(["vault", "destroy"], new Set<string>());
 
 	/** Who does the server say owns `path` (normalized)? Returns the owning id,
 	 *  null when a FRESH manifest confirms the path is absent, or undefined
@@ -995,14 +1081,20 @@ export class SyncEngine {
 	 *  next push (the rename's new-path push, same id) must go REST-first to
 	 *  move/resurrect the row, not CRDT (which the channel drops for a note the
 	 *  server sees as absent). Routing it CRDT would silently strand the rename. */
-	private confirmedNoteIds: Set<string> = new Set();
+	/** Vault-scoped: a confirmed id from the OLD vault would key CRDT frames and
+	 *  rooms against the NEW one — the cross-vault flavor of the 2026-07-07
+	 *  cross-wire class (plugin #200). Ids re-learn via manifest reconcile. */
+	private confirmedNoteIds = this.track(["vault", "destroy"], new Set<string>());
 
 	/** Per-note re-handshake attempt tracking for the live-bound catch-up path,
 	 *  keyed by note_id. `hash` is the server content_hash being retried; a new
 	 *  hash starts a fresh episode. Purely diagnostic now (the logged attempt
 	 *  number, and cleared on commit) — convergence recording lives entirely in
 	 *  `commitCrdtConvergence`; this map never gates a retry. */
-	private crdtRehandshakeAttempts: Map<string, { hash: string; attempts: number }> = new Map();
+	private crdtRehandshakeAttempts = this.track(
+		["vault", "destroy"],
+		new Map<string, { hash: string; attempts: number }>(),
+	);
 
 	/** Fix wave 1 (single-path D3 review): staged convergence for a diverged
 	 *  note, keyed by note_id — staged by the LIVE-BOUND leg and, since Phase
@@ -1032,10 +1124,19 @@ export class SyncEngine {
 	 *  compute client-side — so it stages `content: null`, which keeps the
 	 *  pre-wave-5 best-effort behavior (commit on the next non-empty frame,
 	 *  unverified). */
-	private pendingConvergence: Map<
-		string,
-		{ path: string; serverHash: string; content: string | null; version?: number; seq?: number }
-	> = new Map();
+	private pendingConvergence = this.track(
+		["vault", "destroy"],
+		new Map<
+			string,
+			{
+				path: string;
+				serverHash: string;
+				content: string | null;
+				version?: number;
+				seq?: number;
+			}
+		>(),
+	);
 
 	/** Fix wave 1: per-note_id cooldown for `socketConverge`'s STEP1
 	 *  re-handshake — bounds how often a live-bound note can re-fire reset+
@@ -1045,7 +1146,7 @@ export class SyncEngine {
 	 *  `Date.now()`, set ONLY when a handshake actually fires — never on a
 	 *  suppressed attempt. `healCooldownMs` is a public instance field so
 	 *  tests can shrink it. */
-	private crdtHealCooldown: Map<string, number> = new Map();
+	private crdtHealCooldown = this.track(["vault", "destroy"], new Map<string, number>());
 
 	/** Fix wave 2 (CI-found defect: `test_deaf_note_survives_handshake_rate_
 	 *  limit_and_heals_on_restore`): a poke suppressed by the cooldown must
@@ -1056,7 +1157,11 @@ export class SyncEngine {
 	 *  trailing timer per note_id for the remaining window; further pokes for
 	 *  the same note while a trailing timer is armed coalesce into it (no
 	 *  second timer). Cleared in `destroy()`. */
-	private crdtHealTrailingTimers: Map<string, number> = new Map();
+	private crdtHealTrailingTimers = this.track(
+		["vault", "destroy"],
+		new Map<string, number>(),
+		(timer) => this.time.clearTimeout(timer),
+	);
 
 	/** See `crdtHealCooldown`. 15s (fix wave 2, was 30s): long enough that
 	 *  open+catch-up+heal racing on the same note collapse to one handshake,
@@ -1072,7 +1177,10 @@ export class SyncEngine {
 	 *  pending local ops on that same round-trip. A nudge lost to a socket
 	 *  drop leaves the entry queued; the next flush re-fires (cooldown-
 	 *  bounded). Keyed by note_id → the entry's dequeue coordinates. */
-	private pendingQueueDeliveries: Map<string, { path: string; vaultId?: string }> = new Map();
+	private pendingQueueDeliveries = this.track(
+		["vault", "destroy"],
+		new Map<string, { path: string; vaultId?: string }>(),
+	);
 
 	/** Public: true once this SESSION observed this note's create-ack. Was
 	 *  formerly wired as `CrdtManagerOptions.canSendLive` in main.ts, but that
@@ -2443,7 +2551,13 @@ export class SyncEngine {
 	 *  `invalidateIfVaultChanged`) call this — keeping them in lockstep is the
 	 *  point; a wipe that exists on only one path re-opens #200. */
 	private async wipePerVaultState(): Promise<void> {
-		this.syncState.clear();
+		// Every collection registered for "vault" at its declaration — syncState,
+		// the note_id-keyed CRDT bookkeeping, the path-keyed markers — cleared in
+		// one pass, with timer-holding maps disposed by their declaration hooks.
+		// Before this, the list below was hand-written and eleven vault-scoped
+		// maps were missing from it (#1409); adding a field no longer requires
+		// remembering that this method exists.
+		this.sweep("vault");
 		this.lastSync = "";
 		// The socket op-log replay cursor marks a position in the OLD vault's
 		// seq feed — reset to 0 so the next catch-up replays the new vault from
@@ -2455,14 +2569,13 @@ export class SyncEngine {
 		// and wrongly short-circuit the first reconcile after a swap.
 		this.manifestSeq = 0;
 		this.lastValidatorRewind = null;
-		// The note-id map and confirmed set are per-vault identity state.
-		// Carrying them across vaults keys CRDT frames/rooms by another
-		// vault's note ids — the cross-vault flavor of the 2026-07-07
-		// cross-wire class (plugin #200). Wipe both; ids re-learn via the
-		// manifest reconcile + push adoption. clear() mutates in place: the
-		// instance is shared with main.ts + live views.
+		// The note-id map is per-vault identity state but is NOT a tracked
+		// collection: the instance is shared with main.ts + live views, so it is
+		// cleared in place rather than swept. Carrying it across vaults keys CRDT
+		// frames/rooms by another vault's note ids — the cross-vault flavor of the
+		// 2026-07-07 cross-wire class (plugin #200). Ids re-learn via the manifest
+		// reconcile + push adoption. (`confirmedNoteIds` rides the sweep above.)
 		this.noteIdMap?.clear();
-		this.clearConfirmedNoteIds();
 		// The durable op queue and the unsent-doc set are the two places a note_id
 		// outlives the vault it was minted in. A CrdtOp carries a bare docId and NO
 		// vault, so a create still pending when the user switches vaults is flushed
@@ -2473,17 +2586,6 @@ export class SyncEngine {
 		// safe because lastSync is cleared above, so a later switch BACK re-derives
 		// and re-pushes anything they carried.
 		this.crdtResetOutbox?.();
-		// note_ids are only unique WITHIN a vault (final review MINOR-6) — a
-		// relocation timestamp recorded for an id under the OLD vault must not
-		// survive to stale-gate an unrelated note that happens to reuse the same
-		// id in the new vault. Living here (not just resetForVaultChange) keeps
-		// BOTH vault-change paths in lockstep, per this method's contract.
-		this.lastRelocationTs.clear();
-		// Engine-trash counters are path-keyed and therefore vault-scoped: a
-		// counter stranded in the OLD vault (event eaten by a throw or a closed
-		// gate) must not consume a same-path delete in the NEW one (#419
-		// pre-merge review finding 4).
-		this.engineTrashedPaths.clear();
 		// Folder markers are vault-scoped too: a stale set after a switch lets
 		// handleFolderDelete push marker deletes against the NEW vault (post-
 		// merge review finding 8 — data-safe but cross-vault noise).
@@ -2737,13 +2839,12 @@ export class SyncEngine {
 		normalized: string;
 		file: TFile;
 		seeded: boolean;
-		/** `serverId === the id we asked for` — an ADOPT remap must never trust
-		 *  `seeded`, since the frame landed against a row we did not name. */
+		/** `serverId === the id we asked for`. False means the server answered
+		 *  under an id of its own choosing, so the bytes it stored are filed
+		 *  under a lineage we have never seen. */
 		sameId: boolean;
 		genesisUpdate: Uint8Array | undefined;
 		genesisContent: string | undefined;
-		/** pushFile surfaces a genesis race here; the queued path has no
-		 *  equivalent signal to report. */
 		onHistoryResolved?: (effectiveIdHasHistory: boolean) => void;
 	}): Promise<string | null> {
 		if (!this.crdt) return null;
@@ -3096,7 +3197,13 @@ export class SyncEngine {
 	 *  with its own event regardless of interleaving; the only leak is a
 	 *  crash that eats the event, costing one echo-skipped (resurrectable)
 	 *  delete at that path later — the cheap failure. */
-	private readonly engineTrashedPaths = new Map<string, number>();
+	/** Vault-scoped: path-keyed, so a counter stranded in the OLD vault (event
+	 *  eaten by a throw or a closed gate) must not consume a same-path delete in
+	 *  the NEW one (#419 pre-merge review finding 4). */
+	private readonly engineTrashedPaths = this.track(
+		["vault", "destroy"],
+		new Map<string, number>(),
+	);
 
 	private consumeEngineTrash(path: string): boolean {
 		const n = this.engineTrashedPaths.get(path) ?? 0;
@@ -3628,7 +3735,7 @@ export class SyncEngine {
 	}
 
 	/** Paths modified during a pull that need pushing once pull completes. */
-	private pendingPostPullPushes: Set<string> = new Set();
+	private pendingPostPullPushes = this.track(["vault", "destroy"], new Set<string>());
 
 	/** Push a single file to Engram. Returns true on success.
 	 *  When force is true, skip echo suppression (used by pushAll).
@@ -4753,7 +4860,12 @@ export class SyncEngine {
 	 *  callers), so the user's modal ALWAYS coalesces: without this it renders
 	 *  a dead 0% bar with no filenames for the whole pull, then one final
 	 *  number. Registration is scoped to each caller's own await. */
-	private seqReplayFileListeners = new Set<(path: string) => void>();
+	/** Destroy-only: this holds in-flight replay CALLBACKS, not vault data, and
+	 *  each registration already removes itself in a `finally`. Sweeping it on a
+	 *  vault switch would drop a listener out from under a replay that is still
+	 *  unwinding; the replay itself is what a switch has to stop, not its
+	 *  subscribers. */
+	private seqReplayFileListeners = this.track(["destroy"], new Set<(path: string) => void>());
 	private seqHealLastAt = 0;
 	private seqHealTimer: number | null = null;
 	private static readonly SEQ_HEAL_COOLDOWN_MS = 4_000;
@@ -6805,7 +6917,10 @@ export class SyncEngine {
 	 *  the pull feed's `updated_at` is only seconds-precision on the wire, so
 	 *  two genuinely different relocations for the same id within one second
 	 *  can tie exactly. A tie can't be proven newer, so it must not win. */
-	private lastRelocationTs = new Map<string, number>();
+	/** Vault-scoped: note_ids are unique only WITHIN a vault (review MINOR-6), so
+	 *  a relocation timestamp from the OLD vault must not stale-gate an unrelated
+	 *  note that reuses the same id in the new one. */
+	private lastRelocationTs = this.track(["vault", "destroy"], new Map<string, number>());
 
 	private async moveIfIdRelocated(id: string, newPath: string, eventTs?: number): Promise<void> {
 		// Both authoritative upsert paths (the WS broadcast and the pull feed)
@@ -9769,22 +9884,13 @@ export class SyncEngine {
 
 	/** Cancel all pending debounce, cooldown, and health check timers. */
 	destroy(): void {
-		for (const timer of this.debounceTimers.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.debounceTimers.clear();
-		// Was three near-identical clear-every-timer loops, one per marker map.
+		// Every tracked collection registered for "destroy", timers cancelled by
+		// the dispose hooks at their declarations. `syncState` is registered for
+		// "vault" only and so is deliberately spared here: it is the persisted
+		// sync baseline, not transient state.
+		this.sweep("destroy");
 		this.files.destroy();
-		for (const { timer } of this.recentlyDeleted.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.recentlyDeleted.clear();
-		for (const { timer } of this.relocatedFrom.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.relocatedFrom.clear();
-		this.fileForNote.clear();
-		this.pendingPostPullPushes.clear();
+		// Standalone timer handles — not collections, so they stay explicit.
 		if (this.seqHealTimer !== null) {
 			this.time.clearTimeout(this.seqHealTimer);
 			this.seqHealTimer = null;
@@ -9793,24 +9899,8 @@ export class SyncEngine {
 			this.time.clearTimeout(this.postPullDrainTimer);
 			this.postPullDrainTimer = null;
 		}
-		for (const timer of this.crdtHealTrailingTimers.values()) {
-			this.time.clearTimeout(timer);
-		}
-		this.crdtHealTrailingTimers.clear();
-		// Per-note CRDT bookkeeping that holds no timers, so nothing leaks if it
-		// survives — but it is per-engine-lifetime state and every sibling map
-		// above is swept here. Left behind, a reused engine would carry a stale
-		// heal cooldown (suppressing a handshake the new session needs), a stale
-		// re-handshake attempt count, and a staged convergence for a note whose
-		// room is gone. `syncState` is deliberately NOT in this list: it is the
-		// persisted sync baseline, not transient state.
-		this.pendingConvergence.clear();
-		this.crdtRehandshakeAttempts.clear();
-		this.crdtHealCooldown.clear();
-		this.pendingQueueDeliveries.clear();
 		if (this.degradedNoticeTimer) this.time.clearTimeout(this.degradedNoticeTimer);
 		this.degradedNoticeTimer = null;
-		this.pendingDegraded.clear();
 		this.stopHealthCheck();
 		this.queue.destroy();
 	}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -430,10 +430,10 @@ export class SyncEngine {
 	 * not the other, because a declaration 3,000 lines from either list carries
 	 * no hint that a decision is owed.
 	 *
-	 * `vault`   — describes the remote vault (paths, note_ids, cursors).
-	 *             Swept on a vault switch AND on destroy.
-	 * `install` — local operating state that legitimately outlives a vault
-	 *             switch (in-flight push guards, debounce timers). Destroy only.
+	 * `["vault", "destroy"]` — describes the remote vault (paths, note_ids,
+	 *             cursors). Swept on a vault switch AND on destroy.
+	 * `["destroy"]` — local operating state that legitimately outlives a vault
+	 *             switch (in-flight push guards, debounce timers).
 	 *
 	 * Declared FIRST: class field initializers run top-to-bottom, and every
 	 * `track()` call below pushes into this array.
@@ -459,16 +459,41 @@ export class SyncEngine {
 		return collection;
 	}
 
-	/** Dispose + clear every tracked collection registered for `event`. */
+	/** Dispose + clear every tracked collection registered for `event`.
+	 *
+	 *  Each entry is isolated. A throw used to abandon the whole sweep at the
+	 *  first bad entry, leaving every collection AFTER it fully populated — and
+	 *  since the registry exists precisely so a vault switch cannot leave the
+	 *  previous vault's note_ids behind, one throwing dispose would reinstate
+	 *  the bug for all of them, silently and in registration order. Failures are
+	 *  collected and logged; the `clear()` still runs even when the dispose for
+	 *  that same entry threw, because a leaked timer is a smaller problem than a
+	 *  retained cross-vault map. */
 	private sweep(event: SweepEvent): void {
+		const failures: string[] = [];
 		for (const entry of this.sweepable) {
 			if (!entry.on.includes(event)) continue;
 			if (entry.dispose) {
 				for (const value of (entry.collection as Map<unknown, unknown>).values()) {
-					entry.dispose(value);
+					try {
+						entry.dispose(value);
+					} catch (e) {
+						failures.push(`dispose: ${errMsg(e)}`);
+					}
 				}
 			}
-			entry.collection.clear();
+			try {
+				entry.collection.clear();
+			} catch (e) {
+				failures.push(`clear: ${errMsg(e)}`);
+			}
+		}
+		if (failures.length > 0) {
+			rlog().warn(
+				"lifecycle",
+				`sweep(${event}): ${failures.length} entr${failures.length === 1 ? "y" : "ies"} ` +
+					`failed but the rest were swept — ${failures.join("; ")}`,
+			);
 		}
 	}
 
@@ -3492,6 +3517,25 @@ export class SyncEngine {
 			// under a plan issue) would leave the bar painting the stale count
 			// forever — nothing polls it.
 			this.emitStatus();
+			// Re-check the gate AT FIRE TIME. `handleModify` checked it when the
+			// timer was armed, but the gate can close during the debounce window —
+			// a vault switch, a re-consent prompt, a dead-vault heal — and
+			// `pushFile` has no gate of its own. The armed timer then wrote into
+			// whatever vault is active when it fired, which after a switch is a
+			// DIFFERENT vault the user has not consented to sync yet.
+			//
+			// Dropping the push does not drop the edit: the file's disk content no
+			// longer matches its recorded baseline, so the full sync that runs when
+			// the gate reopens picks it up. That is also why `debounceTimers` stays
+			// destroy-only in the sweep registry — the pending edit is real, it just
+			// must not be delivered by this timer.
+			if (this.syncBlocked) {
+				devLog().log(
+					"sync-blocked",
+					`debounced push dropped — gate closed during the window: ${armedPath}`,
+				);
+				return;
+			}
 			void this.pushFile(file);
 		}, this.settings.debounceMs);
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -13,6 +13,7 @@ import {
 } from "obsidian";
 import { arrayBufferToBase64, base64ToArrayBuffer, type EngramApi } from "./api";
 import type { BaseStore } from "./base-store";
+import type { GenesisOutcome } from "./channel";
 import { fnv1a } from "./content-hash";
 import type { NoteIdMap } from "./crdt/note-id-map";
 import type { ProviderRegistry } from "./crdt/provider-registry";
@@ -356,7 +357,7 @@ export interface CrdtPorts {
 				docId: string,
 				path: string,
 				b64?: string,
-		  ) => Promise<{ docId: string; seeded: boolean }>)
+		  ) => Promise<{ docId: string; seeded: boolean; genesisOutcome: GenesisOutcome }>)
 		| null;
 	delete?: ((docId: string) => Promise<{ doc_id: string }>) | null;
 	enqueue?: ((op: { kind: "create" | "delete"; docId: string; path: string }) => void) | null;
@@ -1379,7 +1380,7 @@ export class SyncEngine {
 				docId: string,
 				path: string,
 				b64?: string,
-		  ) => Promise<{ docId: string; seeded: boolean }>)
+		  ) => Promise<{ docId: string; seeded: boolean; genesisOutcome: GenesisOutcome }>)
 		| null = null;
 
 	setCrdtCreate(
@@ -1388,7 +1389,7 @@ export class SyncEngine {
 					docId: string,
 					path: string,
 					b64?: string,
-			  ) => Promise<{ docId: string; seeded: boolean }>)
+			  ) => Promise<{ docId: string; seeded: boolean; genesisOutcome: GenesisOutcome }>)
 			| null,
 	): void {
 		this.setCrdtPorts({ create: fn });
@@ -1481,6 +1482,7 @@ export class SyncEngine {
 		path: string,
 		seeded = false,
 		genesis?: GenesisFrame,
+		genesisOutcome?: GenesisOutcome,
 	): Promise<void> {
 		const normalized = normalizePath(path);
 		let effectiveId = localId;
@@ -1547,6 +1549,7 @@ export class SyncEngine {
 					sameId: serverId === localId,
 					genesisUpdate: genesis?.update,
 					genesisContent: genesis?.content,
+					genesisOutcome,
 				});
 			} catch (e) {
 				// The row exists (crdt_create already acked); a failed body seed
@@ -2830,11 +2833,45 @@ export class SyncEngine {
 	 *
 	 *  Returns what the manager CONSUMED (the echo baseline for
 	 *  `adoptCreateAck`), or null if nothing transmitted. */
+	/** Pull the server's own lineage for `noteId` and adopt it, room-free
+	 *  (#1467). Applying is a monotonic merge, so this can only converge us
+	 *  toward the server — it never discards local history. Returns the
+	 *  projected text, or null when the read is unavailable (old backend, rate
+	 *  limit, dropped socket) and the caller must decide how to defer.
+	 *
+	 *  ONE implementation on purpose: both callers below reach it from a state
+	 *  where re-sending the body would mint a rival lineage, and a second copy
+	 *  is how the first one drifted (#476). */
+	private async adoptServerLineage(noteId: string, path: string): Promise<string | null> {
+		const fetchState = this.crdtDocState;
+		if (!fetchState || !this.crdt) return null;
+
+		try {
+			const { b64 } = await fetchState(noteId);
+			await this.crdt.applyRemoteUpdate(noteId, fromB64(b64));
+			rlog().info(
+				"crdt",
+				`create: adopted server lineage for ${noteRef(path)} — body not re-sent`,
+			);
+			return await this.crdt.projectedText(noteId);
+		} catch (e) {
+			rlog().warn(
+				"crdt",
+				`create: could not adopt server lineage for ${noteRef(path)}: ${errMsg(e, path)}`,
+			);
+			return null;
+		}
+	}
+
 	private async seedBodyAfterCreate(opts: {
 		effectiveId: string;
 		normalized: string;
 		file: TFile;
 		seeded: boolean;
+		/** What the server did with our genesis frame. `undefined` when the
+		 *  create carried no frame at all; null when the backend predates the
+		 *  field (#476). */
+		genesisOutcome?: GenesisOutcome;
 		/** `serverId === the id we asked for`. False means the server answered
 		 *  under an id of its own choosing, so the bytes it stored are filed
 		 *  under a lineage we have never seen. */
@@ -2903,25 +2940,9 @@ export class SyncEngine {
 
 			// The server re-id'd us (#1409): it stored our body under a lineage we
 			// do not have. Pushing again is exactly how the doubling happens, so
-			// ADOPT its lineage instead — a room-free read (#1467). Applying is a
-			// monotonic merge, so this can only converge us toward the server.
-			const fetchState = this.crdtDocState;
-			if (fetchState) {
-				try {
-					const { b64 } = await fetchState(effectiveId);
-					await this.crdt.applyRemoteUpdate(effectiveId, fromB64(b64));
-					rlog().info(
-						"crdt",
-						`create: adopted server lineage for ${noteRef(normalized)} (re-id) — body not re-sent`,
-					);
-					return await this.crdt.projectedText(effectiveId);
-				} catch (e) {
-					rlog().warn(
-						"crdt",
-						`create: could not adopt server lineage for ${noteRef(normalized)}: ${errMsg(e, normalized)}`,
-					);
-				}
-			}
+			// ADOPT its lineage instead.
+			const adopted = await this.adoptServerLineage(effectiveId, normalized);
+			if (adopted !== null) return adopted;
 
 			// No way to adopt (old backend, rate limit, dropped socket). Pushing
 			// here would double the body, so we deliberately do NOTHING: the
@@ -2936,10 +2957,44 @@ export class SyncEngine {
 			return null;
 		}
 
-		// Either the server declined the seed (it has nothing — pushing is the
-		// only way it ever gets the body), or this doc already carries a real
-		// lineage (so `applyLocalEdit`'s `lca` diffs against it instead of
-		// minting a rival). Both are safe to transmit.
+		// Past here we are about to transmit a body into a doc with NO history,
+		// which mints a fresh lineage. That is only safe if the server truly
+		// holds nothing. A doc that already carries history is fine either way —
+		// `applyLocalEdit`'s `lca` diffs against it rather than minting a rival —
+		// so history short-circuits the whole check.
+		//
+		// `occupied` was the remaining half of #476: the server declined our
+		// genesis because the row already carried a DIFFERENT body (a concurrent
+		// write landed inside the seed's write window, or a room owns the doc),
+		// and the old `seeded: false` reported that identically to "the server
+		// has nothing". We pushed, minted a rival lineage carrying the same text,
+		// and Yjs unioned the two into the note twice over.
+		//
+		// A null outcome is an older backend that sends only `seeded` and so
+		// cannot distinguish those. Rather than guess, ASK: adopting is a
+		// monotonic merge that is harmless when the server is empty, and a
+		// non-empty projection afterwards is direct evidence that pushing would
+		// be a SECOND transmission.
+		const known = opts.genesisOutcome;
+		if (!effectiveIdHasHistory && known !== "absent" && known !== "stored") {
+			const adopted = await this.adoptServerLineage(effectiveId, normalized);
+			if (adopted !== null && adopted.trim().length > 0) return adopted;
+
+			// Known-occupied and we could not read it back: pushing would double
+			// the body, so defer to the catch-up receive path instead. Slower than
+			// seeding, and the only option that cannot corrupt.
+			if (known === "occupied" && adopted === null) {
+				rlog().warn(
+					"crdt",
+					`create: server already holds a body for ${noteRef(normalized)} and its state ` +
+						`is unavailable — deferring to catch-up rather than re-sending the body`,
+				);
+				return null;
+			}
+		}
+
+		// The server holds nothing for this note, so pushing is not merely safe
+		// but the only thing that will ever fill it.
 		return await routeModify(
 			{
 				crdtEligible: true,
@@ -4217,14 +4272,17 @@ export class SyncEngine {
 							content,
 						);
 						const genesisUpdate = chosenGenesis?.update;
-						const { docId: serverId, seeded } =
-							genesisUpdate === undefined
-								? await this.crdtCreate(noteId, pushedPath)
-								: await this.crdtCreate(
-										noteId,
-										pushedPath,
-										encodeUpdateFrame(genesisUpdate),
-									);
+						const {
+							docId: serverId,
+							seeded,
+							genesisOutcome,
+						} = genesisUpdate === undefined
+							? await this.crdtCreate(noteId, pushedPath)
+							: await this.crdtCreate(
+									noteId,
+									pushedPath,
+									encodeUpdateFrame(genesisUpdate),
+								);
 						let effectiveId = noteId;
 						try {
 							// On ADOPT (serverId !== noteId) the path is already owned by a
@@ -4306,6 +4364,7 @@ export class SyncEngine {
 									sameId: serverId === noteId,
 									genesisUpdate,
 									genesisContent: content,
+									genesisOutcome,
 									// The gate cleared this note (no lineage) BEFORE the create
 									// round trip; lineage now means something wrote during that
 									// window and the server holds a lineage we never adopted.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2927,7 +2927,18 @@ export class SyncEngine {
 			return null;
 		}
 
-		await crdt.applyRemoteUpdate(noteId, fromB64(state.b64));
+		// A refused apply (note deleted, doc destroyed mid-hydration) is NOT an
+		// adopt. Reporting it as one is the doubling: the caller falls through and
+		// diffs the body into a doc that never received the server's lineage, and
+		// `applyLocalEdit` reads that as history-less and mints a rival.
+		if (!(await crdt.applyRemoteUpdate(noteId, fromB64(state.b64)))) {
+			rlog().warn(
+				"crdt",
+				`create: server state for ${noteRef(path)} was refused by the registry ` +
+					`(note removed or doc destroyed) — not an adopt`,
+			);
+			return null;
+		}
 		rlog().info("crdt", `create: adopted server lineage for ${noteRef(path)}`);
 		return await crdt.projectedText(noteId);
 	}
@@ -3045,9 +3056,17 @@ export class SyncEngine {
 		normalized: string;
 		file: TFile;
 		seeded: boolean;
-		/** What the server did with our genesis frame. `undefined` when the
-		 *  create carried no frame at all; null when the backend predates the
-		 *  field (#476). */
+		/** What the server did with our genesis frame.
+		 *
+		 *  `null` = the backend predates the field (#476). It does NOT mean "no
+		 *  frame was sent": a bodyless create still gets a real outcome, because
+		 *  the server reconciles its `:absent` seed result against the ROW before
+		 *  replying, so a bodyless create onto a non-empty row answers `occupied`.
+		 *
+		 *  `undefined` is reachable only from a caller that omits the field (test
+		 *  fakes, an older port shape). Handled identically to `null` — both fail
+		 *  the `!== "absent"` gate, so both take the confirm-before-pushing route,
+		 *  which is the conservative one. */
 		genesisOutcome?: GenesisOutcome;
 		/** `serverId === the id we asked for`. False means the server answered
 		 *  under an id of its own choosing, so the bytes it stored are filed
@@ -3320,7 +3339,14 @@ export class SyncEngine {
 				if (state === null) throw new Error("crdt_doc_state unavailable");
 				// Flushes disk on the merge and AWAITS that write, so a failed
 				// write rejects here rather than being reported as converged.
-				await this.crdt.applyRemoteUpdate(noteId, fromB64(state.b64));
+				// A REFUSED apply (note removed, doc destroyed mid-hydration)
+				// resolves without merging anything, and `markSynced` below would
+				// then record a note as converged that holds none of the server's
+				// state — after which every catch-up compares equal hashes and
+				// skips it, permanently. Fall back to the room.
+				if (!(await this.crdt.applyRemoteUpdate(noteId, fromB64(state.b64)))) {
+					throw new Error("registry refused the doc state (note removed or destroyed)");
+				}
 				// `onSynced` fires ONLY from NoteProvider.handleFrame on an
 				// inbound syncStep2 — an applyRemoteUpdate does not fire it. So
 				// the staged episode has to be driven to commit explicitly, or

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2905,6 +2905,54 @@ export class SyncEngine {
 		return await crdt.projectedText(noteId);
 	}
 
+	/** Give the note up to the server's lineage: transmit nothing now, and record
+	 *  disk as the baseline so nothing transmits it LATER either.
+	 *
+	 *  The baseline is the load-bearing half. Both callers reach here holding a
+	 *  history-less Y.Doc and a server that has content, and returning a bare
+	 *  null leaves exactly that state on the floor: `adoptCreateAck` stamps no
+	 *  baseline when nothing was consumed, so `isUnchangedSynced` reads false,
+	 *  so the note's very next cold write takes `applyLocalEdit`'s `lca: false`
+	 *  branch and seeds the whole body into the empty doc — minting the rival
+	 *  lineage this defer exists to avoid. The defer bought one write's delay,
+	 *  not safety (#1409 review).
+	 *
+	 *  Stamping disk arms the adopt-first gate the registry already has
+	 *  (provider-registry `applyLocalEdit`: history-less + unchanged-synced =>
+	 *  "consumed, nothing to push"), which holds the empty doc open until a
+	 *  handshake or catch-up fills it from the server. It also makes
+	 *  `needsColdReconcile` false, which is the same answer for the same
+	 *  reason: reconciling from disk IS the rival mint.
+	 *
+	 *  The hash is a claim about what may be re-encoded locally, not a claim
+	 *  that the server holds these exact bytes — under `occupied` it holds
+	 *  different ones, and the catch-up pull is what settles that.
+	 *
+	 *  An unreadable disk leaves the baseline alone: a WRONG hash would suppress
+	 *  a real push forever, which is worse than the re-arm it would prevent.
+	 *  Always returns null — the "nothing transmitted" contract. */
+	private async deferToServerLineage(
+		normalized: string,
+		file: TFile,
+		why: string,
+	): Promise<null> {
+		try {
+			this.recordCrdtBaseline(normalized, await this.app.vault.cachedRead(file));
+		} catch (e) {
+			rlog().warn(
+				"crdt",
+				`create: deferring ${noteRef(normalized)} but its disk content is unreadable ` +
+					`(${errMsg(e, normalized)}) — the next cold write may re-encode it`,
+			);
+		}
+		rlog().warn(
+			"crdt",
+			`create: ${why} for ${noteRef(normalized)} — deferring to catch-up rather than ` +
+				`re-sending the body`,
+		);
+		return null;
+	}
+
 	/** How many consecutive unanswered `crdt_doc_state` frames disable the read.
 	 *  ONE is too few: a modern backend produces the identical signal whenever
 	 *  the channel dies (phx_error does not reject pending replies, so a crash
@@ -3051,12 +3099,11 @@ export class SyncEngine {
 			// server already holds the content, and this note is now an ordinary
 			// diverged COLD note that the catch-up receive path converges. Slower
 			// than seeding, and the ONLY option that cannot corrupt.
-			rlog().warn(
-				"crdt",
-				`create: server seeded ${noteRef(normalized)} under a different id and its state ` +
-					`is unavailable — deferring to catch-up rather than re-sending the body`,
+			return await this.deferToServerLineage(
+				normalized,
+				file,
+				`server seeded it under a different id and its state is unavailable`,
 			);
-			return null;
 		}
 
 		// Past here we are about to transmit a body into a doc with NO history,
@@ -3111,12 +3158,11 @@ export class SyncEngine {
 			//             device. A possible doubling beats a certain blank.
 			if (adopted === null) {
 				if (known === "occupied") {
-					rlog().warn(
-						"crdt",
-						`create: server holds a body for ${noteRef(normalized)} and its lineage is ` +
-							`unavailable — deferring rather than re-sending`,
+					return await this.deferToServerLineage(
+						normalized,
+						file,
+						`server holds a body for it and its lineage is unavailable`,
 					);
-					return null;
 				}
 
 				rlog().warn(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -450,11 +450,7 @@ export class SyncEngine {
 		collection: T,
 		dispose?: (value: T extends Map<unknown, infer V> ? V : never) => void,
 	): T {
-		this.sweepable.push({
-			on,
-			collection,
-			dispose: dispose as ((value: unknown) => void) | undefined,
-		});
+		this.sweepable.push({ on, collection, dispose });
 		return collection;
 	}
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2878,43 +2878,70 @@ export class SyncEngine {
 	 *  where re-sending the body would mint a rival lineage, and a second copy
 	 *  is how the first one drifted (#476). */
 	private async adoptServerLineage(noteId: string, path: string): Promise<string | null> {
-		const fetchState = this.crdtDocState;
-		if (!fetchState || !this.crdt) return null;
+		const state = await this.readServerDocState(noteId, path);
+		if (state === null || !this.crdt) return null;
 
-		// A backend that predates `crdt_doc_state` never REPLIES to the frame —
-		// it does not reject it, so every call costs a full sendRequest timeout.
-		// Discovered once per session rather than once per note: unlatched, a
-		// bulk import against an older server pays that timeout on every create
-		// and the sync effectively stops (measured: e2e creates went from ~1.5s
-		// to ~2min each). Re-arms on a vault change, since that can mean a
-		// different backend entirely.
-		if (this.unsupportedFrames.has(DOC_STATE_FRAME)) return null;
+		await this.crdt.applyRemoteUpdate(noteId, fromB64(state.b64));
+		rlog().info("crdt", `create: adopted server lineage for ${noteRef(path)}`);
+		return await this.crdt.projectedText(noteId);
+	}
+
+	/** How many consecutive unanswered `crdt_doc_state` frames disable the read.
+	 *  ONE is too few: a modern backend produces the identical signal whenever
+	 *  the channel dies (phx_error does not reject pending replies, so a crash
+	 *  surfaces as a timeout), and under the bulk-import load this feature exists
+	 *  for, a single slow reply is entirely reachable. */
+	private static readonly DOC_STATE_TIMEOUT_LATCH = 2;
+
+	/** The ONE place `crdt_doc_state` is called.
+	 *
+	 *  Both callers route through here so the capability latch is checked AND
+	 *  set in the same place. Previously only `adoptServerLineage` consulted it,
+	 *  while `convergeColdNoteRoomFree` — the HIGHER-volume caller — neither
+	 *  checked nor set it, so the very pathology the latch was written for
+	 *  (~1.5s to ~2min per note against an older backend) ran undiminished on
+	 *  the other path.
+	 *
+	 *  Returns null when the read is unavailable; the caller decides how to
+	 *  degrade, because the two callers degrade differently. */
+	private async readServerDocState(
+		noteId: string,
+		path: string,
+	): Promise<{ b64: string } | null> {
+		const fetchState = this.crdtDocState;
+		if (!fetchState || this.unsupportedFrames.has(DOC_STATE_FRAME)) return null;
 
 		try {
-			const { b64 } = await fetchState(noteId);
-			await this.crdt.applyRemoteUpdate(noteId, fromB64(b64));
-			rlog().info(
-				"crdt",
-				`create: adopted server lineage for ${noteRef(path)} — body not re-sent`,
-			);
-			return await this.crdt.projectedText(noteId);
+			const state = await fetchState(noteId);
+			// A success proves the frame is supported — clear any partial strike
+			// count so one slow reply mid-import cannot accumulate toward a latch
+			// across an otherwise healthy session.
+			this.docStateTimeouts = 0;
+			return state;
 		} catch (e) {
 			const detail = errMsg(e, path);
-			// A TIMEOUT means the server never answered the frame at all, which is
-			// what an older backend does with an unknown event. A structured
-			// reject (rate limit, auth) is a real answer and must NOT latch.
+
+			// A TIMEOUT means the server never answered at all — an older backend
+			// does that with an unknown event. It is NOT proof of an old backend
+			// though: a channel crash looks identical from here, which is why the
+			// log below states the observation and not a diagnosis, and why it
+			// takes repeated strikes. A structured reject (rate limit, auth) is a
+			// real answer from a server that DOES implement the frame, and must
+			// never latch.
 			if (/timeout/i.test(detail)) {
-				this.unsupportedFrames.add(DOC_STATE_FRAME);
-				rlog().warn(
-					"crdt",
-					`crdt_doc_state unanswered by this server — room-free doc reads disabled for ` +
-						`this session (older backend); falling back to the pre-#476 create path`,
-				);
+				this.docStateTimeouts += 1;
+				if (this.docStateTimeouts >= SyncEngine.DOC_STATE_TIMEOUT_LATCH) {
+					this.unsupportedFrames.add(DOC_STATE_FRAME);
+					rlog().warn(
+						"crdt",
+						`crdt_doc_state went unanswered ${this.docStateTimeouts}x — disabling room-free ` +
+							`doc reads for this session. Either the backend predates the frame or the ` +
+							`channel is crashing; both look like this from the client.`,
+					);
+				}
 			}
-			rlog().warn(
-				"crdt",
-				`create: could not adopt server lineage for ${noteRef(path)}: ${detail}`,
-			);
+
+			rlog().warn("crdt", `crdt_doc_state failed for ${noteRef(path)}: ${detail}`);
 			return null;
 		}
 	}
@@ -3190,13 +3217,18 @@ export class SyncEngine {
 		// reads as undelivered), which is the right bias here: the room is always
 		// CORRECT, just more expensive. Convergence is the invariant; saving the
 		// room is the optimization.
-		const fetchState = this.crdtDocState;
-		if (fetchState && this.crdt && !this.crdt.hasUndeliveredOps(noteId)) {
+		if (this.crdt && !this.crdt.hasUndeliveredOps(noteId)) {
+			// Routed through the shared reader so this caller both CHECKS and
+			// FEEDS the capability latch. It used to do neither, so against an
+			// older backend every diverged cold note paid a full request timeout
+			// before falling back — the exact pathology the latch exists for,
+			// running on the higher-volume path (#1409 review).
+			const state = await this.readServerDocState(noteId, change.path);
 			try {
-				const { b64 } = await fetchState(noteId);
+				if (state === null) throw new Error("crdt_doc_state unavailable");
 				// Flushes disk on the merge and AWAITS that write, so a failed
 				// write rejects here rather than being reported as converged.
-				await this.crdt.applyRemoteUpdate(noteId, fromB64(b64));
+				await this.crdt.applyRemoteUpdate(noteId, fromB64(state.b64));
 				// `onSynced` fires ONLY from NoteProvider.handleFrame on an
 				// inbound syncStep2 — an applyRemoteUpdate does not fire it. So
 				// the staged episode has to be driven to commit explicitly, or
@@ -5047,6 +5079,10 @@ export class SyncEngine {
 	 *  because a vault switch can move us to a different backend entirely —
 	 *  self-host and SaaS are different servers at different versions. */
 	private unsupportedFrames = this.track(["vault", "destroy"], new Set<string>());
+
+	/** Consecutive unanswered `crdt_doc_state` frames. Reset by any success, and
+	 *  by a vault change (a different vault can mean a different backend). */
+	private docStateTimeouts = 0;
 
 	setCrdtCatchupSince(fn: CrdtCatchupSinceFn): void {
 		this.setCrdtPorts({ catchupSince: fn });

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -379,6 +379,9 @@ export interface CrdtPorts {
 	 *  old to serve `crdt_doc_state`; callers fall back to the room
 	 *  handshake, so an unwired port costs rooms, never convergence. */
 	docState?: CrdtDocStateFn | null;
+	/** #1409: tell the server this device is done with a note's room, so its
+	 *  `auto_exit` can fire now instead of after the 5-minute idle drain. */
+	release?: ((docId: string) => void) | null;
 }
 
 /** Thrown by `walkOpLog` when the op-log FETCH itself fails, so a caller can
@@ -653,6 +656,7 @@ export class SyncEngine {
 		if ("liveBound" in ports) this.isLiveBound = ports.liveBound ?? (() => false);
 		if ("catchupSince" in ports) this.crdtCatchupSince = ports.catchupSince ?? null;
 		if ("docState" in ports) this.crdtDocState = ports.docState ?? null;
+		if ("release" in ports) this.crdtRelease = ports.release ?? null;
 	}
 
 	setCrdtManager(mgr: ProviderRegistry | null): void {
@@ -6378,6 +6382,11 @@ export class SyncEngine {
 	 *  test_cold_send_over_fanout_opens_no_room). `reset` also clears the
 	 *  channel's once-per-doc STEP1 gate so a FUTURE heal can re-handshake.
 	 *  A live-bound note keeps its room — the editor owns its lifecycle. */
+	/** #1409: the SERVER's half of a release. `releaseHealRoom` reset enrollment
+	 *  and closed the local doc and said nothing on the wire, so the server kept
+	 *  observing the room and it lived until the 5-minute idle drain. */
+	private crdtRelease: ((docId: string) => void) | null = null;
+
 	private releaseHealRoom(noteId: string, path: string | null): void {
 		// Re-resolve the CURRENT path — `path` may be the enqueue/staging-time
 		// path, and a rename in between would otherwise check liveness (and
@@ -6385,6 +6394,10 @@ export class SyncEngine {
 		// owns at its NEW path (silent data loss, the bind-race class).
 		const current = this.noteIdMap?.pathForId(noteId) ?? path;
 		if (current && this.isLiveBound(normalizePath(current))) return;
+		// Tell the SERVER too, or its observation keeps the room alive for the
+		// full idle window no matter what this device does locally. Same gate,
+		// both halves — an open editor keeps its warm room.
+		this.crdtRelease?.(noteId);
 		this.crdtEnrollment?.reset(noteId);
 		if (current) {
 			this.hibernateIfIdle(current, noteId);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3000,26 +3000,62 @@ export class SyncEngine {
 		// monotonic merge that is harmless when the server is empty, and a
 		// non-empty projection afterwards is direct evidence that pushing would
 		// be a SECOND transmission.
+		// ADOPT FIRST, THEN DIFF — never "adopt instead of pushing".
+		//
+		// An earlier revision returned the adopted text here and stopped. That
+		// looked safe and silently DISCARDED the local body: when the server
+		// holds a DIFFERENT body under our id (which is what `occupied` means),
+		// stopping after the adopt means our content never reaches the server and
+		// the adopted text is stamped as the baseline over it. The same shape hit
+		// the ADOPT path, where it overwrote a brand-new local note with another
+		// note's content.
+		//
+		// Adopting is not an alternative to transmitting, it is the PRECONDITION
+		// for transmitting safely. Once the server's lineage is applied the doc
+		// has history, so `applyLocalEdit` takes its `lca` path and emits a
+		// minimal diff onto the shared lineage — not the rival lineage whose YATA
+		// union is #476. So: adopt to acquire identity, then push as a diff.
+		//
+		// The only outcome that skips the push is `stored`, handled above: the
+		// server already holds exactly our bytes, so there is nothing to send.
 		const known = opts.genesisOutcome;
-		if (!effectiveIdHasHistory && known !== "absent" && known !== "stored") {
+		if (!effectiveIdHasHistory && known !== "absent") {
 			const adopted = await this.adoptServerLineage(effectiveId, normalized);
-			if (adopted !== null && adopted.trim().length > 0) return adopted;
 
-			// Known-occupied and we could not read it back: pushing would double
-			// the body, so defer to the catch-up receive path instead. Slower than
-			// seeding, and the only option that cannot corrupt.
-			if (known === "occupied" && adopted === null) {
+			// Adopt failed. What to do depends on whether the server ASSERTED it
+			// holds content, and the two answers are opposite:
+			//
+			//   occupied  the server said so. Pushing mints a rival, so defer.
+			//   null      we could not verify (a backend predating both `genesis`
+			//             and `crdt_doc_state` — they ship together, so a null
+			//             outcome guarantees the read is unavailable too). Here
+			//             deferring is NOT the safe pole: nothing else will ever
+			//             fill this note, so it stays blank forever on every
+			//             device. A possible doubling beats a certain blank.
+			if (adopted === null) {
+				if (known === "occupied") {
+					rlog().warn(
+						"crdt",
+						`create: server holds a body for ${noteRef(normalized)} and its lineage is ` +
+							`unavailable — deferring rather than re-sending`,
+					);
+					return null;
+				}
+
 				rlog().warn(
 					"crdt",
-					`create: server already holds a body for ${noteRef(normalized)} and its state ` +
-						`is unavailable — deferring to catch-up rather than re-sending the body`,
+					`create: cannot verify server state for ${noteRef(normalized)} (backend predates ` +
+						`crdt_doc_state) — transmitting, which risks the pre-#476 doubling`,
 				);
-				return null;
 			}
+			// Adopt succeeded. Fall through: the doc now has history, so the push
+			// below is an `lca` diff. This is deliberate even when `adopted` is
+			// empty — an empty projection means the server is genuinely blank and
+			// our body is the only copy.
 		}
 
-		// The server holds nothing for this note, so pushing is not merely safe
-		// but the only thing that will ever fill it.
+		// Either the server holds nothing (`absent`), or we now share its lineage
+		// and this is a minimal diff onto it.
 		return await routeModify(
 			{
 				crdtEligible: true,

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2878,12 +2878,31 @@ export class SyncEngine {
 	 *  where re-sending the body would mint a rival lineage, and a second copy
 	 *  is how the first one drifted (#476). */
 	private async adoptServerLineage(noteId: string, path: string): Promise<string | null> {
-		const state = await this.readServerDocState(noteId, path);
-		if (state === null || !this.crdt) return null;
+		// Capture the registry BEFORE the await. `setCrdtPorts` reassigns
+		// `this.crdt` on a vault change, so re-reading it after the round trip
+		// can apply the OLD vault's Yjs bytes into the NEW vault's registry under
+		// the same note_id — and note_ids are unique only WITHIN a vault, which
+		// is the very cross-vault identity bug this branch exists to close
+		// (#1409 review). Comparing identity afterwards turns a silent
+		// cross-vault write into a refusal.
+		const crdt = this.crdt;
+		if (!crdt) return null;
 
-		await this.crdt.applyRemoteUpdate(noteId, fromB64(state.b64));
+		const state = await this.readServerDocState(noteId, path);
+		if (state === null) return null;
+
+		if (this.crdt !== crdt) {
+			rlog().warn(
+				"crdt",
+				`create: vault changed while reading server state for ${noteRef(path)} — ` +
+					`discarding the reply rather than applying it to the new vault`,
+			);
+			return null;
+		}
+
+		await crdt.applyRemoteUpdate(noteId, fromB64(state.b64));
 		rlog().info("crdt", `create: adopted server lineage for ${noteRef(path)}`);
-		return await this.crdt.projectedText(noteId);
+		return await crdt.projectedText(noteId);
 	}
 
 	/** How many consecutive unanswered `crdt_doc_state` frames disable the read.

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -2342,13 +2342,15 @@ export class SyncEngine {
 	 *  queue for terminal failures (e.g. 413 Payload Too Large). */
 	readonly issues: IssueStore = new IssueStore();
 
-	/** `IssueStore` already owns `clear(path)`, so it cannot satisfy the
+	/** Public only so the unused-private-member lint stays honest: the field
+	 *  exists to REGISTER at the declaration site, never to be read. `IssueStore`
+	 *  already owns `clear(path)`, so it cannot satisfy the
 	 *  sweepable shape directly — this adapter registers it without renaming a
 	 *  public API. Vault-scoped because plan-limit parks are per-vault: a Free
 	 *  vault's 402 attachments-disabled park must not suppress the same path on
 	 *  a Pro or self-host vault, where `pushFile` short-circuits BEFORE any
 	 *  request so nothing ever arrives to clear it (#1409 review). */
-	private readonly issuesSweeper = this.track(["vault", "destroy"], {
+	readonly issuesSweeper = this.track(["vault", "destroy"], {
 		clear: () => this.issues.clearAll(),
 	});
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1435,81 +1435,15 @@ export class SyncEngine {
 				: null;
 		if (this.crdt && file instanceof TFile && this.isCrdtEligible(file)) {
 			try {
-				// Never trust `seeded` across an ADOPT remap (same defence in depth
-				// as pushFile's live genesis branch) — only `serverId === localId`
-				// reaches the fast path. `hasAnyHistory` (not `hasHistory`, round 2
-				// review finding): `hasHistory` is body-only, so a frontmatter-only
-				// note with an empty body but existing history reported false,
-				// passed the old guard, and got its frontmatter ORDER_KEY doubled
-				// the same way H1's body doubled — see note-seed.ts's
-				// `docHasAnyHistory` docstring for why a raw Y.applyUpdate needs the
-				// whole-document check and `applyLocalEdit`'s `lca` doesn't.
-				const effectiveIdHasHistory =
-					typeof this.crdt.hasAnyHistory === "function"
-						? await this.crdt.hasAnyHistory(effectiveId)
-						: true;
-				if (seeded && serverId === localId && genesis && !effectiveIdHasHistory) {
-					// M1: `genesis.content` was frozen when buildGenesisFrame read disk,
-					// before the crdt_create round-trip. Capture whatever's on disk NOW,
-					// before the apply's flush can silently revert a write that landed
-					// in that window (an importer's second pass, Obsidian Sync, git
-					// pull, Templater, an external editor).
-					let preApplyDisk: string | null = null;
-					try {
-						preApplyDisk = await this.app.vault.cachedRead(file);
-					} catch {
-						// unreadable — proceed without drift protection
-					}
-					// Apply the EXACT SAME update bytes the server accepted — origin =
-					// the provider, so it does NOT re-broadcast and does NOT open a
-					// room. A H1-class collision is impossible here: effectiveIdHasHistory
-					// was just proven false, so this device's doc is empty. This apply
-					// AWAITS its own disk flush (wiring.ts's onFlushToDisk ->
-					// flushFromCrdt), which writes `genesis.content` — so `preApplyDisk`
-					// (captured a line above, BEFORE this call) is the only surviving
-					// record of anything that drifted in during the round-trip; disk
-					// itself is reverted to `genesis.content` the instant this resolves.
-					await this.crdt.applyRemoteUpdate(effectiveId, genesis.update);
-					consumed = genesis.content;
-					if (preApplyDisk !== null && preApplyDisk !== genesis.content) {
-						// Drift happened. The doc NOW has history (just established
-						// above), so this is a safe minimal diff onto that baseline —
-						// mirrors pushFile's own post-apply drift merge. NO `reread`
-						// callback: `preApplyDisk` (captured before the revert above) IS
-						// the merge input — a reread here would re-read the JUST-
-						// REVERTED disk and silently discard the drift (round 2 review
-						// finding: the bug this fix exists to prevent). `applyLocalEdit`
-						// on a local/default origin does NOT auto-flush (only
-						// provider/REMOTE origins do — ensureEntrySync's update
-						// listener), so the merged text is explicitly written to disk
-						// via flushFromCrdt below; without it the doc would hold the
-						// correct merge while disk stayed reverted.
-						const merged = await this.crdt.applyLocalEdit(effectiveId, preApplyDisk);
-						if (merged !== null) {
-							consumed = merged;
-							await this.flushFromCrdt(normalized, merged);
-						}
-					}
-				} else {
-					// The echo baseline comes off what the manager CONSUMED
-					// (adoptCreateAck stamps it) so a later revert to this content
-					// isn't hash-skipped. Also the correct path when
-					// effectiveIdHasHistory is true (H1): applyLocalEdit's own `lca`
-					// defaults to docHasHistory, so this is a safe minimal diff onto
-					// the EXISTING lineage, and its live reread naturally handles a
-					// note that gained content since the frame was built (review H4's
-					// third point: the server's seed_against clause 3 declines —
-					// seeded: false — for exactly that case, landing here).
-					consumed = await routeModify(
-						{
-							crdtEligible: true,
-							noteId: effectiveId,
-							readContent: () => this.app.vault.cachedRead(file),
-						},
-						this.crdt,
-						MAX_CRDT_NOTE_BYTES,
-					);
-				}
+				consumed = await this.seedBodyAfterCreate({
+					effectiveId,
+					normalized,
+					file,
+					seeded,
+					sameId: serverId === localId,
+					genesisUpdate: genesis?.update,
+					genesisContent: genesis?.content,
+				});
 			} catch (e) {
 				// The row exists (crdt_create already acked); a failed body seed
 				// self-heals on the note's next edit. Never fall back to REST.
@@ -2757,6 +2691,104 @@ export class SyncEngine {
 
 	isMarkdown(file: TAbstractFile): boolean {
 		return file instanceof TFile && file.extension === "md";
+	}
+
+	/** Seed a just-created note's body under `effectiveId` — THE one
+	 *  implementation (#1409 consolidation).
+	 *
+	 *  This ran twice: once in `applyCrdtCreateAck` (durable-queue create) and
+	 *  once inline in `pushFile` (live create). The two were identical down to
+	 *  the drift-merge ordering, and `applyCrdtCreateAck`'s docstring promised
+	 *  it "mirrors pushFile's seeded-gated local apply exactly, guard-for-guard"
+	 *  — a contract nothing enforced. #1130 is already logged as "duplicated
+	 *  gates silently diverging"; this is the same lesson, and every fix to this
+	 *  logic had to be made in both copies or silently apply to half the creates.
+	 *
+	 *  Two routes, mutually exclusive:
+	 *
+	 *  FAST — the server confirmed our genesis frame landed against an EMPTY row
+	 *  (`seeded`), it answered under the id we asked for (`sameId`), and this
+	 *  device's doc has no lineage either. Applying the exact accepted bytes with
+	 *  PROVIDER origin neither re-broadcasts nor opens a room, and leaves this
+	 *  device on the server's lineage instead of minting a second one that Yjs
+	 *  would later union into a doubled body (#846).
+	 *
+	 *  SLOW — anything else. `routeModify` diffs live disk onto whatever lineage
+	 *  exists, which is correct when the doc already has history (H1):
+	 *  `applyLocalEdit`'s `lca` makes it a minimal diff, not a rival lineage.
+	 *
+	 *  `hasAnyHistory`, never `hasHistory` (round-2 review): the latter is
+	 *  body-only, so a frontmatter-only note with an empty body reported false,
+	 *  passed the guard, and had its ORDER_KEY array doubled exactly the way H1
+	 *  doubled bodies. A raw applyUpdate is a concurrent insert into EVERY shared
+	 *  type the frame touches. Unknown (older test fakes) fails CLOSED.
+	 *
+	 *  M1 drift: `genesisContent` was frozen before the create round-trip.
+	 *  Anything that wrote to disk in that window (an importer's second pass,
+	 *  Obsidian Sync, git pull, Templater) is reverted by the flush the apply
+	 *  triggers, so disk is captured BEFORE it and merged back after. No
+	 *  `reread` callback on that merge — re-reading would read the just-reverted
+	 *  disk and silently discard the drift, which is the bug this guards.
+	 *
+	 *  Returns what the manager CONSUMED (the echo baseline for
+	 *  `adoptCreateAck`), or null if nothing transmitted. */
+	private async seedBodyAfterCreate(opts: {
+		effectiveId: string;
+		normalized: string;
+		file: TFile;
+		seeded: boolean;
+		/** `serverId === the id we asked for` — an ADOPT remap must never trust
+		 *  `seeded`, since the frame landed against a row we did not name. */
+		sameId: boolean;
+		genesisUpdate: Uint8Array | undefined;
+		genesisContent: string | undefined;
+		/** pushFile surfaces a genesis race here; the queued path has no
+		 *  equivalent signal to report. */
+		onHistoryResolved?: (effectiveIdHasHistory: boolean) => void;
+	}): Promise<string | null> {
+		if (!this.crdt) return null;
+		const { effectiveId, normalized, file, seeded, sameId } = opts;
+
+		const effectiveIdHasHistory =
+			typeof this.crdt.hasAnyHistory === "function"
+				? await this.crdt.hasAnyHistory(effectiveId)
+				: true;
+		opts.onHistoryResolved?.(effectiveIdHasHistory);
+
+		if (
+			seeded &&
+			sameId &&
+			opts.genesisUpdate &&
+			opts.genesisContent !== undefined &&
+			!effectiveIdHasHistory
+		) {
+			let preApplyDisk: string | null = null;
+			try {
+				preApplyDisk = await this.app.vault.cachedRead(file);
+			} catch {
+				// unreadable — proceed without drift protection
+			}
+			await this.crdt.applyRemoteUpdate(effectiveId, opts.genesisUpdate);
+			let consumed: string | null = opts.genesisContent;
+			if (preApplyDisk !== null && preApplyDisk !== opts.genesisContent) {
+				const merged = await this.crdt.applyLocalEdit(effectiveId, preApplyDisk);
+				if (merged !== null) {
+					consumed = merged;
+					await this.flushFromCrdt(normalized, merged);
+				}
+			}
+			return consumed;
+		}
+
+		return await routeModify(
+			{
+				crdtEligible: true,
+				noteId: effectiveId,
+				readContent: () => this.app.vault.cachedRead(file),
+			},
+			this.crdt,
+			MAX_CRDT_NOTE_BYTES,
+		);
 	}
 
 	/** Stage the convergence episode a socket re-handshake must commit, then
@@ -4100,156 +4132,25 @@ export class SyncEngine {
 									);
 									effectiveId = serverId;
 								}
-								// #1409: `serverId === noteId` (never trust `seeded` across an
-								// ADOPT remap — defence in depth: the contract says the
-								// server always answers `seeded: false` on adopt, but if
-								// that were ever wrong, honouring it here would stamp a
-								// baseline for a body that was never sent to the row we
-								// actually remapped to, which is silent data loss).
-								//
-								// Review H1 (HIGH, data corruption): also never trust `seeded`
-								// when THIS DEVICE'S OWN doc for effectiveId already has
-								// history. That happens for a rename of a note this device
-								// has previously synced/opened — same note_id, so its
-								// IndexedDB-persisted doc keeps the full lineage even while
-								// idle now. handleRename drops the old path's syncState, so
-								// the new path's push takes this genesis branch despite the
-								// note being anything but new. The server's own seed_against
-								// correctly no-ops when its row content already matches the
-								// frame (seeded:true, nothing written) — but encodeGenesisUpdate
-								// always mints a FRESH throwaway Y.Doc/clientID, so a raw
-								// Y.applyUpdate of that frame onto THIS device's non-empty doc
-								// is two concurrent inserts of the same text at the same
-								// position; YATA keeps both, doubling the body once the
-								// resulting flush lands on disk. `hasAnyHistory`, NOT
-								// `hasHistory` (round 2 review finding): `hasHistory` is
-								// body-only (note-seed.ts's `textHasHistory`), so a
-								// frontmatter-only note with an empty body but existing
-								// history reported false, passed this guard, and got its
-								// frontmatter ORDER_KEY Y.Array doubled by YATA the same way
-								// an empty-body guard let the body double for H1 — a raw
-								// Y.applyUpdate is a concurrent insert into WHATEVER shared
-								// types the frame touches, not just the body `applyLocalEdit`'s
-								// `lca` cares about. See `docHasAnyHistory`'s docstring.
-								// Unknown (older test fake without the method) fails CLOSED:
-								// assume history exists and take the safe diff path below
-								// rather than risk doubling.
-								const effectiveIdHasHistory =
-									typeof this.crdt.hasAnyHistory === "function"
-										? await this.crdt.hasAnyHistory(effectiveId)
-										: true;
-								// The gate cleared this note (no lineage) BEFORE the create
-								// round trip; if it has lineage now, something wrote during
-								// the window and the server holds a lineage we never adopted.
-								// Not repairable here — surfaced so it stops being invisible.
-								this.reportGenesisRace(
-									chosenGenesis?.fromThrowaway === true && serverId === noteId,
-									effectiveIdHasHistory,
-								);
-								if (
-									seeded &&
-									serverId === noteId &&
-									genesisUpdate &&
-									!effectiveIdHasHistory
-								) {
-									// The server confirmed our genesis frame landed against an
-									// empty row and this device's own doc is ALSO empty — the
-									// only case where a raw local apply is safe (no existing
-									// lineage to collide with).
-									//
-									// Review M1 (MEDIUM): `content` was frozen before the
-									// crdt_create network round-trip. Anything that wrote to
-									// disk during that gap — an importer's second pass, Obsidian
-									// Sync, git pull, Templater, an external editor — would
-									// otherwise be silently reverted by the flush the apply
-									// below triggers, and `consumed = content` would then stamp
-									// a stale baseline that makes the next push echo-skip it.
-									// Capture whatever is on disk RIGHT NOW, before that flush
-									// can destroy it. Best-effort: an unreadable file proceeds
-									// without drift protection rather than blocking the create,
-									// matching captureDiskDriftBeforeRemote's own contract.
-									let preApplyDisk: string | null = null;
-									try {
-										preApplyDisk = await this.app.vault.cachedRead(file);
-									} catch {
-										// unreadable — proceed without drift protection
-									}
-									// Apply the EXACT SAME update bytes to this device's own
-									// (still-empty) doc — origin = the provider, so it does NOT
-									// re-broadcast and does NOT open a room — so this device's
-									// lineage is the one the server has, instead of staying
-									// empty until the next edit seeds a SECOND, independent
-									// lineage (the #846 doubling: an empty doc has no history,
-									// so its next applyLocalEdit would take the
-									// seedOnce/lca=false path and insert the whole body as new
-									// ops, which the server then merges with the genesis
-									// lineage it already holds). Verified no inbound path does
-									// this for us: catch-up replay (discoverAnnouncedNote)
-									// returns early once the file exists on disk, and the
-									// idle-note catch-up backfill (applyChange's diverged
-									// branch) writes DISK content only — it never touches the
-									// Y.Doc for a non-live-bound note.
-									// This AWAITS its own disk flush (wiring.ts's onFlushToDisk
-									// -> flushFromCrdt), writing `content` — so `preApplyDisk`
-									// (captured above, BEFORE this call) is the only surviving
-									// record of anything that drifted in during the round-trip;
-									// disk is reverted to `content` the instant this resolves.
-									await this.crdt.applyRemoteUpdate(effectiveId, genesisUpdate);
-									consumed = content;
-									if (preApplyDisk !== null && preApplyDisk !== content) {
-										// Drift happened during the round-trip. The doc NOW has
-										// history (just established above), so — unlike
-										// captureDiskDriftBeforeRemote, which runs BEFORE its
-										// remote apply because a baseline already exists to diff
-										// against — this merge runs AFTER, because no baseline
-										// existed until this exact moment. Same underlying
-										// mechanism (applyLocalEdit onto a history-full doc is a
-										// safe minimal diff, not a second lineage), just
-										// reordered because the "remote update" here IS the
-										// baseline. NO `reread` callback: `preApplyDisk` (captured
-										// BEFORE the revert above) IS the merge input — a reread
-										// here would re-read the JUST-REVERTED disk and silently
-										// discard the drift (round 2 review finding: the bug this
-										// fix exists to prevent). `applyLocalEdit` on a
-										// local/default origin does NOT auto-flush (only
-										// provider/REMOTE origins do), so the merged text is
-										// explicitly written via flushFromCrdt below — without it
-										// the doc holds the correct merge while disk stays
-										// reverted. A decline (e.g. size cap, merged === null)
-										// leaves `consumed` at the still-valid genesis baseline
-										// rather than nulling out a create that DID succeed.
-										const merged = await this.crdt.applyLocalEdit(
-											effectiveId,
-											preApplyDisk,
-										);
-										if (merged !== null) {
-											consumed = merged;
-											await this.flushFromCrdt(
-												normalizePath(pushedPath),
-												merged,
-											);
-										}
-									}
-								} else {
-									// Seed the body under the effective id via the Y.Doc update
-									// listener, which forwards it over the channel (crdt_msg). A
-									// LIVE reread, not the frozen `content`, backs the manager's
-									// stale-snapshot guard. Also the correct path when
-									// effectiveIdHasHistory is true (H1): applyLocalEdit's own
-									// `lca` defaults to docHasHistory, so this is a safe minimal
-									// diff onto the EXISTING lineage — not a second one — and,
-									// as a bonus, its live reread gives the rename case the same
-									// drift protection M1 gives the true-genesis case.
-									consumed = await routeModify(
-										{
-											crdtEligible: true,
-											noteId: effectiveId,
-											readContent: () => this.app.vault.cachedRead(file),
-										},
-										this.crdt,
-										MAX_CRDT_NOTE_BYTES,
-									);
-								}
+								consumed = await this.seedBodyAfterCreate({
+									effectiveId,
+									normalized: normalizePath(pushedPath),
+									file,
+									seeded,
+									sameId: serverId === noteId,
+									genesisUpdate,
+									genesisContent: content,
+									// The gate cleared this note (no lineage) BEFORE the create
+									// round trip; lineage now means something wrote during that
+									// window and the server holds a lineage we never adopted.
+									// Not repairable here — surfaced so it stops being invisible.
+									onHistoryResolved: (hasHistory) =>
+										this.reportGenesisRace(
+											chosenGenesis?.fromThrowaway === true &&
+												serverId === noteId,
+											hasHistory,
+										),
+								});
 							}
 							// Task 1's canSendLive gate held effectiveId's live update(s)
 							// (including the seed above) until this exact moment, so nothing

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -17,7 +17,7 @@ import { fnv1a } from "./content-hash";
 import type { NoteIdMap } from "./crdt/note-id-map";
 import type { ProviderRegistry } from "./crdt/provider-registry";
 import { uuid7 } from "./crdt/uuid7";
-import { encodeUpdateFrame } from "./crdt/wire";
+import { encodeUpdateFrame, fromB64 } from "./crdt/wire";
 import { crdtOpFailureReason, type GenesisFrame } from "./crdt-op-dispatch";
 import { devLog } from "./dev-log";
 import { errMsg, isHttpStatus } from "./error-util";
@@ -333,6 +333,9 @@ type CrdtCatchupSinceFn = (
 	next_id?: string | null;
 }>;
 
+/** Room-free full Yjs state for one note — see `CrdtChannel.crdtDocState`. */
+type CrdtDocStateFn = (docId: string) => Promise<{ b64: string; head: string }>;
+
 /** Late-injection wiring for the CRDT stack (#376 prerequisite 2). main.ts
  *  wires these in stages — boot, channel join, teardown — each stage passing
  *  only its subset to `setCrdtPorts`. A key must be PRESENT in the patch to
@@ -367,6 +370,10 @@ export interface CrdtPorts {
 	 *  path, so it is the one port with no null state to fall into. */
 	liveBound?: ((path: string) => boolean) | null;
 	catchupSince?: CrdtCatchupSinceFn | null;
+	/** Room-FREE full-state read for one note (#1409). Null on a backend too
+	 *  old to serve `crdt_doc_state`; callers fall back to the room
+	 *  handshake, so an unwired port costs rooms, never convergence. */
+	docState?: CrdtDocStateFn | null;
 }
 
 /** Thrown by `walkOpLog` when the op-log FETCH itself fails, so a caller can
@@ -527,6 +534,7 @@ export class SyncEngine {
 		if ("live" in ports) this.crdtLive = ports.live ?? null;
 		if ("liveBound" in ports) this.isLiveBound = ports.liveBound ?? (() => false);
 		if ("catchupSince" in ports) this.crdtCatchupSince = ports.catchupSince ?? null;
+		if ("docState" in ports) this.crdtDocState = ports.docState ?? null;
 	}
 
 	setCrdtManager(mgr: ProviderRegistry | null): void {
@@ -2763,8 +2771,118 @@ export class SyncEngine {
 		version?: number,
 		seq?: number,
 	): void {
-		this.pendingConvergence.set(noteId, { path, serverHash, content, version, seq });
+		this.stageConvergence(noteId, path, serverHash, content, version, seq);
 		this.socketConverge(path, noteId);
+	}
+
+	/** The stage half of `stageAndConverge`, split out for the room-FREE
+	 *  delivery path (#1409): `convergeColdNoteRoomFree` stages the SAME
+	 *  episode and then delivers over `crdt_doc_state` instead of a room
+	 *  handshake. Kept as one writer so a field added here can't be missed by
+	 *  one of the two delivery paths — the exact fork this helper's own
+	 *  history is about. */
+	private stageConvergence(
+		noteId: string,
+		path: string,
+		serverHash: string,
+		content: string | null,
+		version?: number,
+		seq?: number,
+	): void {
+		this.pendingConvergence.set(noteId, { path, serverHash, content, version, seq });
+	}
+
+	/** Converge a diverged COLD note (nobody has it open) without allocating a
+	 *  server room — #1409's open half.
+	 *
+	 *  The room-based path this replaces is `stageAndConverge`: stage the
+	 *  episode, fire a STEP1, let STEP2 bring the ops back, and let
+	 *  `commitCrdtConvergence` record the stage once an inbound frame proves
+	 *  the round-trip. Every one of those STEP1s routed through the backend's
+	 *  `ensure_room`, so a bulk first sync allocated a room per cold note that
+	 *  fell through to catch-up.
+	 *
+	 *  `crdt_doc_state` returns the same Yjs state off the persisted snapshot +
+	 *  update-log tail with no room. Applying it is the same monotonic merge
+	 *  STEP2's ops would have been, so a checkpoint-lagged reply converges
+	 *  without reverting a fresher local edit — the property that makes this a
+	 *  legal substitute, and the one the feed's plaintext `content` lacks.
+	 *
+	 *  Convergence is recorded on the SAME proof as the room path: not "the
+	 *  fetch resolved", but the doc verifiably projecting the row's content.
+	 *  We stage first and let the manager's remote-merge listener drive
+	 *  `commitCrdtConvergence` exactly as it does for a STEP2, so an apply that
+	 *  lands short (a snapshot genuinely older than this feed row) leaves the
+	 *  stage in place for the next catch-up rather than recording a lie.
+	 *
+	 *  ANY failure falls back to the room handshake. An old backend rejects the
+	 *  unknown frame, a rate limit rejects it, a dropped socket rejects it — in
+	 *  all three the room is still the correct, more expensive answer.
+	 *  Convergence is the invariant; the room saving is the optimization. */
+	private async convergeColdNoteRoomFree(
+		noteId: string,
+		normalized: string,
+		change: NoteChange,
+		content: string | undefined,
+		serverHash: string,
+	): Promise<void> {
+		// Stage BEFORE either delivery attempt: both the room-free apply and the
+		// fallback handshake commit through this same staged episode, and a
+		// fresh content_hash overwrites any prior stage (a new episode, never a
+		// stale commit of superseded server content).
+		this.stageConvergence(
+			noteId,
+			normalized,
+			serverHash,
+			content ?? null,
+			change.version,
+			change.seq,
+		);
+
+		const fetchState = this.crdtDocState;
+		if (fetchState && this.crdt) {
+			try {
+				const { b64 } = await fetchState(noteId);
+				// Flushes disk on the merge and AWAITS that write, so a failed
+				// write rejects here rather than being reported as converged.
+				await this.crdt.applyRemoteUpdate(noteId, fromB64(b64));
+				// `onSynced` fires ONLY from NoteProvider.handleFrame on an
+				// inbound syncStep2 — an applyRemoteUpdate does not fire it. So
+				// the staged episode has to be driven to commit explicitly, or
+				// serverHash is never recorded, the note stays diverged, and
+				// every later catch-up re-fetches it forever. `markSynced` is
+				// the registry's manual trigger for exactly this.
+				//
+				// Triggering it DOES record convergence — `commitCrdtConvergence`
+				// has no text-verify gate (it was removed deliberately: a
+				// cosmetic projection difference wedged the stage forever). What
+				// justifies recording is the same thing that justified it after
+				// syncStep2: this reply is the server's FULL state, snapshot
+				// UNION update-log tail (`CrdtTransport.read_delta` with a nil
+				// state vector), so the post-merge doc provably holds everything
+				// the server held at read time. That is the same reconciliation
+				// strength STEP2 carries, off the same two sources — not a
+				// weaker proof standing in for it.
+				this.crdt.markSynced(noteId);
+				rlog().info(
+					"pull",
+					`CRDT catch-up: diverged cold note converged room-free ${noteRef(change.path)}`,
+				);
+				return;
+			} catch (e) {
+				rlog().warn(
+					"pull",
+					`CRDT catch-up: room-free converge failed for ${noteRef(change.path)}, ` +
+						`falling back to socket re-handshake: ${errMsg(e, change.path)}`,
+				);
+			}
+		}
+
+		rlog().warn(
+			"pull",
+			`CRDT catch-up: diverged cold note, socket re-handshake ${noteRef(change.path)}`,
+		);
+		this.socketConverge(normalized, noteId);
 	}
 
 	/** The full local cleanup for a remotely-deleted file: trash it (marked so
@@ -4691,6 +4809,8 @@ export class SyncEngine {
 	}
 
 	private crdtCatchupSince: CrdtCatchupSinceFn | null = null;
+
+	private crdtDocState: CrdtDocStateFn | null = null;
 
 	setCrdtCatchupSince(fn: CrdtCatchupSinceFn): void {
 		this.setCrdtPorts({ catchupSince: fn });
@@ -7940,26 +8060,33 @@ export class SyncEngine {
 								serverHash: change.content_hash,
 							});
 						} else if (noteId) {
-							// CRDT-enrolled cold note: SAME stage-then-fire pattern as
-							// the live-bound leg above (Phase E3 — the REST delta pull
-							// is deleted). The room re-handshake's STEP2 delivers the
-							// missing Yjs ops, the manager's remote-merge listener
-							// flushes disk, and commitCrdtConvergence records this
-							// stage only once the doc verifiably projects the row.
-							// Never write the feed's content SNAPSHOT — it is
-							// checkpoint-lagged and can revert a fresher live merge
-							// (the D2 stomp class); Yjs merge is monotonic.
-							rlog().warn(
-								"pull",
-								`CRDT catch-up: diverged cold note, socket re-handshake ${noteRef(change.path)}`,
-							);
-							this.stageAndConverge(
+							// CRDT-enrolled COLD note — nobody has this open in an
+							// editor. It still needs the server's Yjs ops (never the
+							// feed's plaintext `content`: that snapshot is
+							// checkpoint-lagged and can revert a fresher live merge,
+							// the D2 stomp class — Yjs merge is monotonic, a
+							// content write is not).
+							//
+							// #1409: getting those ops used to mean a room. The
+							// stage-then-fire pattern below fired a STEP1, the backend
+							// routed it through `ensure_room`, and a bulk first sync
+							// allocated one room per cold note that fell through to
+							// catch-up — measured as 100% of the rooms a 250-note
+							// import opened, and 81-583 per 1,000 notes under CI load.
+							// `crdt_doc_state` returns the same state off the persisted
+							// snapshot + tail with no room; the apply is the same
+							// monotonic merge STEP2's would have been.
+							//
+							// Falls back to the room handshake on ANY failure — an old
+							// backend that doesn't know the frame, a rate limit, a
+							// dropped socket. Convergence is the invariant; the room is
+							// only the expensive way to reach it.
+							await this.convergeColdNoteRoomFree(
 								noteId,
 								normalized,
-								change.content_hash,
+								change,
 								content,
-								change.version,
-								change.seq,
+								change.content_hash,
 							);
 						} else {
 							// No note_id (legacy GET /notes/changes path — no id to pull

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -334,6 +334,10 @@ type CrdtCatchupSinceFn = (
 	next_id?: string | null;
 }>;
 
+/** Socket frame name for the room-free doc read, latched in `unsupportedFrames`
+ *  when a server proves it does not implement it. */
+const DOC_STATE_FRAME = "crdt_doc_state";
+
 /** Room-free full Yjs state for one note — see `CrdtChannel.crdtDocState`. */
 type CrdtDocStateFn = (docId: string) => Promise<{ b64: string; head: string }>;
 
@@ -2846,6 +2850,15 @@ export class SyncEngine {
 		const fetchState = this.crdtDocState;
 		if (!fetchState || !this.crdt) return null;
 
+		// A backend that predates `crdt_doc_state` never REPLIES to the frame —
+		// it does not reject it, so every call costs a full sendRequest timeout.
+		// Discovered once per session rather than once per note: unlatched, a
+		// bulk import against an older server pays that timeout on every create
+		// and the sync effectively stops (measured: e2e creates went from ~1.5s
+		// to ~2min each). Re-arms on a vault change, since that can mean a
+		// different backend entirely.
+		if (this.unsupportedFrames.has(DOC_STATE_FRAME)) return null;
+
 		try {
 			const { b64 } = await fetchState(noteId);
 			await this.crdt.applyRemoteUpdate(noteId, fromB64(b64));
@@ -2855,9 +2868,21 @@ export class SyncEngine {
 			);
 			return await this.crdt.projectedText(noteId);
 		} catch (e) {
+			const detail = errMsg(e, path);
+			// A TIMEOUT means the server never answered the frame at all, which is
+			// what an older backend does with an unknown event. A structured
+			// reject (rate limit, auth) is a real answer and must NOT latch.
+			if (/timeout/i.test(detail)) {
+				this.unsupportedFrames.add(DOC_STATE_FRAME);
+				rlog().warn(
+					"crdt",
+					`crdt_doc_state unanswered by this server — room-free doc reads disabled for ` +
+						`this session (older backend); falling back to the pre-#476 create path`,
+				);
+			}
 			rlog().warn(
 				"crdt",
-				`create: could not adopt server lineage for ${noteRef(path)}: ${errMsg(e, path)}`,
+				`create: could not adopt server lineage for ${noteRef(path)}: ${detail}`,
 			);
 			return null;
 		}
@@ -4937,6 +4962,12 @@ export class SyncEngine {
 	private crdtCatchupSince: CrdtCatchupSinceFn | null = null;
 
 	private crdtDocState: CrdtDocStateFn | null = null;
+
+	/** Socket frames this SERVER has proven it does not implement (it never
+	 *  answers, so each attempt costs a full request timeout). Vault-scoped
+	 *  because a vault switch can move us to a different backend entirely —
+	 *  self-host and SaaS are different servers at different versions. */
+	private unsupportedFrames = this.track(["vault", "destroy"], new Set<string>());
 
 	setCrdtCatchupSince(fn: CrdtCatchupSinceFn): void {
 		this.setCrdtPorts({ catchupSince: fn });

--- a/src/synced-file.ts
+++ b/src/synced-file.ts
@@ -142,8 +142,19 @@ export class SyncedFileTable {
 		this.files.delete(path);
 	}
 
-	/** Cancel every outstanding timer. Call on teardown. */
-	destroy(): void {
+	/** Cancel every outstanding timer and drop every marker.
+	 *
+	 *  Named `clear` (not only `destroy`) so the table satisfies the engine's
+	 *  sweepable contract: its markers are PATH-keyed and therefore vault-scoped
+	 *  — an echo marker stranded from the old vault suppresses a real event for
+	 *  the same path in the new one. It escaped the sweep registry purely
+	 *  because it is a composed object rather than a Map (#1409 review). */
+	clear(): void {
 		for (const path of [...this.files.keys()]) this.forget(path);
+	}
+
+	/** Teardown alias — same work, kept for call-site clarity. */
+	destroy(): void {
+		this.clear();
 	}
 }

--- a/src/tabs/self-hosted-tab.ts
+++ b/src/tabs/self-hosted-tab.ts
@@ -488,15 +488,12 @@ export function describeListVaultsError(e: unknown): string {
  *  helper is unit-testable without dragging in the Obsidian DOM stack. */
 export interface VaultSwitchTarget {
 	settings: { vaultId: string | null; remoteVaultName?: string };
-	api: { setVaultId: (id: string | null) => void };
+	/** THE shared vault-change transition (main.ts). This used to be
+	 *  re-implemented here and agreed with the picker on 1 of 8 steps (#1409);
+	 *  the divergence is what let a previous vault's note-id map survive a
+	 *  switch. One path now, so it cannot drift again. */
+	switchVault: (id: string, name?: string) => Promise<void>;
 	saveSettings: () => Promise<void>;
-	/** #1409. Per-vault bookkeeping — the path -> note_id map above all — is
-	 *  scoped to the vault it was learned in. This interface narrows the plugin
-	 *  for testability, and `syncEngine` being absent from it is precisely why
-	 *  the reset was never wired here while main.ts's picker path
-	 *  (`applyVaultChange`) has always done it. Optional so existing callers and
-	 *  tests that construct a bare target still typecheck. */
-	syncEngine?: { resetForVaultChange: () => Promise<void> };
 }
 
 /** Apply a user-driven vault switch. Returns `true` if the active vault
@@ -508,26 +505,12 @@ export async function applyVaultSwitch(
 	value: string,
 	name?: string,
 ): Promise<boolean> {
+	// No-op guard stays HERE, before the shared transition: switching to the
+	// vault you are already on must not wipe per-vault state.
 	if (!value || value === plugin.settings.vaultId) return false;
-	plugin.settings.vaultId = value;
-	if (name !== undefined) plugin.settings.remoteVaultName = name;
-	plugin.api.setVaultId(value);
-	// #1409 ROOT CAUSE. Switching the active vault WITHOUT this left the
-	// previous vault's path -> note_id map live, so `crdt_create` proposed
-	// foreign-vault ids. The server cannot reuse one (the #1318 collision
-	// class), answers with a fresh id, `serverId !== noteId` fails the seeded
-	// fast path, and the fallback broadcasts a sync_update that opens a room
-	// PER NOTE. Measured on a real 423-item import: 225 rooms for 317 notes,
-	// all source=edit, ZERO crdt_update_log rows — every room redundant.
-	//
-	// main.ts's picker (`applyVaultChange`) has always done this; only the
-	// self-hosted settings path was missing it, which is why the bug reproduced
-	// on selfhost and never in the e2e harness.
-	//
-	// BEFORE saveSettings, mirroring applyVaultChange's ordering: the reset also
-	// clears lastSync/cursors, and persisting the new vault id beside the old
-	// vault's bookkeeping is the state we are trying to make unreachable.
-	await plugin.syncEngine?.resetForVaultChange();
+	await plugin.switchVault(value, name);
+	// saveSettings, not savePluginData — unlike the picker, this path WANTS the
+	// sync-gate chain to re-fire so the user is prompted for the new vault.
 	await plugin.saveSettings();
 	return true;
 }

--- a/src/tabs/self-hosted-tab.ts
+++ b/src/tabs/self-hosted-tab.ts
@@ -490,6 +490,13 @@ export interface VaultSwitchTarget {
 	settings: { vaultId: string | null; remoteVaultName?: string };
 	api: { setVaultId: (id: string | null) => void };
 	saveSettings: () => Promise<void>;
+	/** #1409. Per-vault bookkeeping — the path -> note_id map above all — is
+	 *  scoped to the vault it was learned in. This interface narrows the plugin
+	 *  for testability, and `syncEngine` being absent from it is precisely why
+	 *  the reset was never wired here while main.ts's picker path
+	 *  (`applyVaultChange`) has always done it. Optional so existing callers and
+	 *  tests that construct a bare target still typecheck. */
+	syncEngine?: { resetForVaultChange: () => Promise<void> };
 }
 
 /** Apply a user-driven vault switch. Returns `true` if the active vault
@@ -505,6 +512,22 @@ export async function applyVaultSwitch(
 	plugin.settings.vaultId = value;
 	if (name !== undefined) plugin.settings.remoteVaultName = name;
 	plugin.api.setVaultId(value);
+	// #1409 ROOT CAUSE. Switching the active vault WITHOUT this left the
+	// previous vault's path -> note_id map live, so `crdt_create` proposed
+	// foreign-vault ids. The server cannot reuse one (the #1318 collision
+	// class), answers with a fresh id, `serverId !== noteId` fails the seeded
+	// fast path, and the fallback broadcasts a sync_update that opens a room
+	// PER NOTE. Measured on a real 423-item import: 225 rooms for 317 notes,
+	// all source=edit, ZERO crdt_update_log rows — every room redundant.
+	//
+	// main.ts's picker (`applyVaultChange`) has always done this; only the
+	// self-hosted settings path was missing it, which is why the bug reproduced
+	// on selfhost and never in the e2e harness.
+	//
+	// BEFORE saveSettings, mirroring applyVaultChange's ordering: the reset also
+	// clears lastSync/cursors, and persisting the new vault id beside the old
+	// vault's bookkeeping is the state we are trying to make unreachable.
+	await plugin.syncEngine?.resetForVaultChange();
 	await plugin.saveSettings();
 	return true;
 }

--- a/tests/auth-state.test.ts
+++ b/tests/auth-state.test.ts
@@ -232,12 +232,14 @@ function makeTarget(overrides: Partial<EngramSyncSettings> = {}): ApiUrlSwitchTa
 	api: { setAuthProvider: ReturnType<typeof mock> };
 	noteStream: { disconnect: ReturnType<typeof mock> } | null;
 	resetAuthProvider: ReturnType<typeof mock>;
+	discardVaultScopedState: ReturnType<typeof mock>;
 } {
 	return {
 		settings: fullSettings(overrides),
 		api: { setAuthProvider: mock(() => {}) },
 		noteStream: { disconnect: mock(() => {}) },
 		resetAuthProvider: mock(() => {}),
+		discardVaultScopedState: mock(async () => {}),
 	};
 }
 
@@ -283,6 +285,33 @@ describe("applyApiUrlChange", () => {
 		expect(target.noteStream?.disconnect).toHaveBeenCalledTimes(1);
 		expect(target.resetAuthProvider).toHaveBeenCalledTimes(1);
 		expect(save).toHaveBeenCalledTimes(1);
+	});
+
+	test("different origin: wipes the vault-scoped state too", async () => {
+		// `withClearedAuth` nulls `vaultId`, which makes a backend change a VAULT
+		// change — and note_ids are unique only within the vault that issued
+		// them. Clearing the credentials while keeping the note-id map handed the
+		// new backend the old one's ids (#1409 review). Called with the
+		// already-nulled value, not a literal, so it tracks the cleared set.
+		const target = makeTarget({ apiUrl: "https://engram.ras.band" });
+		await applyApiUrlChange(
+			target,
+			"http://engram.ax",
+			mock(async () => {}),
+		);
+		expect(target.discardVaultScopedState).toHaveBeenCalledWith(null);
+	});
+
+	test("same origin: leaves the vault-scoped state alone", async () => {
+		// Not a vault change — wiping the map here would cost a full re-reconcile
+		// on every trailing-slash edit.
+		const target = makeTarget({ apiUrl: "https://engram.ras.band" });
+		await applyApiUrlChange(
+			target,
+			"https://engram.ras.band/api",
+			mock(async () => {}),
+		);
+		expect(target.discardVaultScopedState).not.toHaveBeenCalled();
 	});
 
 	test("different origin: resets the live in-memory auth provider", async () => {
@@ -444,6 +473,7 @@ describe("pluginSwitchTarget.resetAuthProvider (#420)", () => {
 					disposed++;
 				},
 			},
+			discardVaultScopedState: async () => {},
 		};
 		pluginSwitchTarget(plugin).resetAuthProvider();
 		// An undisposed instance's in-flight refresh would later persist rotated

--- a/tests/channel-crdt.test.ts
+++ b/tests/channel-crdt.test.ts
@@ -1122,8 +1122,14 @@ describe("NoteChannel CRDT frame senders", () => {
 			{ status: "ok", response: { doc_id: "server-id-Y" } },
 		]);
 		// An older server / no-b64 reply omits `seeded` entirely — the safe
-		// default is "not seeded" (#1409).
-		await expect(p).resolves.toEqual({ docId: "server-id-Y", seeded: false });
+		// default is "not seeded" (#1409). It also omits `genesis`, which is
+		// reported as null rather than guessed: the caller then CONFIRMS the
+		// server's doc is empty before transmitting a body (#476).
+		await expect(p).resolves.toEqual({
+			docId: "server-id-Y",
+			seeded: false,
+			genesisOutcome: null,
+		});
 
 		channel.disconnect();
 	});
@@ -1143,9 +1149,13 @@ describe("NoteChannel CRDT frame senders", () => {
 			frame[1],
 			"crdt:u1:v1",
 			"phx_reply",
-			{ status: "ok", response: { doc_id: "server-id", seeded: true } },
+			{ status: "ok", response: { doc_id: "server-id", seeded: true, genesis: "stored" } },
 		]);
-		await expect(p).resolves.toEqual({ docId: "server-id", seeded: true });
+		await expect(p).resolves.toEqual({
+			docId: "server-id",
+			seeded: true,
+			genesisOutcome: "stored",
+		});
 
 		channel.disconnect();
 	});
@@ -1162,9 +1172,13 @@ describe("NoteChannel CRDT frame senders", () => {
 			frame[1],
 			"crdt:u1:v1",
 			"phx_reply",
-			{ status: "ok", response: { doc_id: "local-id", seeded: false } },
+			{ status: "ok", response: { doc_id: "local-id", seeded: false, genesis: "absent" } },
 		]);
-		await expect(p).resolves.toEqual({ docId: "local-id", seeded: false });
+		await expect(p).resolves.toEqual({
+			docId: "local-id",
+			seeded: false,
+			genesisOutcome: "absent",
+		});
 
 		channel.disconnect();
 	});

--- a/tests/crdt-cross-wire-overwrite.test.ts
+++ b/tests/crdt-cross-wire-overwrite.test.ts
@@ -133,10 +133,14 @@ describe("cross-wired map must not destroy an unrelated note", () => {
 
 		const e = engine as unknown as {
 			cacheManifestOwners(m: unknown): void;
-			manifestOwnersFetchedAt: number;
+			manifestOwners: { owners: Map<string, string> | null; fetchedAt: number };
 		};
 		e.cacheManifestOwners(manifest([{ id: "X", path: "A.md" }])); // old: a.md absent
-		e.manifestOwnersFetchedAt = Date.now() - 60_000; // aged past the 30s TTL
+		// The snapshot and its stamp are ONE sweepable unit now, so that a vault
+		// switch cannot leave a trusted-but-empty map behind — an empty map that
+		// still reads as fresh answers "absent" for every path and would
+		// authorize trashing (#1409 review).
+		e.manifestOwners.fetchedAt = Date.now() - 60_000; // aged past the 30s TTL
 		// Fresh server truth: Y now lives at a.md.
 		getManifest.mockResolvedValue(
 			manifest([

--- a/tests/crdt-genesis-outcome.test.ts
+++ b/tests/crdt-genesis-outcome.test.ts
@@ -169,6 +169,47 @@ describe("an older backend that sends no outcome is confirmed, not guessed", () 
 		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
 	});
 
+	test("a server that never ANSWERS the read is latched off after one timeout", async () => {
+		// An older backend does not reject `crdt_doc_state` — it does not reply at
+		// all, so every probe costs a full sendRequest timeout. Unlatched, a bulk
+		// import pays that on every create and sync effectively stops: the e2e
+		// suite measured creates going from ~1.5s to ~2min each, which is how
+		// this regression was caught before it reached anyone.
+		let attempts = 0;
+		const { engine, calls } = makeEngine({
+			docState: async () => {
+				attempts++;
+				throw new Error("sendRequest timeout: crdt_doc_state");
+			},
+		});
+
+		await seed(engine, null);
+		await seed(engine, null);
+		await seed(engine, null);
+
+		expect(attempts).toBe(1);
+		// ...and every create still delivers its body, just without the probe.
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY, LOCAL_BODY, LOCAL_BODY]);
+	});
+
+	test("a structured REJECT is a real answer and must not latch", async () => {
+		// Rate limits and auth errors mean the server implements the frame and
+		// declined this call. Latching on those would silently disable the
+		// doubling protection on a healthy backend for the rest of the session.
+		let attempts = 0;
+		const { engine } = makeEngine({
+			docState: async () => {
+				attempts++;
+				throw new Error('request failed: {"reason":"rate_limited"}');
+			},
+		});
+
+		await seed(engine, null);
+		await seed(engine, null);
+
+		expect(attempts).toBe(2);
+	});
+
 	test("null outcome + no room-free read at all: still transmits", async () => {
 		// Against a backend with NEITHER the outcome field nor `crdt_doc_state`,
 		// refusing to push would leave every note permanently blank. That is a

--- a/tests/crdt-genesis-outcome.test.ts
+++ b/tests/crdt-genesis-outcome.test.ts
@@ -45,6 +45,9 @@ function makeEngine(opts: { hasHistory?: boolean; docState?: unknown } = {}) {
 		applyLocalEdit: [] as string[],
 		applyRemoteUpdate: 0,
 		docState: 0,
+		/** Call ORDER — adopt-before-diff is the invariant, and a set of counts
+		 *  cannot express it. */
+		order: [] as string[],
 	};
 
 	const engine = new SyncEngine(
@@ -62,10 +65,12 @@ function makeEngine(opts: { hasHistory?: boolean; docState?: unknown } = {}) {
 		// doubling is back.
 		applyLocalEdit: async (_id: string, text: string) => {
 			calls.applyLocalEdit.push(text);
+			calls.order.push("applyLocalEdit");
 			return text;
 		},
 		applyRemoteUpdate: async () => {
 			calls.applyRemoteUpdate++;
+			calls.order.push("applyRemoteUpdate");
 		},
 		projectedText: async () => SERVER_BODY,
 		isCrdtEligible: () => true,
@@ -96,30 +101,27 @@ function seed(engine: AnyEngine, genesisOutcome: unknown) {
 }
 
 describe("genesis outcome decides whether a body may be transmitted (#476)", () => {
-	test("occupied: adopts the server's lineage and NEVER transmits", async () => {
+	test("occupied: adopts the server's lineage FIRST, then transmits as a diff", async () => {
+		// Adopting is the PRECONDITION for transmitting safely, not a substitute
+		// for it. An earlier revision returned the adopted text and stopped,
+		// which silently discarded the local body: `occupied` means the server
+		// holds a DIFFERENT body, so stopping means ours never arrives and the
+		// server's text gets stamped as the baseline over it.
 		const { engine, calls } = makeEngine();
 
-		const consumed = await seed(engine, "occupied");
+		await seed(engine, "occupied");
 
-		// The whole bug in one assertion.
-		expect(calls.applyLocalEdit).toEqual([]);
+		// Both halves, and the ORDER is the point: acquire identity, then diff
+		// onto it. Reversed, the push is a rival lineage — that is #476.
 		expect(calls.applyRemoteUpdate).toBe(1);
-		expect(consumed).toBe(SERVER_BODY);
-	});
-
-	test("absent: transmits, because nothing else will ever fill the note", async () => {
-		const { engine, calls } = makeEngine();
-
-		await seed(engine, "absent");
-
 		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
-		// Trusted outright — no confirmation round trip on the common path.
-		expect(calls.docState).toBe(0);
+		expect(calls.order).toEqual(["applyRemoteUpdate", "applyLocalEdit"]);
 	});
 
-	test("occupied with an unreadable server: transmits NOTHING and defers", async () => {
-		// Deferring costs a slow convergence through catch-up. Pushing costs a
-		// corrupted note. Only one of those is recoverable.
+	test("occupied: adopt FAILING transmits nothing — the server said it holds a body", async () => {
+		// Deferring costs a slow convergence. Pushing costs a corrupted note.
+		// Only one of those is recoverable, and here the server ASSERTED it holds
+		// content, so we are not guessing.
 		const { engine, calls } = makeEngine({
 			docState: async () => {
 				throw new Error("rate limited");
@@ -130,6 +132,16 @@ describe("genesis outcome decides whether a body may be transmitted (#476)", () 
 
 		expect(calls.applyLocalEdit).toEqual([]);
 		expect(consumed).toBeNull();
+	});
+
+	test("absent: transmits, because nothing else will ever fill the note", async () => {
+		const { engine, calls } = makeEngine();
+
+		await seed(engine, "absent");
+
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
+		// Trusted outright — no confirmation round trip on the common path.
+		expect(calls.docState).toBe(0);
 	});
 
 	test("a doc that already has history transmits regardless of outcome", async () => {
@@ -145,18 +157,28 @@ describe("genesis outcome decides whether a body may be transmitted (#476)", () 
 });
 
 describe("an older backend that sends no outcome is confirmed, not guessed", () => {
-	test("null outcome + server holds a body: adopts instead of transmitting", async () => {
-		// The pre-#476 server sends only `seeded`. Rather than inherit its
-		// ambiguity, ask: adopting is a monotonic merge that is harmless when the
-		// server is empty, and a non-empty projection afterwards is direct
-		// evidence that a push would be a SECOND transmission.
+	test("null outcome + adoptable server: adopts, then diffs onto that lineage", async () => {
+		// A null outcome means an older backend. Where the room-free read still
+		// answers, we can acquire the lineage and the push is a safe diff.
 		const { engine, calls } = makeEngine();
 
-		const consumed = await seed(engine, null);
+		await seed(engine, null);
 
 		expect(calls.docState).toBe(1);
-		expect(calls.applyLocalEdit).toEqual([]);
-		expect(consumed).toBe(SERVER_BODY);
+		expect(calls.order).toEqual(["applyRemoteUpdate", "applyLocalEdit"]);
+	});
+
+	test("null outcome + unverifiable server: transmits anyway, and says why", async () => {
+		// THE asymmetry with `occupied`. A backend predating `genesis` also
+		// predates `crdt_doc_state` — they ship together — so a null outcome
+		// guarantees the read is unavailable and we can never verify. Deferring
+		// here is NOT the safe pole: nothing else fills this note, so it stays
+		// blank on every device forever. A possible double beats a certain blank.
+		const { engine, calls } = makeEngine({ docState: null });
+
+		await seed(engine, null);
+
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
 	});
 
 	test("null outcome + server genuinely empty: falls through and transmits", async () => {

--- a/tests/crdt-genesis-outcome.test.ts
+++ b/tests/crdt-genesis-outcome.test.ts
@@ -134,6 +134,70 @@ describe("genesis outcome decides whether a body may be transmitted (#476)", () 
 		expect(consumed).toBeNull();
 	});
 
+	test("a defer stamps disk as the baseline, or it only POSTPONES the doubling", async () => {
+		// The half that made the defer real. Deferring leaves a history-less doc
+		// next to a server that has content — and that is precisely the state
+		// `applyLocalEdit` seeds a whole body into (`lca: false`), minting the
+		// rival lineage. So the note's very NEXT cold write re-armed #476 and the
+		// defer had bought exactly one write's delay.
+		//
+		// The baseline is what disarms it: the registry's adopt-first gate
+		// ("history-less AND unchanged-synced => consumed, nothing to push")
+		// holds the empty doc open until a handshake or catch-up fills it from
+		// the server.
+		const { engine } = makeEngine({
+			docState: async () => {
+				throw new Error("rate limited");
+			},
+		});
+
+		expect(engine.isUnchangedSynced("Notes/a.md", LOCAL_BODY)).toBe(false);
+		await seed(engine, "occupied");
+		expect(engine.isUnchangedSynced("Notes/a.md", LOCAL_BODY)).toBe(true);
+	});
+
+	test("re-id'd + unreadable server state: same defer, same baseline", async () => {
+		// The other defer site: the server took our bytes but filed them under an
+		// id we have never seen (`seeded` + `sameId: false`), and its lineage is
+		// unavailable. Identical hazard, so it must take the identical route —
+		// the two sites drifting apart is how this class survives.
+		const { engine, calls } = makeEngine({
+			docState: async () => {
+				throw new Error("rate limited");
+			},
+		});
+
+		const consumed = await engine.seedBodyAfterCreate({
+			effectiveId: "server-chosen-id",
+			normalized: "Notes/a.md",
+			file: { path: "Notes/a.md" },
+			seeded: true,
+			sameId: false,
+			genesisUpdate: undefined,
+			genesisContent: undefined,
+			genesisOutcome: "stored",
+		});
+
+		expect(consumed).toBeNull();
+		expect(calls.applyLocalEdit).toEqual([]);
+		expect(engine.isUnchangedSynced("Notes/a.md", LOCAL_BODY)).toBe(true);
+	});
+
+	test("an unreadable disk leaves the baseline alone rather than stamping a lie", async () => {
+		// A WRONG hash suppresses a real push for the life of the vault, which is
+		// strictly worse than the re-arm it would prevent. Absence is honest.
+		const { engine } = makeEngine({
+			docState: async () => {
+				throw new Error("rate limited");
+			},
+		});
+		engine.app.vault.cachedRead = mock().mockRejectedValue(new Error("EIO"));
+
+		await seed(engine, "occupied");
+
+		expect(engine.isUnchangedSynced("Notes/a.md", LOCAL_BODY)).toBe(false);
+	});
+
 	test("absent: transmits, because nothing else will ever fill the note", async () => {
 		const { engine, calls } = makeEngine();
 

--- a/tests/crdt-genesis-outcome.test.ts
+++ b/tests/crdt-genesis-outcome.test.ts
@@ -40,7 +40,9 @@ const LOCAL_BODY = "the body sitting on local disk";
  *        history, transmitting is always safe (`lca` diffs against it), so the
  *        outcome only matters when this is false — the empty-doc case.
  */
-function makeEngine(opts: { hasHistory?: boolean; docState?: unknown } = {}) {
+function makeEngine(
+	opts: { hasHistory?: boolean; docState?: unknown; applyRefused?: boolean } = {},
+) {
 	const calls = {
 		applyLocalEdit: [] as string[],
 		applyRemoteUpdate: 0,
@@ -71,6 +73,12 @@ function makeEngine(opts: { hasHistory?: boolean; docState?: unknown } = {}) {
 		applyRemoteUpdate: async () => {
 			calls.applyRemoteUpdate++;
 			calls.order.push("applyRemoteUpdate");
+			// TRUE means "a doc actually received this". The registry returns
+			// false when it refuses (note removed, doc destroyed mid-hydration),
+			// and the adopt must not report success on a merge that never
+			// happened — a fake that answered void made every one of these tests
+			// pass against exactly that bug.
+			return opts.applyRefused !== true;
 		},
 		projectedText: async () => SERVER_BODY,
 		isCrdtEligible: () => true,
@@ -130,6 +138,22 @@ describe("genesis outcome decides whether a body may be transmitted (#476)", () 
 
 		const consumed = await seed(engine, "occupied");
 
+		expect(calls.applyLocalEdit).toEqual([]);
+		expect(consumed).toBeNull();
+	});
+
+	test("a REFUSED apply is not an adopt — it must not license the push", async () => {
+		// `applyRemoteUpdate` refuses silently when the note is in `removed` or
+		// its doc was destroyed mid-hydration. Its promise still RESOLVES, so
+		// reading resolution as proof of a merge meant logging "adopted server
+		// lineage" for a doc that received nothing and then diffing the body into
+		// it — which `applyLocalEdit` sees as history-less and mints a rival
+		// lineage for. The refusal has to be visible, and it now is.
+		const { engine, calls } = makeEngine({ applyRefused: true });
+
+		const consumed = await seed(engine, "occupied");
+
+		expect(calls.applyRemoteUpdate).toBe(1);
 		expect(calls.applyLocalEdit).toEqual([]);
 		expect(consumed).toBeNull();
 	});

--- a/tests/crdt-genesis-outcome.test.ts
+++ b/tests/crdt-genesis-outcome.test.ts
@@ -191,12 +191,18 @@ describe("an older backend that sends no outcome is confirmed, not guessed", () 
 		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
 	});
 
-	test("a server that never ANSWERS the read is latched off after one timeout", async () => {
+	test("a server that never ANSWERS the read is latched off after repeated timeouts", async () => {
 		// An older backend does not reject `crdt_doc_state` — it does not reply at
 		// all, so every probe costs a full sendRequest timeout. Unlatched, a bulk
 		// import pays that on every create and sync effectively stops: the e2e
 		// suite measured creates going from ~1.5s to ~2min each, which is how
 		// this regression was caught before it reached anyone.
+		//
+		// TWO strikes, not one. A modern backend produces the identical signal
+		// whenever the channel dies (phx_error does not reject pending replies,
+		// so a crash surfaces as a timeout), and one slow reply under import load
+		// is entirely reachable — latching on a single sample would disable the
+		// doubling protection on a healthy server for the rest of the session.
 		let attempts = 0;
 		const { engine, calls } = makeEngine({
 			docState: async () => {
@@ -209,7 +215,7 @@ describe("an older backend that sends no outcome is confirmed, not guessed", () 
 		await seed(engine, null);
 		await seed(engine, null);
 
-		expect(attempts).toBe(1);
+		expect(attempts).toBe(2);
 		// ...and every create still delivers its body, just without the probe.
 		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY, LOCAL_BODY, LOCAL_BODY]);
 	});

--- a/tests/crdt-genesis-outcome.test.ts
+++ b/tests/crdt-genesis-outcome.test.ts
@@ -1,0 +1,182 @@
+/**
+ * #476 — the note-doubling class, closed at its source.
+ *
+ * A create used to be acked with ONE bit, `seeded: boolean`. That bit reported
+ * `false` for two server states that demand OPPOSITE client actions:
+ *
+ *   "I stored nothing, the row is empty"      -> the client MUST push the body
+ *   "I declined, the row holds another body"  -> the client must NOT push
+ *
+ * In the second case the client pushed anyway, into a Y.Doc it still believed
+ * was empty. Writing a body into an empty doc mints a fresh clientID, so that
+ * push was a RIVAL lineage carrying identical text, and YATA's contract is to
+ * preserve both concurrent inserts rather than deduplicate them. The union is
+ * the note, twice — and the next import reads the doubled file and doubles it
+ * again. Measured across eight real 423-item imports: 3 MB grew to 120 MB, one
+ * 34 KB note reaching 4.9 MB with its 225 distinct lines repeated 144 times.
+ *
+ * No client-side guard could fix that, which is the point worth remembering:
+ * the invariant "a body reaches the server exactly once per create" was written
+ * correctly and STILL doubled 13 notes, because it was evaluated against an
+ * input that could not express the difference. The fix is the wire format —
+ * the server now names the outcome (`stored` / `absent` / `occupied`) it
+ * already computed and used to throw away.
+ *
+ * These tests pin the decision table directly, since it is the thing that must
+ * never regress.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../src/sync";
+import { DEFAULT_SETTINGS } from "../src/types";
+
+type AnyEngine = Record<string, any>;
+
+const SERVER_BODY = "the body the server already holds";
+const LOCAL_BODY = "the body sitting on local disk";
+
+/**
+ * @param hasHistory whether the local doc already carries a lineage. With
+ *        history, transmitting is always safe (`lca` diffs against it), so the
+ *        outcome only matters when this is false — the empty-doc case.
+ */
+function makeEngine(opts: { hasHistory?: boolean; docState?: unknown } = {}) {
+	const calls = {
+		applyLocalEdit: [] as string[],
+		applyRemoteUpdate: 0,
+		docState: 0,
+	};
+
+	const engine = new SyncEngine(
+		{
+			vault: { cachedRead: mock().mockResolvedValue(LOCAL_BODY) },
+		} as any,
+		{} as any,
+		{ ...DEFAULT_SETTINGS },
+		mock().mockResolvedValue(undefined),
+	) as unknown as AnyEngine;
+
+	engine.crdt = {
+		hasAnyHistory: async () => opts.hasHistory === true,
+		// The ONLY transmit path. If this fires on an `occupied` outcome, the
+		// doubling is back.
+		applyLocalEdit: async (_id: string, text: string) => {
+			calls.applyLocalEdit.push(text);
+			return text;
+		},
+		applyRemoteUpdate: async () => {
+			calls.applyRemoteUpdate++;
+		},
+		projectedText: async () => SERVER_BODY,
+		isCrdtEligible: () => true,
+	};
+
+	engine.crdtDocState =
+		opts.docState === undefined
+			? async () => {
+					calls.docState++;
+					return { b64: "" };
+				}
+			: opts.docState;
+
+	return { engine, calls };
+}
+
+function seed(engine: AnyEngine, genesisOutcome: unknown) {
+	return engine.seedBodyAfterCreate({
+		effectiveId: "note-1",
+		normalized: "Notes/a.md",
+		file: { path: "Notes/a.md" },
+		seeded: genesisOutcome === "stored",
+		sameId: true,
+		genesisUpdate: undefined,
+		genesisContent: undefined,
+		genesisOutcome,
+	});
+}
+
+describe("genesis outcome decides whether a body may be transmitted (#476)", () => {
+	test("occupied: adopts the server's lineage and NEVER transmits", async () => {
+		const { engine, calls } = makeEngine();
+
+		const consumed = await seed(engine, "occupied");
+
+		// The whole bug in one assertion.
+		expect(calls.applyLocalEdit).toEqual([]);
+		expect(calls.applyRemoteUpdate).toBe(1);
+		expect(consumed).toBe(SERVER_BODY);
+	});
+
+	test("absent: transmits, because nothing else will ever fill the note", async () => {
+		const { engine, calls } = makeEngine();
+
+		await seed(engine, "absent");
+
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
+		// Trusted outright — no confirmation round trip on the common path.
+		expect(calls.docState).toBe(0);
+	});
+
+	test("occupied with an unreadable server: transmits NOTHING and defers", async () => {
+		// Deferring costs a slow convergence through catch-up. Pushing costs a
+		// corrupted note. Only one of those is recoverable.
+		const { engine, calls } = makeEngine({
+			docState: async () => {
+				throw new Error("rate limited");
+			},
+		});
+
+		const consumed = await seed(engine, "occupied");
+
+		expect(calls.applyLocalEdit).toEqual([]);
+		expect(consumed).toBeNull();
+	});
+
+	test("a doc that already has history transmits regardless of outcome", async () => {
+		// `applyLocalEdit`'s `lca` diffs against the existing lineage instead of
+		// minting a second one, so there is nothing to protect against here — and
+		// refusing would strand a real local edit.
+		const { engine, calls } = makeEngine({ hasHistory: true });
+
+		await seed(engine, "occupied");
+
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
+	});
+});
+
+describe("an older backend that sends no outcome is confirmed, not guessed", () => {
+	test("null outcome + server holds a body: adopts instead of transmitting", async () => {
+		// The pre-#476 server sends only `seeded`. Rather than inherit its
+		// ambiguity, ask: adopting is a monotonic merge that is harmless when the
+		// server is empty, and a non-empty projection afterwards is direct
+		// evidence that a push would be a SECOND transmission.
+		const { engine, calls } = makeEngine();
+
+		const consumed = await seed(engine, null);
+
+		expect(calls.docState).toBe(1);
+		expect(calls.applyLocalEdit).toEqual([]);
+		expect(consumed).toBe(SERVER_BODY);
+	});
+
+	test("null outcome + server genuinely empty: falls through and transmits", async () => {
+		const { engine, calls } = makeEngine();
+		engine.crdt.projectedText = async () => "";
+
+		await seed(engine, null);
+
+		expect(calls.docState).toBe(1);
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
+	});
+
+	test("null outcome + no room-free read at all: still transmits", async () => {
+		// Against a backend with NEITHER the outcome field nor `crdt_doc_state`,
+		// refusing to push would leave every note permanently blank. That is a
+		// worse, and silent, failure than the doubling it would avoid.
+		const { engine, calls } = makeEngine({ docState: null });
+
+		await seed(engine, null);
+
+		expect(calls.applyLocalEdit).toEqual([LOCAL_BODY]);
+	});
+});

--- a/tests/crdt-op-wiring.test.ts
+++ b/tests/crdt-op-wiring.test.ts
@@ -34,7 +34,11 @@ describe("crdtOpFailureReason", () => {
 describe("makeCrdtOpSend dispatch + taxonomy", () => {
 	function fakeChannel(overrides: Partial<CrdtOpChannel> = {}): CrdtOpChannel {
 		return {
-			crdtCreate: mock(async (docId: string) => ({ docId, seeded: false })),
+			crdtCreate: mock(async (docId: string) => ({
+				docId,
+				seeded: false,
+				genesisOutcome: "absent" as const,
+			})),
 			crdtDeleteAcked: mock(async (docId: string) => ({ doc_id: docId })),
 			...overrides,
 		};
@@ -44,13 +48,28 @@ describe("makeCrdtOpSend dispatch + taxonomy", () => {
 		const onCreated = mock(() => {});
 		const send = makeCrdtOpSend({
 			channel: () =>
-				fakeChannel({ crdtCreate: async () => ({ docId: "server-id", seeded: false }) }),
+				fakeChannel({
+					crdtCreate: async () => ({
+						docId: "server-id",
+						seeded: false,
+						genesisOutcome: "absent" as const,
+					}),
+				}),
 			onCreated,
 			onTerminal: () => {},
 		});
 		await expect(send(op("create", "local-id", "N.md"))).resolves.toBe("ok");
 		// #1409: onCreated also carries seeded + the (here-unwired) genesis frame.
-		expect(onCreated).toHaveBeenCalledWith("local-id", "server-id", "N.md", false, undefined);
+		// #476: and the server's genesis OUTCOME, which is what actually decides
+		// whether the body may be transmitted — `seeded` alone could not.
+		expect(onCreated).toHaveBeenCalledWith(
+			"local-id",
+			"server-id",
+			"N.md",
+			false,
+			undefined,
+			"absent",
+		);
 	});
 
 	// H4 (adversarial review): a replayed create must still carry the genesis
@@ -62,6 +81,7 @@ describe("makeCrdtOpSend dispatch + taxonomy", () => {
 		const crdtCreate = mock(async (_docId: string, _path: string, b64?: string) => ({
 			docId: "server-id",
 			seeded: b64 !== undefined,
+			genesisOutcome: b64 === undefined ? ("absent" as const) : ("stored" as const),
 		}));
 		const onCreated = mock(() => {});
 		const genesis = {
@@ -79,13 +99,21 @@ describe("makeCrdtOpSend dispatch + taxonomy", () => {
 		await expect(send(op("create", "local-id", "N.md"))).resolves.toBe("ok");
 
 		expect(crdtCreate).toHaveBeenCalledWith("local-id", "N.md", "BASE64FRAME");
-		expect(onCreated).toHaveBeenCalledWith("local-id", "server-id", "N.md", true, genesis);
+		expect(onCreated).toHaveBeenCalledWith(
+			"local-id",
+			"server-id",
+			"N.md",
+			true,
+			genesis,
+			"stored",
+		);
 	});
 
 	test("H4: a note that doesn't qualify (buildGenesisFrame returns undefined) sends a bodyless create as before", async () => {
 		const crdtCreate = mock(async (docId: string, _path: string, b64?: string) => ({
 			docId,
 			seeded: b64 !== undefined,
+			genesisOutcome: b64 === undefined ? ("absent" as const) : ("stored" as const),
 		}));
 		const onCreated = mock(() => {});
 		const send = makeCrdtOpSend({
@@ -98,7 +126,16 @@ describe("makeCrdtOpSend dispatch + taxonomy", () => {
 		await expect(send(op("create", "local-id", "N.md"))).resolves.toBe("ok");
 
 		expect(crdtCreate).toHaveBeenCalledWith("local-id", "N.md");
-		expect(onCreated).toHaveBeenCalledWith("local-id", "local-id", "N.md", false, undefined);
+		// No frame was sent, so the server has nothing to hold: `absent` is what
+		// permits the caller to transmit the body (#476).
+		expect(onCreated).toHaveBeenCalledWith(
+			"local-id",
+			"local-id",
+			"N.md",
+			false,
+			undefined,
+			"absent",
+		);
 	});
 
 	test("delete resolve → ok", async () => {

--- a/tests/crdt-release-room.test.ts
+++ b/tests/crdt-release-room.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #1409: the server holds a room open for `idle_exit_ms` (5 minutes) after the
+ * last frame, because a room is `auto_exit: true` and the ONLY thing that ever
+ * released the channel's observation was the room's own idle drain.
+ *
+ * That is right for an open editor and wrong for a bulk first sync, where each
+ * note needs its room for milliseconds. A 2,000-note import held 2,000 rooms
+ * for five minutes past their last frame, bounded only by the LRU force-evicting
+ * them.
+ *
+ * `releaseHealRoom` already did the CLIENT half — reset enrollment, close the
+ * local doc — and said nothing on the wire, so the server kept observing. These
+ * pin the missing half: the same gate that decides the client is done must also
+ * tell the server.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../src/sync";
+import { DEFAULT_SETTINGS } from "../src/types";
+
+type AnyEngine = Record<string, any>;
+
+function makeEngine(opts: { liveBound?: boolean } = {}) {
+	const released: string[] = [];
+	const engine = new SyncEngine(
+		{ vault: { cachedRead: mock().mockResolvedValue(""), getFileByPath: () => null } } as any,
+		{} as any,
+		{ ...DEFAULT_SETTINGS },
+		mock().mockResolvedValue(undefined),
+	) as unknown as AnyEngine;
+
+	engine.setCrdtPorts({
+		manager: { closeDoc: mock() } as any,
+		enrollment: { reset: mock(), enroll: mock() } as any,
+		liveBound: () => opts.liveBound === true,
+		release: (docId: string) => released.push(docId),
+	});
+	engine.noteIdMap = { pathForId: (_id: string) => "Notes/a.md" } as any;
+	return { engine, released };
+}
+
+describe("a released note tells the SERVER, not just itself (#1409)", () => {
+	test("an idle note's room is released on the wire", async () => {
+		const { engine, released } = makeEngine();
+
+		engine.releaseHealRoom("note-1", "Notes/a.md");
+
+		expect(released).toEqual(["note-1"]);
+	});
+
+	test("a LIVE-BOUND note keeps its room — 5 minutes is correct for an open editor", async () => {
+		// The whole point of the split: interactive editing keeps the warm room,
+		// only import-shaped traffic releases early. Releasing here would make
+		// every keystroke pay a re-handshake.
+		const { engine, released } = makeEngine({ liveBound: true });
+
+		engine.releaseHealRoom("note-1", "Notes/a.md");
+
+		expect(released).toEqual([]);
+	});
+
+	test("a note whose id is unmapped is still released", async () => {
+		// Deleted since staging: it cannot be live-bound, and a deleted note must
+		// not keep holding a room.
+		const { engine, released } = makeEngine();
+		engine.noteIdMap = { pathForId: (_id: string) => null } as any;
+
+		engine.releaseHealRoom("note-1", null);
+
+		expect(released).toEqual(["note-1"]);
+	});
+
+	test("a missing release port is a no-op, never a throw", async () => {
+		// Older backend / no socket: the local half must still run.
+		const { engine } = makeEngine();
+		engine.setCrdtPorts({ release: null });
+
+		expect(() => engine.releaseHealRoom("note-1", "Notes/a.md")).not.toThrow();
+	});
+});

--- a/tests/device-flow-modal.test.ts
+++ b/tests/device-flow-modal.test.ts
@@ -602,7 +602,7 @@ describe("DeviceFlowModal — foreground resume", () => {
 	// Otherwise the deferred probe is one more orphan holding a dead
 	// device_code — the same class of leak as the socket and the listener.
 	test("resetFlow cancels a deferred resume probe", () => {
-		const { modal, exchanged, fire, runDeferred, resetWithTimers } = startFlow();
+		const { exchanged, fire, runDeferred, resetWithTimers } = startFlow();
 		fire();
 		resetWithTimers();
 

--- a/tests/main-auth-ux.test.ts
+++ b/tests/main-auth-ux.test.ts
@@ -91,9 +91,10 @@ describe("status bar when signed out", () => {
 describe("clearAuthAndPromptRelink surfaces into an open preview modal", () => {
 	test("sets the sign-in plan error on the open modal", async () => {
 		const planErrors: string[] = [];
+		let vaultWipes = 0;
 		const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
 			settings: { refreshToken: "rt" } as Record<string, unknown>,
-			api: { setAuthProvider(_p: unknown) {} },
+			api: { setAuthProvider(_p: unknown) {}, setVaultId(_v: unknown) {} },
 			authProvider: null,
 			noteStream: null,
 			liveConnected: false,
@@ -105,6 +106,9 @@ describe("clearAuthAndPromptRelink surfaces into an open preview modal", () => {
 			},
 			async savePluginData(_ls: unknown) {},
 			syncEngine: {
+				async resetForVaultChange() {
+					vaultWipes++;
+				},
 				getLastSync() {
 					return 0;
 				},
@@ -124,6 +128,11 @@ describe("clearAuthAndPromptRelink surfaces into an open preview modal", () => {
 		// The open modal must flip to the sign-in error instead of spinning
 		// until the enumerate budget expires and blaming the connection.
 		expect(planErrors).toEqual([planLoadErrorMessage(false)]);
+		// #1409 review: `withClearedAuth` nulls `vaultId`, so this IS a vault
+		// change. Re-linking to a different account or a second vault used to
+		// inherit the previous vault's note-id map.
+		expect(vaultWipes).toBe(1);
+		expect(fake.settings.vaultId).toBeNull();
 	});
 });
 
@@ -183,7 +192,7 @@ describe("round-1 review fixes (#422)", () => {
 		};
 		const base = {
 			settings: { refreshToken: "rt" } as Record<string, unknown>,
-			api: { setAuthProvider(_p: unknown) {} },
+			api: { setAuthProvider(_p: unknown) {}, setVaultId(_v: unknown) {} },
 			authProvider: null,
 			noteStream: null,
 			liveConnected: false,
@@ -191,6 +200,7 @@ describe("round-1 review fixes (#422)", () => {
 			openPreviewModal: null as unknown,
 			async savePluginData(_ls: unknown) {},
 			syncEngine: {
+				async resetForVaultChange() {},
 				getLastSync() {
 					return 0;
 				},

--- a/tests/main-heal-dead-vault.test.ts
+++ b/tests/main-heal-dead-vault.test.ts
@@ -8,9 +8,14 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 import EngramSyncPlugin from "../src/main";
+import { destroyRemoteLog, initRemoteLog } from "../src/remote-log";
 
 function makeFakePlugin(over: Record<string, unknown> = {}) {
-	const fake = {
+	// Prototype-backed, not a bare literal: the heal delegates the state wipe to
+	// the real `discardVaultScopedState`, and a literal `this` would leave that
+	// undefined — a TypeError the heal's own catch would then swallow, quietly
+	// turning this suite green against a heal that does nothing.
+	const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
 		healingVault: false,
 		settings: { vaultId: "dead-vault-id", remoteVaultName: "Dead" },
 		syncGateAcceptedFor: "some-fingerprint",
@@ -19,11 +24,15 @@ function makeFakePlugin(over: Record<string, unknown> = {}) {
 			setVaultId: mock(),
 		},
 		openPreviewModal: { close: mock() },
-		syncEngine: { setSyncBlocked: mock(), getLastSync: mock().mockReturnValue("") },
+		syncEngine: {
+			setSyncBlocked: mock(),
+			getLastSync: mock().mockReturnValue(""),
+			resetForVaultChange: mock().mockResolvedValue(undefined),
+		},
 		savePluginData: mock().mockResolvedValue(undefined),
 		doSyncWithFirstSyncCheck: mock().mockResolvedValue(undefined),
 		...over,
-	};
+	});
 	const heal = (EngramSyncPlugin.prototype as any).healDeadVault as (
 		this: unknown,
 		e: unknown,
@@ -53,6 +62,63 @@ describe("healDeadVault", () => {
 		// Finding 9: a stale open preview must be closed before reopening the
 		// picker — the guard makes the reopen a no-op while it is open.
 		expect(previewClose as any).toHaveBeenCalled();
+		// #1409 review: the vault is GONE, so its note-id map addresses nothing.
+		// Nulling the id while keeping the map let the NEXT vault the picker
+		// lands on inherit the dead vault's note_ids.
+		expect(fake.syncEngine.resetForVaultChange as any).toHaveBeenCalled();
+	});
+
+	test("a heal that throws midway is logged, not swallowed", async () => {
+		// The catch used to wrap the whole heal, so any throw inside it left the
+		// vault half-cleared with nothing written anywhere — and the next 404
+		// re-entered and failed identically, forever. The log is the ONLY
+		// observable difference, which is exactly why it has to be asserted.
+		const logger = initRemoteLog();
+		const errors: string[] = [];
+		(logger as unknown as { error: unknown }).error = (_cat: string, msg: string) => {
+			errors.push(msg);
+		};
+		const { fake, heal } = makeFakePlugin({
+			syncEngine: {
+				setSyncBlocked: mock(),
+				getLastSync: mock().mockReturnValue(""),
+				resetForVaultChange: mock().mockRejectedValue(new Error("indexeddb gone")),
+			},
+		});
+
+		try {
+			await heal(err404);
+		} finally {
+			await destroyRemoteLog();
+		}
+
+		expect(errors.some((m) => m.includes("Dead-vault heal failed midway"))).toBe(true);
+		// ...and the guard still releases, or the heal can never run again.
+		expect(fake.healingVault).toBe(false);
+	});
+
+	test("a listVaults failure stays silent — nothing was concluded", async () => {
+		// The narrowed catch must still swallow the PROBE's failure: offline is
+		// not evidence the vault is gone, and logging an error every time the
+		// user's laptop sleeps is noise.
+		const logger = initRemoteLog();
+		const errors: string[] = [];
+		(logger as unknown as { error: unknown }).error = (_cat: string, msg: string) => {
+			errors.push(msg);
+		};
+		const { fake, heal } = makeFakePlugin({
+			api: { listVaults: mock().mockRejectedValue(new Error("offline")) },
+		});
+
+		try {
+			await heal(err404);
+		} finally {
+			await destroyRemoteLog();
+		}
+
+		expect(errors).toEqual([]);
+		expect(fake.settings.vaultId).toBe("dead-vault-id");
+		expect(fake.healingVault).toBe(false);
 	});
 
 	test("vault still exists server-side → 404 was about something else, no heal", async () => {

--- a/tests/main-oauth-token-rebind.test.ts
+++ b/tests/main-oauth-token-rebind.test.ts
@@ -50,6 +50,9 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 				order.push("saveSettings");
 			},
 			syncEngine: {
+				async resetForVaultChange() {
+					order.push("resetForVaultChange");
+				},
 				bumpAuthGeneration() {
 					order.push("bumpAuthGeneration");
 				},
@@ -118,6 +121,9 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 				order.push("saveSettings");
 			},
 			syncEngine: {
+				async resetForVaultChange() {
+					order.push("resetForVaultChange");
+				},
 				bumpAuthGeneration() {
 					order.push("bumpAuthGeneration");
 				},
@@ -174,6 +180,7 @@ describe("provider swaps dispose the outgoing OAuthAuth (#420)", () => {
 			async saveSettings() {},
 			syncEngine: {
 				bumpAuthGeneration() {},
+				async resetForVaultChange() {},
 				getLastSync() {
 					return 0;
 				},
@@ -256,7 +263,7 @@ describe("swap-site hardening round 2 (#420 review)", () => {
 			api: { setAuthProvider(_p: unknown) {} },
 			noteStream: null,
 			async saveSettings() {},
-			syncEngine: { bumpAuthGeneration() {} },
+			syncEngine: { bumpAuthGeneration() {}, async resetForVaultChange() {} },
 		});
 
 		void old.getToken();
@@ -291,7 +298,7 @@ describe("swap-site hardening round 2 (#420 review)", () => {
 			},
 			noteStream: null,
 			async saveSettings() {},
-			syncEngine: { bumpAuthGeneration() {} },
+			syncEngine: { bumpAuthGeneration() {}, async resetForVaultChange() {} },
 		});
 
 		await EngramSyncPlugin.prototype.clearOAuthTokens.call(fake as never);

--- a/tests/main-oauth-token-rebind.test.ts
+++ b/tests/main-oauth-token-rebind.test.ts
@@ -29,6 +29,7 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 				return newProvider;
 			},
 			api: {
+				setVaultId(_v: unknown) {},
 				setAuthProvider(p: unknown) {
 					order.push(
 						p === newProvider ? "api.setAuthProvider:new" : "api.setAuthProvider:other",
@@ -102,6 +103,7 @@ describe("saveOAuthTokens auth-provider ordering", () => {
 				authMethod: "oauth",
 			} as Record<string, unknown>,
 			api: {
+				setVaultId(_v: unknown) {},
 				setAuthProvider(_p: unknown) {
 					order.push("api.setAuthProvider");
 				},
@@ -167,6 +169,7 @@ describe("provider swaps dispose the outgoing OAuthAuth (#420)", () => {
 				return { tag: "new-provider" };
 			},
 			api: {
+				setVaultId(_v: unknown) {},
 				setAuthProvider(_p: unknown) {},
 				getMe() {
 					return Promise.resolve({ id: "u" });
@@ -260,7 +263,7 @@ describe("swap-site hardening round 2 (#420 review)", () => {
 			createAuthProvider() {
 				return null;
 			},
-			api: { setAuthProvider(_p: unknown) {} },
+			api: { setAuthProvider(_p: unknown) {}, setVaultId(_v: unknown) {} },
 			noteStream: null,
 			async saveSettings() {},
 			syncEngine: { bumpAuthGeneration() {}, async resetForVaultChange() {} },
@@ -292,6 +295,7 @@ describe("swap-site hardening round 2 (#420 review)", () => {
 			settings: {} as Record<string, unknown>,
 			authProvider: old,
 			api: {
+				setVaultId(_v: unknown) {},
 				setAuthProvider(p: unknown) {
 					wired.push(p);
 				},

--- a/tests/main-register-vault-identity-wipe.test.ts
+++ b/tests/main-register-vault-identity-wipe.test.ts
@@ -103,3 +103,50 @@ describe("registerVault identity wipe (#1409)", () => {
 		expect(order).toEqual(["wipe", "save"]);
 	});
 });
+
+/**
+ * The persisted `noteIds` cache is per-VAULT identity. It used to be seeded
+ * unconditionally on load, so a plugin reload after a vault change resurrected
+ * the previous vault's path -> note_id entries — outliving every in-session
+ * wipe, because those run against memory and not data.json. That is the route
+ * the register-time wipe above does NOT cover: `registerVault` early-returns
+ * when `settings.vaultId` is already set, which is the case on every reload.
+ */
+describe("noteIds cache is vault-scoped (#1409 root cause)", () => {
+	function seedWith(data: Record<string, unknown>, activeVault: string | null) {
+		const seeded: Array<Record<string, string> | undefined> = [];
+		const fake = {
+			settings: { vaultId: activeVault },
+			noteIdMap: { seed: (ids: Record<string, string> | undefined) => seeded.push(ids) },
+		};
+		// Mirrors the load-time gate in main.ts.
+		const cached = (data as { noteIdsVaultId?: string | null }).noteIdsVaultId;
+		const active = fake.settings.vaultId ?? null;
+		if (cached !== undefined && cached !== null && active !== null && cached !== active) {
+			// refused
+		} else {
+			fake.noteIdMap.seed((data as { noteIds?: Record<string, string> }).noteIds);
+		}
+		return seeded;
+	}
+
+	const IDS = { "Notes/a.md": "id-from-old-vault" };
+
+	test("REFUSES a cache recorded under a different vault", () => {
+		expect(seedWith({ noteIds: IDS, noteIdsVaultId: "old-vault" }, "new-vault")).toEqual([]);
+	});
+
+	test("accepts a cache recorded under the SAME vault", () => {
+		expect(seedWith({ noteIds: IDS, noteIdsVaultId: "same-vault" }, "same-vault")).toEqual([
+			IDS,
+		]);
+	});
+
+	test("adopts a pre-upgrade cache with no recorded vault (no needless re-mint)", () => {
+		expect(seedWith({ noteIds: IDS }, "any-vault")).toEqual([IDS]);
+	});
+
+	test("accepts when there is no active vault yet (first run, nothing to conflict with)", () => {
+		expect(seedWith({ noteIds: IDS, noteIdsVaultId: "old-vault" }, null)).toEqual([IDS]);
+	});
+});

--- a/tests/main-register-vault-identity-wipe.test.ts
+++ b/tests/main-register-vault-identity-wipe.test.ts
@@ -105,48 +105,115 @@ describe("registerVault identity wipe (#1409)", () => {
 });
 
 /**
- * The persisted `noteIds` cache is per-VAULT identity. It used to be seeded
- * unconditionally on load, so a plugin reload after a vault change resurrected
- * the previous vault's path -> note_id entries — outliving every in-session
- * wipe, because those run against memory and not data.json. That is the route
- * the register-time wipe above does NOT cover: `registerVault` early-returns
- * when `settings.vaultId` is already set, which is the case on every reload.
+ * The persisted `noteIds` cache is per-VAULT identity, and its stamp is the
+ * fix's actual root-cause half.
+ *
+ * An earlier revision of this block RE-IMPLEMENTED the load-time gate inside
+ * the test file (`// Mirrors the load-time gate in main.ts`) and asserted
+ * against its own copy. It imported nothing and executed no production code, so
+ * all four of its tests passed unchanged with the real gate deleted AND with
+ * the stamp deleted — the two mutations a reviewer ran to prove it. It carried
+ * the label "#1409 root cause" while covering none of it.
+ *
+ * These drive the real methods.
  */
 describe("noteIds cache is vault-scoped (#1409 root cause)", () => {
-	function seedWith(data: Record<string, unknown>, activeVault: string | null) {
+	const IDS = { "Notes/a.md": "id-from-old-vault" };
+
+	/** Run the REAL load-time gate by calling loadSettings on a fake `this`. */
+	function loadWith(data: Record<string, unknown>, activeVault: string | null) {
 		const seeded: Array<Record<string, string> | undefined> = [];
 		const fake = {
 			settings: { vaultId: activeVault },
-			noteIdMap: { seed: (ids: Record<string, string> | undefined) => seeded.push(ids) },
-		};
-		// Mirrors the load-time gate in main.ts.
-		const cached = (data as { noteIdsVaultId?: string | null }).noteIdsVaultId;
-		const active = fake.settings.vaultId ?? null;
-		if (cached !== undefined && cached !== null && active !== null && cached !== active) {
-			// refused
-		} else {
-			fake.noteIdMap.seed((data as { noteIds?: Record<string, string> }).noteIds);
-		}
-		return seeded;
+			noteIdMap: {
+				seed: (ids: Record<string, string> | undefined) => seeded.push(ids),
+				toJSON: () => ({}),
+			},
+			loadPluginData: mock().mockResolvedValue(data),
+			writePluginData: mock().mockResolvedValue(undefined),
+			app: { vault: { getName: () => "V" } },
+		} as Record<string, unknown>;
+
+		const load = (EngramSyncPlugin.prototype as any).loadSettings as (
+			this: unknown,
+		) => Promise<void>;
+		return { fake, seeded, run: () => load.call(fake) };
 	}
 
-	const IDS = { "Notes/a.md": "id-from-old-vault" };
-
-	test("REFUSES a cache recorded under a different vault", () => {
-		expect(seedWith({ noteIds: IDS, noteIdsVaultId: "old-vault" }, "new-vault")).toEqual([]);
+	test("REFUSES a cache whose recorded provenance is a different vault", async () => {
+		const { seeded, run } = loadWith(
+			{ noteIds: IDS, noteIdsVaultId: "old-vault", settings: { vaultId: "new-vault" } },
+			"new-vault",
+		);
+		await run();
+		expect(seeded).toEqual([]);
 	});
 
-	test("accepts a cache recorded under the SAME vault", () => {
-		expect(seedWith({ noteIds: IDS, noteIdsVaultId: "same-vault" }, "same-vault")).toEqual([
-			IDS,
-		]);
+	test("accepts a cache recorded under the SAME vault", async () => {
+		const { seeded, run } = loadWith(
+			{ noteIds: IDS, noteIdsVaultId: "same-vault", settings: { vaultId: "same-vault" } },
+			"same-vault",
+		);
+		await run();
+		expect(seeded).toEqual([IDS]);
 	});
 
-	test("adopts a pre-upgrade cache with no recorded vault (no needless re-mint)", () => {
-		expect(seedWith({ noteIds: IDS }, "any-vault")).toEqual([IDS]);
+	test("adopts a pre-upgrade cache with no recorded vault (no needless re-mint)", async () => {
+		const { seeded, run } = loadWith(
+			{ noteIds: IDS, settings: { vaultId: "any-vault" } },
+			"any-vault",
+		);
+		await run();
+		expect(seeded).toEqual([IDS]);
+	});
+});
+
+/**
+ * The stamp that feeds the gate. It must record the map's PROVENANCE, not
+ * whichever vault happened to be active when the file was written — reading it
+ * from `settings.vaultId` at save time made the gate essentially unfireable,
+ * because ~10 fire-and-forget saves would restamp a stale map with the new
+ * vault before any reload.
+ */
+describe("noteIdsVaultId records provenance, not the active vault", () => {
+	function saveWith(owner: string | null, activeVault: string | null) {
+		let written: Record<string, unknown> | undefined;
+		const fake = {
+			settings: { vaultId: activeVault },
+			noteIdsOwner: owner,
+			noteIdMap: { toJSON: () => ({ "Notes/a.md": "id-1" }) },
+			syncGateAcceptedFor: null,
+			syncEngine: {
+				exportSyncState: () => ({}),
+				exportHashes: () => ({}),
+				getCatchupSeq: () => 0,
+				getCatchupId: () => null,
+				getManifestSeq: () => 0,
+				getSyncStateVaultId: () => null,
+				queue: { persistable: () => [] },
+				issues: { serialize: () => [] },
+				ignoredFiles: { serialize: () => [] },
+			},
+			writePluginData: async (d: Record<string, unknown>) => {
+				written = d;
+			},
+		} as Record<string, unknown>;
+
+		const save = (EngramSyncPlugin.prototype as any).savePluginData as (
+			this: unknown,
+		) => Promise<void>;
+		return { run: async () => (await save.call(fake), written) };
+	}
+
+	test("stamps the OWNER even when a different vault is already active", async () => {
+		// THE regression. The map still holds vault-A ids; `settings.vaultId` has
+		// already moved to B. Stamping B would make the gate accept A's map.
+		const written = await saveWith("vault-A", "vault-B").run();
+		expect(written?.noteIdsVaultId).toBe("vault-A");
 	});
 
-	test("accepts when there is no active vault yet (first run, nothing to conflict with)", () => {
-		expect(seedWith({ noteIds: IDS, noteIdsVaultId: "old-vault" }, null)).toEqual([IDS]);
+	test("stamps the active vault once the map has been re-owned", async () => {
+		const written = await saveWith("vault-B", "vault-B").run();
+		expect(written?.noteIdsVaultId).toBe("vault-B");
 	});
 });

--- a/tests/main-register-vault-identity-wipe.test.ts
+++ b/tests/main-register-vault-identity-wipe.test.ts
@@ -20,9 +20,15 @@ import { describe, expect, mock, test } from "bun:test";
 import EngramSyncPlugin from "../src/main";
 
 function makeFakePlugin(noteIds: Record<string, string>, over: Record<string, unknown> = {}) {
-	const fake = {
+	// Prototype-backed: registerVault delegates the transition to the real
+	// `discardVaultScopedState`, and a bare literal `this` would leave that
+	// undefined — the throw lands in registerVault's own catch and the suite
+	// goes green against a registration that wipes nothing.
+	const fake = Object.assign(Object.create(EngramSyncPlugin.prototype), {
 		// Falsy vaultId is what sends registerVault down the register-fresh leg.
 		settings: { vaultId: null, clientId: "client-1", remoteVaultName: undefined },
+		syncGateAcceptedFor: "stale-fingerprint",
+		lastMapReconcileAt: 999,
 		app: { vault: { getName: () => "My Vault" } },
 		api: {
 			registerVault: mock().mockResolvedValue({
@@ -36,7 +42,7 @@ function makeFakePlugin(noteIds: Record<string, string>, over: Record<string, un
 		syncEngine: { resetForVaultChange: mock().mockResolvedValue(undefined) },
 		saveSettings: mock().mockResolvedValue(undefined),
 		...over,
-	};
+	});
 	const register = (EngramSyncPlugin.prototype as any).registerVault as (
 		this: unknown,
 	) => Promise<boolean>;
@@ -55,16 +61,31 @@ describe("registerVault identity wipe (#1409)", () => {
 		// THE assertion: the stale map must not survive into the new vault.
 		expect(fake.syncEngine.resetForVaultChange as any).toHaveBeenCalled();
 		expect(fake.settings.vaultId).toBe("new-vault-id");
+		// ...and the WHOLE transition, not just the map. This ran one of the
+		// five steps on its own for months. The gate fingerprint covers (auth +
+		// vault), so leaving it set makes the new vault inherit the old one's
+		// consent instead of re-prompting.
+		expect(fake.syncGateAcceptedFor).toBeNull();
+		expect(fake.lastMapReconcileAt).toBe(0);
+		expect((fake.api.setVaultId as any).mock.calls.at(-1)?.[0]).toBe("new-vault-id");
 	});
 
-	test("first-ever install (empty map) is a silent no-op — no wipe", async () => {
-		// The wipe also clears lastSync/cursors; doing that on a fresh install
-		// would look like a bug and would re-scan for nothing.
+	test("an empty map does NOT prove empty cursors — wipe anyway, just quietly", async () => {
+		// This used to assert the opposite, on the reasoning that a fresh
+		// install has nothing to wipe. The reasoning skipped a step: the map is
+		// only one of the things `resetForVaultChange` clears. `onVaultDeleted`
+		// empties the map WITHOUT touching lastSync or the catch-up cursor, so
+		// registering after it hit this branch and inherited a watermark from a
+		// different vault — the first catch-up then resumed from a seq that
+		// means nothing here and skipped every note below it.
+		//
+		// On a genuine first install the wipe is a no-op, so gating it bought
+		// nothing. What the guard is still good for is the LOG.
 		const { fake, register } = makeFakePlugin({});
 
 		expect(await register()).toBe(true);
 
-		expect(fake.syncEngine.resetForVaultChange as any).not.toHaveBeenCalled();
+		expect(fake.syncEngine.resetForVaultChange as any).toHaveBeenCalled();
 		expect(fake.settings.vaultId).toBe("new-vault-id");
 	});
 

--- a/tests/main-register-vault-identity-wipe.test.ts
+++ b/tests/main-register-vault-identity-wipe.test.ts
@@ -202,7 +202,12 @@ describe("noteIdsVaultId records provenance, not the active vault", () => {
 		const save = (EngramSyncPlugin.prototype as any).savePluginData as (
 			this: unknown,
 		) => Promise<void>;
-		return { run: async () => (await save.call(fake), written) };
+		return {
+			run: async () => {
+				await save.call(fake);
+				return written;
+			},
+		};
 	}
 
 	test("stamps the OWNER even when a different vault is already active", async () => {

--- a/tests/main-register-vault-identity-wipe.test.ts
+++ b/tests/main-register-vault-identity-wipe.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests: registerVault must not carry a PREVIOUS vault's path -> note_id map
+ * into a vault it just registered (#1409 root cause).
+ *
+ * Two live paths null `settings.vaultId` without touching identity state — the
+ * 404 dead-vault heal and `onVaultDeleted` — and neither runs
+ * `resetForVaultChange`. registerVault then binds the install to a brand-new
+ * server vault while the map still describes the old one, so `crdt_create`
+ * proposes foreign-vault ids. The server cannot reuse them (the #1318 collision
+ * class), answers with fresh ones, `serverId !== noteId` fails the seeded fast
+ * path, and the fallback broadcasts a sync_update that opens a room PER NOTE.
+ *
+ * Measured on a real 423-item import before this fix: 225 rooms for 317 notes,
+ * every one source=edit, ZERO crdt_update_log rows — all redundant, the
+ * roomless genesis seed had already stored the state.
+ *
+ * Same Function.call-on-a-fake-`this` idiom as main-heal-dead-vault.test.ts.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import EngramSyncPlugin from "../src/main";
+
+function makeFakePlugin(noteIds: Record<string, string>, over: Record<string, unknown> = {}) {
+	const fake = {
+		// Falsy vaultId is what sends registerVault down the register-fresh leg.
+		settings: { vaultId: null, clientId: "client-1", remoteVaultName: undefined },
+		app: { vault: { getName: () => "My Vault" } },
+		api: {
+			registerVault: mock().mockResolvedValue({
+				id: "new-vault-id",
+				name: "My Vault",
+				slug: "my-vault",
+			}),
+			setVaultId: mock(),
+		},
+		noteIdMap: { toJSON: () => noteIds },
+		syncEngine: { resetForVaultChange: mock().mockResolvedValue(undefined) },
+		saveSettings: mock().mockResolvedValue(undefined),
+		...over,
+	};
+	const register = (EngramSyncPlugin.prototype as any).registerVault as (
+		this: unknown,
+	) => Promise<boolean>;
+	return { fake, register: () => register.call(fake) };
+}
+
+describe("registerVault identity wipe (#1409)", () => {
+	test("wipes per-vault identity state when a map from a PREVIOUS vault is still held", async () => {
+		const { fake, register } = makeFakePlugin({
+			"Notes/a.md": "id-from-old-vault",
+			"Notes/b.md": "another-old-id",
+		});
+
+		expect(await register()).toBe(true);
+
+		// THE assertion: the stale map must not survive into the new vault.
+		expect(fake.syncEngine.resetForVaultChange as any).toHaveBeenCalled();
+		expect(fake.settings.vaultId).toBe("new-vault-id");
+	});
+
+	test("first-ever install (empty map) is a silent no-op — no wipe", async () => {
+		// The wipe also clears lastSync/cursors; doing that on a fresh install
+		// would look like a bug and would re-scan for nothing.
+		const { fake, register } = makeFakePlugin({});
+
+		expect(await register()).toBe(true);
+
+		expect(fake.syncEngine.resetForVaultChange as any).not.toHaveBeenCalled();
+		expect(fake.settings.vaultId).toBe("new-vault-id");
+	});
+
+	test("already-bound vault short-circuits before any of this", async () => {
+		const { fake, register } = makeFakePlugin(
+			{ "Notes/a.md": "id-1" },
+			{ settings: { vaultId: "existing-vault", clientId: "c", remoteVaultName: "X" } },
+		);
+
+		expect(await register()).toBe(true);
+
+		// No registration, and emphatically no wipe of a map that is CORRECT
+		// for the vault we are already on.
+		expect(fake.api.registerVault as any).not.toHaveBeenCalled();
+		expect(fake.syncEngine.resetForVaultChange as any).not.toHaveBeenCalled();
+	});
+
+	test("wipe happens BEFORE saveSettings, so a crash cannot persist the new vault beside the stale map", async () => {
+		const order: string[] = [];
+		const { register } = makeFakePlugin(
+			{ "Notes/a.md": "id-from-old-vault" },
+			{
+				syncEngine: {
+					resetForVaultChange: mock(async () => {
+						order.push("wipe");
+					}),
+				},
+				saveSettings: mock(async () => {
+					order.push("save");
+				}),
+			},
+		);
+
+		await register();
+
+		expect(order).toEqual(["wipe", "save"]);
+	});
+});

--- a/tests/main-switch-vault-transition.test.ts
+++ b/tests/main-switch-vault-transition.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests: `switchVault` — the vault-change entry point the sync-preview picker
+ * uses — performs the WHOLE transition, by delegating it.
+ *
+ * There were two implementations of this transition and they agreed on one of
+ * eight steps (#1409). The fix was not "add the missing seven to both": it was
+ * to make `discardVaultScopedState` the single owner and have every entry point
+ * call it. `switchVault` was the last one still spelling out its own copy, and
+ * a duplicated list is exactly how the drift started.
+ *
+ * The existing coverage in self-hosted-tab.test.ts asserts `applyVaultSwitch`
+ * CALLS `switchVault` — against a mocked `switchVault`. That is the right test
+ * for that seam and says nothing about this one, which is why the body went
+ * unpinned while it was wrong.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import EngramSyncPlugin from "../src/main";
+
+function makeFakePlugin(over: Record<string, unknown> = {}) {
+	// Prototype-backed: `switchVault` delegates to the real
+	// `discardVaultScopedState`, and a bare literal `this` leaves that undefined.
+	return Object.assign(Object.create(EngramSyncPlugin.prototype), {
+		settings: { vaultId: "old-vault", remoteVaultName: "Old" },
+		syncGateAcceptedFor: "fingerprint-for-the-old-vault",
+		lastMapReconcileAt: 12_345,
+		api: { setVaultId: mock() },
+		syncEngine: {
+			updateSettings: mock(),
+			resetForVaultChange: mock().mockResolvedValue(undefined),
+			setSyncBlocked: mock(),
+		},
+		crdtWiring: { clearStrandHealAttempts: mock() },
+		...over,
+	});
+}
+
+describe("switchVault performs the whole vault transition", () => {
+	test("every step runs, not just the id", async () => {
+		const fake = makeFakePlugin();
+
+		await (fake as { switchVault(id: string, name?: string): Promise<void> }).switchVault(
+			"new-vault",
+			"New",
+		);
+
+		expect(fake.settings.vaultId).toBe("new-vault");
+		expect(fake.settings.remoteVaultName).toBe("New");
+		// Per-file hashes, lastSync, cursors and the note-id map: note_ids are
+		// unique only WITHIN a vault, so carrying the map over makes `crdt_create`
+		// propose the old vault's ids (the #1318 collision class).
+		expect(fake.syncEngine.resetForVaultChange).toHaveBeenCalled();
+		// EngramApi keeps its OWN copy of the id and stamps it on every request.
+		expect(fake.api.setVaultId).toHaveBeenCalledWith("new-vault");
+		// The accepted-gate fingerprint covers (auth + vault) — a new vault must
+		// re-prompt rather than inherit the old vault's consent.
+		expect(fake.syncGateAcceptedFor).toBeNull();
+		// Re-reconcile on next connect; this is a real swap, not a storm.
+		expect(fake.lastMapReconcileAt).toBe(0);
+		// Strand-heal retry counts are keyed by the PREVIOUS vault's note_ids.
+		expect(fake.crdtWiring.clearStrandHealAttempts).toHaveBeenCalled();
+		expect(fake.syncEngine.setSyncBlocked).toHaveBeenCalledWith(true);
+	});
+
+	test("an omitted name leaves the previous remote name alone", async () => {
+		// The picker passes a name; the Connection-page dropdown does not. An
+		// undefined name must not blank the stored one.
+		const fake = makeFakePlugin();
+
+		await (fake as { switchVault(id: string, name?: string): Promise<void> }).switchVault(
+			"new-vault",
+		);
+
+		expect(fake.settings.remoteVaultName).toBe("Old");
+		expect(fake.settings.vaultId).toBe("new-vault");
+	});
+
+	test("the sync gate is blocked AFTER the wipe, never before it", async () => {
+		// Ordering matters: blocking first and wiping second leaves a window
+		// where the gate is shut but the old vault's map is still live, and a
+		// reconnect in that window re-proposes foreign ids.
+		const order: string[] = [];
+		const fake = makeFakePlugin({
+			syncEngine: {
+				updateSettings: mock(),
+				resetForVaultChange: mock(async () => {
+					order.push("wipe");
+				}),
+				setSyncBlocked: mock(() => {
+					order.push("block");
+				}),
+			},
+		});
+
+		await (fake as { switchVault(id: string): Promise<void> }).switchVault("new-vault");
+
+		expect(order).toEqual(["wipe", "block"]);
+	});
+});

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -36,14 +36,19 @@ describe("renderEngramUrlSetting", () => {
 function makePlugin(initial: string | null): VaultSwitchTarget & {
 	api: { setVaultId: ReturnType<typeof mock> };
 	saveSettings: ReturnType<typeof mock>;
-	syncEngine: { resetForVaultChange: ReturnType<typeof mock> };
+	switchVault: ReturnType<typeof mock>;
 } {
-	return {
-		settings: { vaultId: initial },
+	const target = {
+		settings: { vaultId: initial } as { vaultId: string | null; remoteVaultName?: string },
 		api: { setVaultId: mock(() => {}) },
 		saveSettings: mock(async () => {}),
-		syncEngine: { resetForVaultChange: mock(async () => {}) },
+		switchVault: mock(async (id: string, name?: string) => {
+			target.settings.vaultId = id;
+			if (name !== undefined) target.settings.remoteVaultName = name;
+			target.api.setVaultId(id);
+		}),
 	};
+	return target;
 }
 
 describe("applyVaultSwitch", () => {
@@ -78,14 +83,17 @@ describe("applyVaultSwitch", () => {
 		expect(plugin.settings.vaultId).toBe("1");
 	});
 
-	test("setVaultId runs before saveSettings", async () => {
+	// Was "setVaultId runs before saveSettings". The api.setVaultId call moved
+	// INTO the shared `switchVault` transition (#1409 consolidation), so the
+	// ordering invariant is now asserted at that seam: the whole state
+	// transition must complete before anything is persisted, or a crash could
+	// leave the new vault id on disk beside the old vault's bookkeeping.
+	test("switchVault runs before saveSettings", async () => {
 		const order: string[] = [];
 		const plugin: VaultSwitchTarget = {
 			settings: { vaultId: "3" },
-			api: {
-				setVaultId: () => {
-					order.push("setVaultId");
-				},
+			switchVault: async () => {
+				order.push("switchVault");
 			},
 			saveSettings: async () => {
 				order.push("saveSettings");
@@ -94,7 +102,7 @@ describe("applyVaultSwitch", () => {
 
 		await applyVaultSwitch(plugin, "9");
 
-		expect(order).toEqual(["setVaultId", "saveSettings"]);
+		expect(order).toEqual(["switchVault", "saveSettings"]);
 	});
 });
 
@@ -312,13 +320,13 @@ describe("applyVaultSwitch resets per-vault state (#1409)", () => {
 	test("wipes per-vault bookkeeping on a real switch", async () => {
 		const plugin = makePlugin("old-vault");
 		await applyVaultSwitch(plugin, "new-vault");
-		expect(plugin.syncEngine.resetForVaultChange).toHaveBeenCalledTimes(1);
+		expect(plugin.switchVault).toHaveBeenCalledTimes(1);
 	});
 
 	test("resets BEFORE saveSettings — never persist a new vault id beside stale state", async () => {
 		const order: string[] = [];
 		const plugin = makePlugin("old-vault");
-		plugin.syncEngine.resetForVaultChange = mock(async () => {
+		plugin.switchVault = mock(async () => {
 			order.push("reset");
 		});
 		plugin.saveSettings = mock(async () => {
@@ -331,6 +339,6 @@ describe("applyVaultSwitch resets per-vault state (#1409)", () => {
 	test("no-op switch does NOT reset (selecting the vault you are already on)", async () => {
 		const plugin = makePlugin("same");
 		await applyVaultSwitch(plugin, "same");
-		expect(plugin.syncEngine.resetForVaultChange).not.toHaveBeenCalled();
+		expect(plugin.switchVault).not.toHaveBeenCalled();
 	});
 });

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -38,6 +38,12 @@ function makePlugin(initial: string | null): VaultSwitchTarget & {
 	saveSettings: ReturnType<typeof mock>;
 	switchVault: ReturnType<typeof mock>;
 } {
+	// The fake's `switchVault` mirrors the real one's observable effects so the
+	// no-op guard below has real state to guard against. It is NOT evidence:
+	// asserting `api.setVaultId` here would only re-read this script. What that
+	// method actually does is pinned in main-switch-vault-transition.test.ts;
+	// what belongs HERE is `applyVaultSwitch`'s own contract — whether, when and
+	// with what it delegates.
 	const target = {
 		settings: { vaultId: initial } as { vaultId: string | null; remoteVaultName?: string },
 		api: { setVaultId: mock(() => {}) },
@@ -56,7 +62,7 @@ describe("applyVaultSwitch", () => {
 		const plugin = makePlugin("3");
 		const changed = await applyVaultSwitch(plugin, "");
 		expect(changed).toBe(false);
-		expect(plugin.api.setVaultId).not.toHaveBeenCalled();
+		expect(plugin.switchVault).not.toHaveBeenCalled();
 	});
 
 	test("ignores no-op value (selecting the already-active vault)", async () => {
@@ -71,8 +77,9 @@ describe("applyVaultSwitch", () => {
 		const changed = await applyVaultSwitch(plugin, "9");
 
 		expect(changed).toBe(true);
-		expect(plugin.settings.vaultId).toBe("9");
-		expect(plugin.api.setVaultId).toHaveBeenCalledWith("9");
+		// The delegation contract, not the fake's own script: the id and the
+		// (absent) name are forwarded verbatim, and persistence follows.
+		expect(plugin.switchVault).toHaveBeenCalledWith("9", undefined);
 		expect(plugin.saveSettings).toHaveBeenCalledTimes(1);
 	});
 

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -36,11 +36,13 @@ describe("renderEngramUrlSetting", () => {
 function makePlugin(initial: string | null): VaultSwitchTarget & {
 	api: { setVaultId: ReturnType<typeof mock> };
 	saveSettings: ReturnType<typeof mock>;
+	syncEngine: { resetForVaultChange: ReturnType<typeof mock> };
 } {
 	return {
 		settings: { vaultId: initial },
 		api: { setVaultId: mock(() => {}) },
 		saveSettings: mock(async () => {}),
+		syncEngine: { resetForVaultChange: mock(async () => {}) },
 	};
 }
 
@@ -299,5 +301,36 @@ describe("renderAuthSection — signed in", () => {
 	test("still offers sign out", () => {
 		renderSignedIn("https://api.engram.page");
 		expect(__settingCapture.buttons.some((b) => b.text === "Sign out")).toBe(true);
+	});
+});
+
+// #1409 root cause: this path changed the active vault while leaving the
+// PREVIOUS vault's path -> note_id map live, so crdt_create proposed
+// foreign-vault ids and the server's re-id cost a room per note. main.ts's
+// picker always reset; only this selfhost path did not.
+describe("applyVaultSwitch resets per-vault state (#1409)", () => {
+	test("wipes per-vault bookkeeping on a real switch", async () => {
+		const plugin = makePlugin("old-vault");
+		await applyVaultSwitch(plugin, "new-vault");
+		expect(plugin.syncEngine.resetForVaultChange).toHaveBeenCalledTimes(1);
+	});
+
+	test("resets BEFORE saveSettings — never persist a new vault id beside stale state", async () => {
+		const order: string[] = [];
+		const plugin = makePlugin("old-vault");
+		plugin.syncEngine.resetForVaultChange = mock(async () => {
+			order.push("reset");
+		});
+		plugin.saveSettings = mock(async () => {
+			order.push("save");
+		});
+		await applyVaultSwitch(plugin, "new-vault");
+		expect(order).toEqual(["reset", "save"]);
+	});
+
+	test("no-op switch does NOT reset (selecting the vault you are already on)", async () => {
+		const plugin = makePlugin("same");
+		await applyVaultSwitch(plugin, "same");
+		expect(plugin.syncEngine.resetForVaultChange).not.toHaveBeenCalled();
 	});
 });

--- a/tests/self-hosted-tab.test.ts
+++ b/tests/self-hosted-tab.test.ts
@@ -177,6 +177,7 @@ describe("renderEngramUrlSetting — no Save button", () => {
 			api: { setAuthProvider: () => {} },
 			noteStream: { disconnect: () => {} },
 			resetAuthProvider: () => {},
+			discardVaultScopedState: async () => {},
 			saveSettings: async () => {},
 		};
 		const ctx: any = { containerEl: {}, app: {}, plugin, redisplay: () => {} };
@@ -222,6 +223,7 @@ describe("renderEngramUrlSetting — no Save button", () => {
 			api: { setAuthProvider: () => {} },
 			noteStream: { disconnect: () => {} },
 			resetAuthProvider: () => {},
+			discardVaultScopedState: async () => {},
 			saveSettings: async () => {
 				saved.push(plugin.settings.apiUrl);
 			},

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -124,6 +124,9 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		});
 		const closeDoc = mock();
 		engine.setCrdtManager({
+			// The real registry always answers this; the room-free read is only
+			// legal when it is false, because that frame cannot carry local ops up.
+			hasUndeliveredOps: () => false,
 			applyLocalEdit: mock().mockImplementation(async (_id: string, c: string) => c),
 			applyRemoteUpdate,
 			encodeStateVector,
@@ -234,6 +237,9 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 	test("no note_id (legacy /notes/changes path): falls back to the content-snapshot backfill unchanged", async () => {
 		const engine = createEngine();
 		engine.setCrdtManager({
+			// The real registry always answers this; the room-free read is only
+			// legal when it is false, because that frame cannot carry local ops up.
+			hasUndeliveredOps: () => false,
 			applyLocalEdit: mock().mockImplementation(async (_id: string, c: string) => c),
 			applyRemoteUpdate: mock().mockResolvedValue(undefined),
 			encodeStateVector: mock().mockResolvedValue(new Uint8Array([0])),

--- a/tests/sync-crdt-route.test.ts
+++ b/tests/sync-crdt-route.test.ts
@@ -1521,3 +1521,41 @@ describe("genesis echo-cooldown window (repo-review 2026-08)", () => {
 		expect(files.has("Notes/brand-new.md", "pushed")).toBe(true);
 	});
 });
+
+describe("the debounce window is not a hole in the sync gate (#1409 review)", () => {
+	test("a gate that closes mid-window drops the armed push", async () => {
+		// `handleModify` checks the gate when it ARMS the timer; nothing checked
+		// it when the timer FIRED, and `pushFile` has no gate of its own. So an
+		// edit made just before a vault switch was delivered into whichever vault
+		// was active ~2s later — a vault the user had not consented to sync yet.
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("note.md", "id-note");
+		const engine = createEngine(noteIdMap);
+		const applyLocalEdit = mock(async (_id: string, c: string) => c);
+		engine.setCrdtManager({ applyLocalEdit } as any);
+		markConfirmed(engine, "id-note");
+
+		engine.handleModify(new TFile("note.md"));
+		// The switch lands inside the debounce window.
+		engine.setSyncBlocked(true);
+		await flush();
+
+		expect(applyLocalEdit).not.toHaveBeenCalled();
+		// The edit is not lost: disk still disagrees with the recorded baseline,
+		// so the full sync that runs when the gate reopens picks it up.
+	});
+
+	test("an open gate still delivers it", async () => {
+		const noteIdMap = new NoteIdMap();
+		noteIdMap.set("note.md", "id-note");
+		const engine = createEngine(noteIdMap);
+		const applyLocalEdit = mock(async (_id: string, c: string) => c);
+		engine.setCrdtManager({ applyLocalEdit } as any);
+		markConfirmed(engine, "id-note");
+
+		engine.handleModify(new TFile("note.md"));
+		await flush();
+
+		expect(applyLocalEdit).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -1235,10 +1235,43 @@ describe("convergeColdNoteRoomFree (#1409 — cold notes converge without a room
 			},
 			markSynced: (id: string) => void engine.commitCrdtConvergence(id),
 			closeDoc: () => {},
+			// The real registry always answers this; the room-free read is only
+			// legal when it is false (the frame cannot carry local ops upward).
+			hasUndeliveredOps: () => false,
 		} as unknown as Partial<CrdtManager>);
 		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
 		return engine;
 	}
+
+	test("a note with UNDELIVERED local ops takes the room, not the read", async () => {
+		// `crdt_doc_state` is a READ. The handshake it replaces is bidirectional
+		// — the server answers syncStep1 with [syncStep2, syncStep1] and the
+		// client's reply to that second step1 IS the upload half.
+		//
+		// So taking this path with undelivered local ops downloads, marks the
+		// note synced, and never transmits them: complete on this device, blank
+		// on every other, and stamped in-sync so every later catch-up compares
+		// equal hashes and skips it. Permanently, with no error anywhere.
+		const applied: Array<[string, Uint8Array]> = [];
+		const engine = coldEngine(applied);
+		const docState = mock().mockResolvedValue({ b64: "AQID", head: "h" });
+		engine.setCrdtPorts({ docState });
+		(engine as any).crdt.hasUndeliveredOps = () => true;
+		const converge = spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		await (engine as any).convergeColdNoteRoomFree(
+			"id-a",
+			"Notes/a.md",
+			CHANGE,
+			"server body",
+			"H2",
+		);
+
+		// The read is never even attempted, and the bidirectional path runs.
+		expect(docState).not.toHaveBeenCalled();
+		expect(applied).toEqual([]);
+		expect(converge).toHaveBeenCalledTimes(1);
+	});
 
 	test("applies the room-free state and never fires the room handshake", async () => {
 		const applied: Array<[string, Uint8Array]> = [];

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -74,7 +74,14 @@ function makeEngineWithCrdt(crdt: Partial<CrdtManager>): SyncEngine {
 		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
 		mock().mockResolvedValue(undefined),
 	);
-	e.setCrdtManager(crdt as unknown as CrdtManager);
+	// The real registry always answers `hasUndeliveredOps`; partial doubles do
+	// not. Default it to false (nothing local pending) so existing tests keep
+	// exercising the room-free read, and let a caller override to assert the
+	// opposite. Spread FIRST so an explicit value in `crdt` wins.
+	e.setCrdtManager({
+		hasUndeliveredOps: () => false,
+		...crdt,
+	} as unknown as CrdtManager);
 	e.setReady();
 	const map = new NoteIdMap();
 	map.set("Notes/a.md", "id-a");

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -1205,3 +1205,109 @@ describe("op-log pager — contract shared by replay + enumerate", () => {
 		);
 	});
 });
+
+// #1409: a diverged COLD note (nobody has it open) used to converge via a
+// STEP1 re-handshake, and the backend routes every STEP1 through ensure_room —
+// so a bulk first sync allocated one server room per such note. Attribution on
+// a 250-note import put 100% of the rooms at this one call site. The room-free
+// `crdt_doc_state` read returns the same Yjs state off the persisted snapshot,
+// and applying it is the same monotonic merge STEP2's ops would have been.
+describe("convergeColdNoteRoomFree (#1409 — cold notes converge without a room)", () => {
+	const CHANGE = {
+		id: "id-a",
+		path: "Notes/a.md",
+		content_hash: "H2",
+		version: 2,
+		seq: 7,
+	} as unknown as SyncNoteChange;
+
+	// `markSynced` on the real registry re-enters SyncEngine via the onSynced
+	// port (crdt/wiring.ts), which is what drives commitCrdtConvergence. The
+	// double mirrors that so a test can prove the helper COMMITS, not merely
+	// that it stages — an earlier revision of these tests called
+	// commitCrdtConvergence by hand and would have passed against a version
+	// that never triggered it at all.
+	function coldEngine(applied: Array<[string, Uint8Array]>) {
+		const engine: SyncEngine = makeEngineWithCrdt({
+			applyRemoteUpdate: (id: string, u: Uint8Array) => {
+				applied.push([id, u]);
+				return Promise.resolve();
+			},
+			markSynced: (id: string) => void engine.commitCrdtConvergence(id),
+			closeDoc: () => {},
+		} as unknown as Partial<CrdtManager>);
+		engine.importSyncState({ "Notes/a.md": { hash: 1, serverHash: "H1" } });
+		return engine;
+	}
+
+	test("applies the room-free state and never fires the room handshake", async () => {
+		const applied: Array<[string, Uint8Array]> = [];
+		const engine = coldEngine(applied);
+		const docState = mock().mockResolvedValue({ b64: "AQID", head: "h" });
+		engine.setCrdtPorts({ docState });
+		const converge = spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		await (engine as any).convergeColdNoteRoomFree(
+			"id-a",
+			"Notes/a.md",
+			CHANGE,
+			"server body",
+			"H2",
+		);
+
+		expect(docState).toHaveBeenCalledWith("id-a");
+		expect(applied).toEqual([["id-a", new Uint8Array([1, 2, 3])]]);
+		// THE assertion this whole change exists for.
+		expect(converge).not.toHaveBeenCalled();
+	});
+
+	test("DRIVES the convergence commit — applyRemoteUpdate does not fire onSynced, so an untriggered stage would leave the note diverged forever", async () => {
+		const engine = coldEngine([]);
+		engine.setCrdtPorts({ docState: mock().mockResolvedValue({ b64: "", head: "h" }) });
+		await (engine as any).convergeColdNoteRoomFree(
+			"id-a",
+			"Notes/a.md",
+			CHANGE,
+			"server body",
+			"H2",
+		);
+
+		await Promise.resolve();
+		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H2");
+	});
+
+	test("falls back to the room handshake when the frame fails (old backend, rate limit, dropped socket)", async () => {
+		const engine = coldEngine([]);
+		engine.setCrdtPorts({
+			docState: mock().mockRejectedValue(new Error("unmatched topic")),
+		});
+		const converge = spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		await (engine as any).convergeColdNoteRoomFree(
+			"id-a",
+			"Notes/a.md",
+			CHANGE,
+			"server body",
+			"H2",
+		);
+
+		expect(converge).toHaveBeenCalledTimes(1);
+		expect(converge.mock.calls[0]).toEqual(["Notes/a.md", "id-a"]);
+	});
+
+	test("falls back to the room handshake when the port is unwired entirely", async () => {
+		const engine = coldEngine([]);
+		engine.setCrdtPorts({ docState: null });
+		const converge = spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		await (engine as any).convergeColdNoteRoomFree(
+			"id-a",
+			"Notes/a.md",
+			CHANGE,
+			"server body",
+			"H2",
+		);
+
+		expect(converge).toHaveBeenCalledTimes(1);
+	});
+});

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -107,7 +107,7 @@ describe("discoverAnnouncedNote (e2e test_27 — announce-driven immediate empty
 		// the seq-replay for a recentlyDeleted / queued-delete note.
 		const crdt = {
 			hasHistory: (_id: string) => Promise.resolve(false),
-			applyRemoteUpdate: (_id: string, _u: Uint8Array) => Promise.resolve(),
+			applyRemoteUpdate: (_id: string, _u: Uint8Array) => Promise.resolve(true),
 			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([0])),
 			projectedText: (_id: string) => Promise.resolve(""),
 			closeDoc: () => {},
@@ -142,7 +142,7 @@ describe("discoverAnnouncedNote (e2e test_27 — announce-driven immediate empty
 		// for that id in the window must not trigger a catch-up that resurrects it.
 		const crdt = {
 			hasHistory: (_id: string) => Promise.resolve(false),
-			applyRemoteUpdate: (_id: string, _u: Uint8Array) => Promise.resolve(),
+			applyRemoteUpdate: (_id: string, _u: Uint8Array) => Promise.resolve(true),
 			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([0])),
 			projectedText: (_id: string) => Promise.resolve(""),
 			closeDoc: () => {},
@@ -165,7 +165,7 @@ describe("discoverAnnouncedNote (e2e test_27 — announce-driven immediate empty
 	test("never throws when the delta fetch fails (failure-isolated)", async () => {
 		const crdt = {
 			hasHistory: (_id: string) => Promise.resolve(false),
-			applyRemoteUpdate: (_id: string, _u: Uint8Array) => Promise.resolve(),
+			applyRemoteUpdate: (_id: string, _u: Uint8Array) => Promise.resolve(true),
 			encodeStateVector: (_id: string) => Promise.resolve(new Uint8Array([0])),
 			projectedText: (_id: string) => Promise.resolve(""),
 			closeDoc: () => {},
@@ -1238,7 +1238,12 @@ describe("convergeColdNoteRoomFree (#1409 — cold notes converge without a room
 		const engine: SyncEngine = makeEngineWithCrdt({
 			applyRemoteUpdate: (id: string, u: Uint8Array) => {
 				applied.push([id, u]);
-				return Promise.resolve();
+				// TRUE = "a doc received this". False is the registry REFUSING
+				// (note removed, doc destroyed mid-hydration), and `markSynced`
+				// below must not run on a merge that never happened — it would
+				// record the note as converged holding none of the server's state,
+				// after which every catch-up compares equal hashes and skips it.
+				return Promise.resolve(true);
 			},
 			markSynced: (id: string) => void engine.commitCrdtConvergence(id),
 			closeDoc: () => {},
@@ -1314,6 +1319,29 @@ describe("convergeColdNoteRoomFree (#1409 — cold notes converge without a room
 
 		await Promise.resolve();
 		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H2");
+	});
+
+	test("a REFUSED apply falls back to the room and does NOT record convergence", async () => {
+		// `applyRemoteUpdate` refuses silently when the note is in `removed` or
+		// its doc was destroyed mid-hydration — and its promise still RESOLVES.
+		// Treating resolution as a merge meant `markSynced` recorded a note as
+		// converged holding none of the server's state, after which every later
+		// catch-up compared equal hashes and skipped it. Permanently, silently.
+		const engine = coldEngine([]);
+		(engine as any).crdt.applyRemoteUpdate = () => Promise.resolve(false);
+		engine.setCrdtPorts({ docState: mock().mockResolvedValue({ b64: "AQID", head: "h" }) });
+		const converge = spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		await (engine as any).convergeColdNoteRoomFree(
+			"id-a",
+			"Notes/a.md",
+			CHANGE,
+			"server body",
+			"H2",
+		);
+
+		expect(converge).toHaveBeenCalledTimes(1);
+		expect(engine.exportSyncState()["Notes/a.md"].serverHash).toBe("H1");
 	});
 
 	test("falls back to the room handshake when the frame fails (old backend, rate limit, dropped socket)", async () => {

--- a/tests/sync-sweep-registry.test.ts
+++ b/tests/sync-sweep-registry.test.ts
@@ -1,0 +1,246 @@
+/**
+ * The guard that makes #1409's bug class impossible to reintroduce.
+ *
+ * BACKGROUND. `SyncEngine` carried two hand-written teardown enumerations that
+ * had been drifting apart since March 2026:
+ *
+ *   destroy()           — swept the transient per-note maps, deliberately
+ *                         sparing the persisted `syncState`.
+ *   wipePerVaultState() — swept `syncState` + cursors + identity, and left the
+ *                         per-note maps alone.
+ *
+ * Each was correct for its own job. Nothing owned their INTERSECTION — state
+ * that is both vault-scoped AND transient — so eleven note_id- and path-keyed
+ * maps survived a vault switch and went on addressing the NEW vault with the
+ * OLD vault's ids. Measured consequence on a real 423-item import: 225 CRDT
+ * rooms for 317 notes, plus 16 duplicate rows created BY the switch itself.
+ *
+ * Six separate bug fixes (2026-03-15 through 2026-08-18) each added a Map to
+ * one list and not the other. None of the authors were careless: a declaration
+ * three thousand lines from either list carries no hint that a decision is
+ * owed, and forgetting was silent.
+ *
+ * THE GUARD. Scope now lives at the declaration (`this.track([...], new Map())`)
+ * and both teardowns derive from that registry. This test closes the last hole
+ * — an author writing a bare `new Map()` and skipping `track()` entirely — by
+ * reflecting over a live engine and failing on any collection the registry does
+ * not know about. The failure names the field, so the fix is obvious.
+ *
+ * Adding a collection to `SyncEngine` therefore forces exactly one decision:
+ * does it die with the vault, with the engine, or both. That is the decision
+ * the six fixes above were never prompted to make.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { EngramApi } from "../src/api";
+import { SyncEngine } from "../src/sync";
+import { DEFAULT_SETTINGS } from "../src/types";
+
+const mockApp = {
+	vault: {
+		configDir: ".obsidian",
+		cachedRead: mock().mockResolvedValue(""),
+		getAbstractFileByPath: mock().mockReturnValue(null),
+		getFileByPath: mock().mockReturnValue(null),
+		getFiles: mock().mockReturnValue([]),
+	},
+	fileManager: { trashFile: mock().mockResolvedValue(undefined) },
+	workspace: {
+		getActiveViewOfType: mock().mockReturnValue(null),
+		getLeavesOfType: mock().mockReturnValue([]),
+	},
+} as any;
+
+type SweepEntry = { on: readonly string[]; collection: { clear(): void } };
+
+function createEngine(): SyncEngine {
+	return new SyncEngine(
+		mockApp,
+		{ getManifest: mock().mockResolvedValue(null) } as unknown as EngramApi,
+		{ ...DEFAULT_SETTINGS, debounceMs: 1 },
+		mock().mockResolvedValue(undefined),
+	);
+}
+
+function registry(engine: SyncEngine): SweepEntry[] {
+	return (engine as unknown as { sweepable: SweepEntry[] }).sweepable;
+}
+
+/**
+ * Own enumerable Map/Set fields on the instance. Nested collections inside
+ * composed objects (`queue`, `files`, `issues`) are those objects' own problem
+ * — each owns its `destroy()` — so only the engine's own fields are in scope.
+ */
+function ownCollections(engine: SyncEngine): Array<[string, Map<unknown, unknown> | Set<unknown>]> {
+	return Object.entries(engine).filter(
+		(entry): entry is [string, Map<unknown, unknown> | Set<unknown>] =>
+			entry[1] instanceof Map || entry[1] instanceof Set,
+	);
+}
+
+describe("sweep registry covers every engine collection", () => {
+	test("no Map or Set field escapes track()", () => {
+		const engine = createEngine();
+		const tracked = new Set(registry(engine).map((e) => e.collection));
+
+		// Identity, not name matching: a typo'd label in track() cannot fake
+		// coverage, because the assertion compares the actual instances.
+		const untracked = ownCollections(engine)
+			.filter(([, value]) => !tracked.has(value))
+			.map(([name]) => name);
+
+		expect(untracked).toEqual([]);
+	});
+
+	test("every registered collection declares at least one sweep event", () => {
+		// `track([], x)` would type-check and silently never sweep.
+		const orphaned = registry(createEngine()).filter((e) => e.on.length === 0);
+		expect(orphaned).toEqual([]);
+	});
+
+	test("registry is non-trivial — a broken track() cannot vacuously pass", () => {
+		// Without this, deleting every track() call would make the first test
+		// pass by finding nothing to compare.
+		const entries = registry(createEngine());
+		expect(entries.length).toBeGreaterThanOrEqual(16);
+		expect(entries.some((e) => e.on.includes("vault"))).toBe(true);
+		expect(entries.some((e) => e.on.includes("destroy"))).toBe(true);
+	});
+});
+
+describe("sweep events are independent, not a severity ladder", () => {
+	test("syncState is vault-scoped but survives destroy()", () => {
+		// It is the persisted sync baseline. Blanking it on unload would force a
+		// full re-scan of the vault on next load.
+		const engine = createEngine();
+		const state = (engine as unknown as { syncState: Map<string, unknown> }).syncState;
+		const entry = registry(engine).find((e) => e.collection === state);
+
+		expect(entry?.on).toEqual(["vault"]);
+	});
+
+	test("debounceTimers is the exact inverse — destroy-only", () => {
+		// A debounce pending across a vault switch still describes a real local
+		// edit to a file that still exists, and still deserves its push.
+		const engine = createEngine();
+		const timers = (engine as unknown as { debounceTimers: Map<string, unknown> })
+			.debounceTimers;
+		const entry = registry(engine).find((e) => e.collection === timers);
+
+		expect(entry?.on).toEqual(["destroy"]);
+	});
+});
+
+describe("the eleven collections that leaked across a vault switch (#1409)", () => {
+	// Named individually and asserted vault-scoped, so a future refactor that
+	// silently re-tags one of them fails here with the field name.
+	const LEAKED = [
+		"fileForNote",
+		"manifestPathOwners",
+		"pendingOrphanSweep",
+		"crdtRehandshakeAttempts",
+		"pendingConvergence",
+		"crdtHealCooldown",
+		"crdtHealTrailingTimers",
+		"pendingQueueDeliveries",
+		"recentlyDeleted",
+		"relocatedFrom",
+		"pendingPostPullPushes",
+	] as const;
+
+	for (const field of LEAKED) {
+		test(`${field} is swept on a vault switch`, () => {
+			const engine = createEngine();
+			const value = (engine as unknown as Record<string, unknown>)[field];
+
+			// `manifestPathOwners` is a nullable CACHE, not a live collection: it
+			// is discarded by nulling the field, which no registry can express.
+			// Assert that shape explicitly rather than skipping it.
+			if (value === null) {
+				expect(field).toBe("manifestPathOwners");
+				return;
+			}
+
+			const entry = registry(engine).find((e) => e.collection === value);
+			expect(entry?.on).toContain("vault");
+		});
+	}
+});
+
+describe("the public vault-change entry point actually reaches the sweep", () => {
+	// The tests above prove the TAGS are right. This proves the wiring: that
+	// `resetForVaultChange` — what main.ts calls on a switch — really empties
+	// the maps that leaked, rather than the registry being correct but unused.
+	test("resetForVaultChange empties the previously-leaking collections", async () => {
+		const engine = createEngine();
+		const e = engine as unknown as {
+			fileForNote: Map<string, string>;
+			pendingOrphanSweep: Set<string>;
+			crdtHealCooldown: Map<string, number>;
+			pendingQueueDeliveries: Map<string, unknown>;
+			pendingPostPullPushes: Set<string>;
+			pushing: Set<string>;
+			saveData(patch: unknown): Promise<void>;
+		};
+		e.saveData = mock().mockResolvedValue(undefined);
+
+		e.fileForNote.set("old-vault-id", "Notes/a.md");
+		e.pendingOrphanSweep.add("old-vault-id");
+		e.crdtHealCooldown.set("old-vault-id", 1);
+		e.pendingQueueDeliveries.set("old-vault-id", { path: "Notes/a.md" });
+		e.pendingPostPullPushes.add("Notes/a.md");
+		e.pushing.add("in-flight.md");
+
+		await engine.resetForVaultChange();
+
+		expect(e.fileForNote.size).toBe(0);
+		expect(e.pendingOrphanSweep.size).toBe(0);
+		expect(e.crdtHealCooldown.size).toBe(0);
+		expect(e.pendingQueueDeliveries.size).toBe(0);
+		expect(e.pendingPostPullPushes.size).toBe(0);
+		// ...and the destroy-only guard is untouched by a vault change.
+		expect(e.pushing.has("in-flight.md")).toBe(true);
+	});
+});
+
+describe("sweeping disposes timers rather than stranding them", () => {
+	test("a vault sweep cancels every timer held in a tracked map", () => {
+		const engine = createEngine();
+		const cleared: number[] = [];
+		(engine as unknown as { time: { clearTimeout(t: number): void } }).time = {
+			clearTimeout: (t: number) => cleared.push(t),
+		};
+
+		// Populate the three timer-carrying vault-scoped maps directly.
+		const e = engine as unknown as {
+			recentlyDeleted: Map<string, { timer: number; path: string }>;
+			relocatedFrom: Map<string, { from: string; timer: number }>;
+			crdtHealTrailingTimers: Map<string, number>;
+			sweep(event: string): void;
+		};
+		e.recentlyDeleted.set("id-1", { timer: 101, path: "a.md" });
+		e.relocatedFrom.set("b.md", { from: "old.md", timer: 102 });
+		e.crdtHealTrailingTimers.set("id-2", 103);
+
+		e.sweep("vault");
+
+		expect(cleared.sort()).toEqual([101, 102, 103]);
+		expect(e.recentlyDeleted.size).toBe(0);
+		expect(e.relocatedFrom.size).toBe(0);
+		expect(e.crdtHealTrailingTimers.size).toBe(0);
+	});
+
+	test("a vault sweep leaves destroy-only collections alone", () => {
+		const engine = createEngine();
+		const e = engine as unknown as {
+			pushing: Set<string>;
+			sweep(event: string): void;
+		};
+		// An in-flight push guard must survive: clearing it mid-flight would
+		// re-admit a second concurrent push of the same path.
+		e.pushing.add("in-flight.md");
+
+		e.sweep("vault");
+
+		expect(e.pushing.has("in-flight.md")).toBe(true);
+	});
+});

--- a/tests/sync-sweep-registry.test.ts
+++ b/tests/sync-sweep-registry.test.ts
@@ -236,6 +236,39 @@ describe("sweeping disposes timers rather than stranding them", () => {
 		expect(e.crdtHealTrailingTimers.size).toBe(0);
 	});
 
+	test("one throwing dispose does not abandon the rest of the sweep", () => {
+		// The failure mode this registry exists to prevent, reintroduced by its
+		// own error handling: a throw used to abort the loop, so every collection
+		// registered AFTER the bad one stayed fully populated — carrying the old
+		// vault's note_ids into the new one, silently, in registration order.
+		const engine = createEngine();
+		const cleared: number[] = [];
+		(engine as unknown as { time: { clearTimeout(t: number): void } }).time = {
+			clearTimeout: (t: number) => {
+				if (t === 101) throw new Error("stale handle");
+				cleared.push(t);
+			},
+		};
+
+		const e = engine as unknown as {
+			recentlyDeleted: Map<string, { timer: number; path: string }>;
+			crdtHealTrailingTimers: Map<string, number>;
+			noteIdMapReconciled: Set<string>;
+			sweep(event: string): void;
+		};
+		e.recentlyDeleted.set("id-1", { timer: 101, path: "a.md" });
+		e.crdtHealTrailingTimers.set("id-2", 103);
+
+		e.sweep("vault");
+
+		// The throwing entry still gets CLEARED — a leaked timer is a smaller
+		// problem than a retained cross-vault map.
+		expect(e.recentlyDeleted.size).toBe(0);
+		// ...and everything after it was swept normally.
+		expect(cleared).toEqual([103]);
+		expect(e.crdtHealTrailingTimers.size).toBe(0);
+	});
+
 	test("a vault sweep leaves destroy-only collections alone", () => {
 		const engine = createEngine();
 		const e = engine as unknown as {

--- a/tests/sync-sweep-registry.test.ts
+++ b/tests/sync-sweep-registry.test.ts
@@ -66,9 +66,17 @@ function registry(engine: SyncEngine): SweepEntry[] {
 }
 
 /**
- * Own enumerable Map/Set fields on the instance. Nested collections inside
- * composed objects (`queue`, `files`, `issues`) are those objects' own problem
- * — each owns its `destroy()` — so only the engine's own fields are in scope.
+ * Own enumerable Map/Set fields on the instance.
+ *
+ * This deliberately does NOT excuse composed objects. An earlier revision of
+ * this comment said `queue`, `files` and `issues` were "those objects' own
+ * problem — each owns its `destroy()`", which conflated HAS A TEARDOWN with IS
+ * NOT VAULT-SCOPED. All three were vault-scoped and none were swept: `files`
+ * held path-keyed echo markers that suppressed real events for the same path in
+ * the new vault, and the offline queue delivered a vault-A delete against
+ * vault-B. They are registered now, and a future composed object must be too —
+ * this helper simply cannot see inside them, so the reasoning has to be done at
+ * the declaration.
  */
 function ownCollections(engine: SyncEngine): Array<[string, Map<unknown, unknown> | Set<unknown>]> {
 	return Object.entries(engine).filter(
@@ -135,7 +143,7 @@ describe("the eleven collections that leaked across a vault switch (#1409)", () 
 	// silently re-tags one of them fails here with the field name.
 	const LEAKED = [
 		"fileForNote",
-		"manifestPathOwners",
+		"manifestOwners",
 		"pendingOrphanSweep",
 		"crdtRehandshakeAttempts",
 		"pendingConvergence",
@@ -152,14 +160,13 @@ describe("the eleven collections that leaked across a vault switch (#1409)", () 
 			const engine = createEngine();
 			const value = (engine as unknown as Record<string, unknown>)[field];
 
-			// `manifestPathOwners` is a nullable CACHE, not a live collection: it
-			// is discarded by nulling the field, which no registry can express.
-			// Assert that shape explicitly rather than skipping it.
-			if (value === null) {
-				expect(field).toBe("manifestPathOwners");
-				return;
-			}
-
+			// No escape hatch. An earlier revision of this test exempted
+			// `manifestPathOwners` with `if (value === null) return`, which
+			// asserted the field was NULLABLE rather than that anything cleared
+			// it — and that exemption was the only thing hiding a live leak
+			// through an entire review (#1409). The cache is now a tracked
+			// object owning both the map and its freshness stamp, so it is
+			// swept like everything else and needs no special case.
 			const entry = registry(engine).find((e) => e.collection === value);
 			expect(entry?.on).toContain("vault");
 		});

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -2473,10 +2473,19 @@ describe("content-free queue entries", () => {
 		expect(engine.queue.size).toBe(0);
 	});
 
-	test("flushQueue drains to 0 even when entry.vaultId differs from current settings.vaultId", async () => {
-		// Regression: entries were dequeued by settings.vaultId, not entry.vaultId,
-		// so an entry enqueued under vault-A would never be removed after settings
-		// changed to vault-B — queue could never reach 0.
+	test("flushQueue drains a foreign-vault entry by DROPPING it, never delivering it", async () => {
+		// Two requirements, and the original test conflated them.
+		//
+		// The one that matters and still holds: the queue must reach 0. Entries
+		// were once dequeued by settings.vaultId rather than entry.vaultId, so an
+		// entry enqueued under vault-A could never be removed after settings moved
+		// to vault-B and the queue could never drain.
+		//
+		// The one that was a BUG: it also asserted the entry was delivered. But
+		// `this.api` points at whichever vault is active now, so delivering a
+		// vault-A entry executes it against vault-B — and for a delete that
+		// destroys an unrelated note at the same path (#1409 review). Draining is
+		// the invariant; delivering to the wrong vault never was.
 		const engine = createEngine({ vaultId: "vault-B" });
 
 		engine.queue.load([
@@ -2494,7 +2503,10 @@ describe("content-free queue entries", () => {
 
 		const flushed = await engine.flushQueue();
 
-		expect(flushed).toBe(1);
+		// Dropped, not delivered.
+		expect(flushed).toBe(0);
+		expect(mockApi.pushNote as jest.Mock).not.toHaveBeenCalled();
+		// ...and the queue still drains, which is what the regression was about.
 		expect(engine.queue.size).toBe(0);
 	});
 });

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -730,6 +730,10 @@ describe("SyncEngine.applySyncChange (apply behavior)", () => {
 		engine.setCrdtManager({
 			removeDoc: () => Promise.resolve(),
 			closeDoc: () => {},
+			// The real registry always answers this. The room-free catch-up read
+			// is only legal when it is false, because that frame is a READ and
+			// cannot carry local ops upward.
+			hasUndeliveredOps: () => false,
 		} as unknown as import("../src/crdt/provider-registry").ProviderRegistry);
 		const path = "Notes/Clean306.md";
 


### PR DESCRIPTION
Single PR for all of #1409's client-side work. Pairs with **engram-app/Engram#1467** (the `crdt_doc_state` frame this consumes) — merge that one first; this side falls back to the room handshake against a backend that doesn't know the frame, so neither blocks the other.

Supersedes #471 (its commit is included here), #472 (diagnostic) and #473 (rejected — evidence recorded there).

## Background: what a real import actually does

Seven consecutive 423-item Obsidian imports, single device, nothing open in an editor:

| | |
|---|---|
| Notes | 317 |
| Rooms opened | **225** (0.71/note), `edit` × 225 |
| `crdt_update_log` rows those rooms wrote | **0** |
| Notes already holding server-side state | 317/317 |

The rooms do no work — the roomless genesis seed had already stored every note's content.

## What's in here

### 1. Room-free cold-note convergence (`be15c20`)
A diverged **cold** note (nobody has it open) converged via a syncStep1 re-handshake, and `crdt_msg` routes every STEP1 through `ensure_room`. Now uses `crdt_doc_state`, which reads the same full state off the persisted snapshot + tail with no room. Falls back to the handshake on any failure.

`applyRemoteUpdate` does **not** fire `onSynced` — only an inbound syncStep2 does — so the staged episode is driven to commit explicitly via `markSynced`. Without that the note shows zero rooms while silently never recording convergence, and re-fetches forever. The unit test drives the commit through the port rather than calling it by hand, so a version that skips the trigger fails.

Measured: `test_77` 3–4 rooms → **0**. On the real vault: 24 room-free convergences, zero conflicts across all seven imports.

### 2. Per-vault identity guards (`0d27dfc`, `064b636`, `2c98dfc`)
Three places where a previous vault's path → note_id map could survive a vault change:
- `registerVault()` re-registering after the 404-heal or `onVaultDeleted` nulled the vaultId
- the persisted `noteIds` cache, which had no vault stamp (unlike `syncState`'s `syncStateVaultId`)
- `applyVaultSwitch` (selfhost dropdown) changing vaults without resetting anything

**Honest status:** all three are real holes, and **none of them fired** on the flow that reproduces the bug — verified live, each logged zero times across a full import while the stale ids kept coming. They are defensive, not the fix.

### 3. Vault-switch consolidation (`8dc20ca`)
Two implementations of "switch the active vault" agreeing on **1 of 8** steps:

| | dropdown | picker |
|---|---|---|
| `updateSettings` / `resetForVaultChange` / gate fingerprint / reconcile throttle / strand-heal / `setSyncBlocked` / stream rebuild / rerender | ✗ | ✓ |

The dropdown isn't only a first-time picker — it also renders when the stored vault is missing server-side, a real vault change carrying a full stale map. `EngramSyncPlugin.switchVault()` is now the only path. Persistence stays caller-specific on purpose: the picker uses `savePluginData` precisely to avoid `saveSettings` re-firing the sync-gate chain, while the dropdown wants that chain.

### 4. Genesis-seed consolidation (`d57dbf4`, −99 lines)
The "seed a just-created note's body" sequence was written twice — `applyCrdtCreateAck` and inline in `pushFile` — identical down to drift-merge ordering, with a docstring promising it "mirrors pushFile's seeded-gated local apply exactly, **guard-for-guard**" and nothing enforcing it. #1130 is already on record as "duplicated gates silently diverging". Both now call `seedBodyAfterCreate`.

## What this does NOT fix

**The room storm.** Mechanism is confirmed end to end — stale id → server re-ids → `sameId=false` → `routeModify` broadcast → one room per note — but *where the stale id survives from* is still unidentified. Full evidence and the ruled-out paths are in #1409.

**Correction (2026-08-25):** an earlier revision of this description claimed duplicate note rows went 16 → 0. That was wrong — measured mid-run, before the duplicates landed. Final counts per import are 0, 2, 2, 2, 16, 16, 16 across v1–v7: duplicates got WORSE over the session and nothing here improved them. Same path, two note ids; tracked separately.

## Verification

2894 unit tests pass; biome clean. Both consolidations mutation-checked — disabling the shared genesis fast branch fails 4 tests, so both former call sites provably route through it.

**Not yet validated:** neither consolidation has run a real 423-item import. That is the recommended pre-merge check.

Refs #1409, #1318, #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp
