### PR TITLE
fix(crdt): don't converge a note whose local file is empty (#477)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Required status checks on `main`: `build-and-test`, `version-check / version-che
 - A note that logs `re-handshake fired` and then goes silent forever (the create-ack gate swallowing syncStep1; plus how to read `ci-debug` client logs without misordering them) → `docs/context/crdt-pull-gated-by-create-ack.md`
 - Touching create-ack bookkeeping, or wondering what actually opens the live-send gate (`setCrdtHead`/`hasServerNote`, NOT `confirmNoteId` — and the ordering `adoptCreateAck` must keep) → `docs/context/crdt-pull-gated-by-create-ack.md`
 - Bulk first sync opens a CRDT room per idle (non-editor-open) note (`flushHeldEditsOnCreateAck`'s self-heal was the one `enroll()` call site not gated on `isLiveBound`; #1409 handshake half) → `docs/context/crdt-createack-selfheal-ungated-enroll.md`
-- Notes land EMPTY during a first sync and fill in a pass later, or you are about to treat a 0-byte file as "nothing to protect" (three ways an empty file lies: a converged clear, undelivered ops, a `cachedRead` that invented it) → `docs/context/crdt-empty-placeholder-cold-rooms.md`
+- About to treat a 0-byte file as "nothing to protect" (three ways an empty file lies: a converged clear, undelivered ops, a `cachedRead` that invented it) → `docs/context/crdt-empty-placeholder-cold-rooms.md`
 - Wondering why a catch-up leg records no `serverHash`/`seq`, or tempted to add one (a row can lag its own `content_hash`; recording it marks the note in sync at bytes you cannot verify and every later row compares equal and is skipped) → `docs/context/crdt-empty-placeholder-cold-rooms.md`
 
 @/home/open-claw/documents/code-projects/ops-agent/docs/self-updating-docs.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,5 +179,7 @@ Required status checks on `main`: `build-and-test`, `version-check / version-che
 - A note that logs `re-handshake fired` and then goes silent forever (the create-ack gate swallowing syncStep1; plus how to read `ci-debug` client logs without misordering them) → `docs/context/crdt-pull-gated-by-create-ack.md`
 - Touching create-ack bookkeeping, or wondering what actually opens the live-send gate (`setCrdtHead`/`hasServerNote`, NOT `confirmNoteId` — and the ordering `adoptCreateAck` must keep) → `docs/context/crdt-pull-gated-by-create-ack.md`
 - Bulk first sync opens a CRDT room per idle (non-editor-open) note (`flushHeldEditsOnCreateAck`'s self-heal was the one `enroll()` call site not gated on `isLiveBound`; #1409 handshake half) → `docs/context/crdt-createack-selfheal-ungated-enroll.md`
+- Notes land EMPTY during a first sync and fill in a pass later, or you are about to treat a 0-byte file as "nothing to protect" (three ways an empty file lies: a converged clear, undelivered ops, a `cachedRead` that invented it) → `docs/context/crdt-empty-placeholder-cold-rooms.md`
+- Wondering why a catch-up leg records no `serverHash`/`seq`, or tempted to add one (a row can lag its own `content_hash`; recording it marks the note in sync at bytes you cannot verify and every later row compares equal and is skipped) → `docs/context/crdt-empty-placeholder-cold-rooms.md`
 
 @/home/open-claw/documents/code-projects/ops-agent/docs/self-updating-docs.md

--- a/docs/context/crdt-empty-placeholder-cold-rooms.md
+++ b/docs/context/crdt-empty-placeholder-cold-rooms.md
@@ -1,11 +1,12 @@
-# Notes land EMPTY during a first sync, and an empty file lies three ways
+# An empty file lies three ways (and the first-sync placeholder it hides)
 
 _Last verified: 2026-08-27 (UTC)_
 
 ## Status
 Fixed on `fix/477-empty-placeholder-cold-rooms` (`Engram-obsidian#477`, PR #478).
-**The fix is a correctness/UX fix, not a perf one** — see "What this does NOT buy"
-before quoting a room number off it.
+**Read "What this does NOT buy" before quoting any number off this.** Both
+benefits this started out claiming — fewer rooms, and a visible empty-note
+window — were measured and did not survive.
 
 ## What This Is
 `#477` was filed as "cold-note catch-up opens a room per note", off a prod first
@@ -25,9 +26,8 @@ realer defect underneath, and killed the perf premise on the way.
    condition fails → the note takes the cold-converge leg to fetch a body **this
    very row already carries.**
 
-So for ~13% of a first sync, the user watches notes arrive EMPTY and fill in a
-pass later. That is the defect worth fixing. The room was a correct heal of a
-hole the client dug itself.
+The room was a correct heal of a hole the client dug itself. What the fix is
+actually worth is narrower than that sounds — see "What this does NOT buy".
 
 ## An empty file is not a license to write
 
@@ -65,9 +65,21 @@ what this row just materialized, walking `seq` backward and re-serving consumed
 rows. `commitCrdtConvergence` records unconditionally once a stage exists — there
 is no text-verify gate to save you.
 
-## What this does NOT buy: room count
+## What this does NOT buy: room count, or a visible empty-note window
 
-Measured, 150-note bulk first sync, n=3 each:
+**Tested and disproved.** A first-sync e2e asserting "B holds no 0-byte notes
+after its catch-up" passes on plain `main` too, twice — the cold converge fills
+the placeholder inside the same `trigger_full_sync()`. So the empty window is
+sub-pass, not a settled state a user sits looking at, and there is no e2e oracle
+at this granularity that can tell the two builds apart. The test was written,
+run against both, and deleted rather than shipped: a test that cannot fail is
+worse than no test, because it reads as coverage.
+
+What that leaves as the real benefit: **~13% of a first sync's notes stop paying
+a `crdt_doc_state` round-trip** for a body the row already carried. That is the
+whole of it.
+
+Room count, measured over a 150-note bulk first sync, n=3 each:
 
 | build | rooms |
 |---|---|

--- a/docs/context/crdt-empty-placeholder-cold-rooms.md
+++ b/docs/context/crdt-empty-placeholder-cold-rooms.md
@@ -1,94 +1,109 @@
-# A 0-byte placeholder makes a first sync converge notes it already holds
+# Notes land EMPTY during a first sync, and an empty file lies three ways
 
-_Last verified: 2026-08-27_
+_Last verified: 2026-08-27 (UTC)_
 
 ## Status
-Fixed on `fix/477-empty-placeholder-cold-rooms` — `Engram-obsidian#477`.
-Measured on a 150-note bulk first sync against `origin/main`: **2 handshake
-rooms → 0**, and ~20 notes/150 stop paying a `crdt_doc_state` round-trip for a
-body the feed row already carried.
+Fixed on `fix/477-empty-placeholder-cold-rooms` (`Engram-obsidian#477`, PR #478).
+**The fix is a correctness/UX fix, not a perf one** — see "What this does NOT buy"
+before quoting a room number off it.
 
 ## What This Is
-`#477` was filed off a prod first sync that opened **833 rooms for ~1,000
-notes**. The room was never the defect — it was a **correct heal of a hole the
-client dug itself one pass earlier.**
+`#477` was filed as "cold-note catch-up opens a room per note", off a prod first
+sync that showed **833 rooms for ~1,000 notes**. Chasing it turned up a different,
+realer defect underneath, and killed the perf premise on the way.
 
 ## The chain
 
 1. Device A pushes. The op-log feed emits a `v=1` create row whose `content` is
    EMPTY (its `content_hash` is the empty-content hash — every such row shares
-   one hash, which is how you spot them in a log).
-2. Device B's catch-up hits the **discovery** leg (`applyChange`, "CRDT
-   discovery: enrolling new note"), which materializes the row's body — so it
-   writes a **0-byte file** and records that empty as the baseline.
-3. The real body lands server-side; a later row carries it with a fresh
-   `content_hash`.
-4. B's catch-up: hash differs → diverged, not live-bound. Disk (0b) ≠ row (39b),
-   so the quiet-record guard's `localNow === content` condition fails and the
-   note takes the cold-converge leg — a `crdt_doc_state` read, or a full room
-   handshake whenever that read falls back — to fetch a body **this very row
-   already carries.**
+   one, which is how you spot them in a log).
+2. Device B's catch-up hits the **discovery** leg, which materializes the row's
+   body — so it writes a **0-byte file** and records that empty as its baseline.
+   Measured: **20 of 150 notes** on a bulk first sync.
+3. The real body lands server-side; a later row carries it with a fresh hash.
+4. Disk (0b) ≠ row (39b) → the quiet-record guard's `localNow === content`
+   condition fails → the note takes the cold-converge leg to fetch a body **this
+   very row already carries.**
 
-Measured (150-note bulk first sync): 20 notes materialized empty; on the
-pre-`#474` tree 13-16 of them each bought a room, on `main` 2 did.
+So for ~13% of a first sync, the user watches notes arrive EMPTY and fill in a
+pass later. That is the defect worth fixing. The room was a correct heal of a
+hole the client dug itself.
 
-## The fix
-Route an empty local file that this row can fill into the snapshot backfill
-instead of the cold converge:
+## An empty file is not a license to write
 
-```ts
-} else if (noteId && !(localNow === "" && content !== "")) {   // cold converge
-} else {                                                       // backfill
-```
+The first fix was "disk is empty, so there's nothing a converge could protect —
+just write the row's body." Review killed it. `isUnconvergedEmptyPlaceholder`
+exists because an empty file lies in three different ways:
 
-An empty file has no content a converge could protect, so it falls through to the
-existing snapshot backfill (`flushFromCrdt` + `stampSyncedRow` +
-`markServerKnown`) — the same write the discovery leg performs one pass earlier,
-for the same reason.
+1. **The emptiness IS the converged state.** A remote clear applied through
+   `flushFromCrdt` calls `recordCrdtBaseline("")`, so `stored.hash === fnv1a("")`
+   and `localDiverged` reads FALSE — the drift-copy escape hatch never fires. A
+   later checkpoint-lagged row carrying the PRE-clear body would resurrect
+   deleted content. **`crdtHead` separates them:** a converged note carries a
+   REAL head; a discovery placeholder carries only the `CRDT_HEAD_CREATED`
+   sentinel ("the server has this note, we have never applied its ops").
+2. **The doc holds local work.** `hasUndeliveredOps` is the precondition
+   `convergeColdNoteRoomFree` already enforces, for the same reason: a snapshot
+   write, like a `crdt_doc_state` read, cannot carry anything upward.
+3. **The cache invented it.** `localNow` is a `cachedRead`, and a `cachedRead`
+   right after a create is exactly where Obsidian's cache lies — proving the 0
+   bytes took `adapter.read` during the investigation, so the overwrite demands
+   the same proof. A read failure answers false; the converge is always correct.
 
-**Both halves of the condition are load-bearing** (adversarial review found this,
-not the first draft). With an EMPTY row, `flushFromCrdt` short-circuits on "disk
-already holds this content" and writes nothing, so the leg would stamp
-`serverHash` + `seq` for a note whose disk stayed empty. If such a row were a
-checkpoint-lagged projection (fresh hash, stale bytes — the test_82 "went deaf on
-the stale bytes" class), the note is recorded in sync while empty and every later
-catch-up compares equal and skips it. Permanently. An empty row keeps the
-converge, whose commit records only on proof.
+## And never record what you cannot verify
 
-This does **not** reopen the D2 stomp class the cold leg guards against: that
-guard protects *content on disk* from a checkpoint-lagged projection, and an
-empty file has none. A genuine local blanking never reaches the line — it trips
-`localDiverged` above and takes the drift-copy branch, which preserves the local
-edit.
+The leg writes the body and then records **exactly what the discovery leg
+records** — `hash` via `recordCrdtBaseline`, plus `markServerKnown`. No
+`serverHash`, no `seq`. A row can lag its own `content_hash` (fresh hash, stale
+bytes — the test_82 "went deaf on the stale bytes" class), so recording that hash
+marks the note in sync at bytes we cannot verify, after which every later row
+carrying it compares equal and is skipped. Permanently.
 
-## Don't re-derive: the prod 833 is not main's number
-`origin/main` (plugin 1.24.3 + a backend that answers `crdt_doc_state`) allocates
-**2** handshake rooms per 150 notes — nowhere near 833/1,000. `#474`'s room-free
-cold-note path already removed the bulk of it. The prod observation must have run
-a client/server pair where that path fell back to rooms; treat 833 as a
-pre-`#474`-shaped number, not a main baseline. Re-measure before quoting it.
+It also drops any staged `pendingConvergence` episode for the note: an in-flight
+room's STEP2 would otherwise commit an OLDER `serverHash`/`version`/`seq` over
+what this row just materialized, walking `seq` backward and re-serving consumed
+rows. `commitCrdtConvergence` records unconditionally once a stage exists — there
+is no text-verify gate to save you.
 
-Related: room count was never a RAM proxy (a room is ~85 KB; 52 draining
-released 4 MB) — see `project_1409_closed_premise_invalidated`.
+## What this does NOT buy: room count
+
+Measured, 150-note bulk first sync, n=3 each:
+
+| build | rooms |
+|---|---|
+| plain `main` | 1, 3, 1 |
+| first (unsafe) fix — recorded `serverHash` | 0, 0, 0 |
+| final fix — records nothing | 0, 3, 4, 3 |
+
+**The consistent 0 came entirely from recording a hash we could not verify** —
+i.e. from suppressing all future convergence for those notes, which was the
+defect. Once that stops, the room count is indistinguishable from `main`. The
+leg still fires (7-20 notes per 150, confirmed with a probe log); it just moves
+the body one pass earlier instead of removing the converge.
+
+Also do not quote the issue's 833/1,000: `main` allocates ~1-3 per 150 because
+#474's room-free path already removed the bulk. That figure is pre-#474-shaped.
+And room count was never a RAM proxy — a room is ~85 KB, 52 draining released
+4 MB (`project_1409_closed_premise_invalidated`).
 
 ## How it was found (the method that worked)
 `enrollSites` buckets by **stack frame**, so it can only ever name
-`fireCrdtReHandshake`, the funnel every caller collapses into. Weeks of that
-named nothing. Two cheap instruments cracked it in one session:
+`fireCrdtReHandshake`, the funnel every caller collapses into — weeks of it named
+nothing. Two cheap instruments cracked it in one session:
 
-1. **`convergeSites`** — an explicit label string passed at each
-   `socketConverge` call site. That granularity names code to change; it
-   identified `catchup-diverged-cold`.
-2. **A per-condition miss counter** at the quiet-record guard, bucketing which
-   of its three conditions failed. Answer: **`disk-differs`, 100%** — killing
-   the standing hypothesis that a recorded `serverHash` was skipping the guard.
+1. **`convergeSites`** — an explicit label passed at each `socketConverge` call
+   site. That granularity names code to change; it identified
+   `catchup-diverged-cold`.
+2. **A per-condition miss counter** at the quiet-record guard, bucketing which of
+   its three conditions failed. Answer: **`disk-differs`, 100%**, killing the
+   standing hypothesis that a recorded `serverHash` was skipping the guard.
 
-Then `adapter.read` alongside `cachedRead` proved the file was *genuinely* 0
-bytes rather than a stale Obsidian cache. Don't skip that step — a `cachedRead`
-right after a create is exactly where you'd expect the cache to lie.
+Then `adapter.read` alongside `cachedRead` proved the 0 bytes were real. Both
+instruments live on `chore/diag-enroll-all-devices` ("not for merge").
 
-Both instruments live on `chore/diag-enroll-all-devices` (commits marked "not
-for merge") if this class needs re-opening.
+**Confirm the leg you added actually fires.** A one-line probe log plus
+`docker logs | grep -c` is the difference between "0 rooms" meaning "it worked"
+and "0 rooms" meaning "it never ran."
 
 ## Repro loop
 ~90 s per iteration, reproduces every run. Stack + env per
@@ -108,42 +123,23 @@ full 1,000 and the default must never be lowered; the room bounds are calibrated
 to that size. Client `rlog()` lines land in `docker logs engram-crdt-engram-1` as
 `[client:*]`; their timestamps are ship-time, so never order by them.
 
-## `markServerKnown` before `stampSyncedRow` is a no-op
-Same backfill leg, found by the same review. The order was:
-
-```ts
-this.markServerKnown(normalized);   // setCrdtHead -> patchSyncedRow (merge)
-this.stampSyncedRow(normalized, {…}); // REPLACES the row — head gone
-```
-
-`stampSyncedRow`'s contract is an explicit wholesale REPLACE ("prior bookkeeping
-(crdtHead, seq, version…) is deliberately dropped"), and `crdtHead` lives in that
-same `syncState` row — so the head was erased by the very next line. It went
-unnoticed because only the legacy no-`note_id` leg reached here, and
-`hasServerNote` is keyed by note_id, which a legacy note doesn't have.
-
-For a CRDT note it bites: no head → `pushFile` takes the genesis branch and
-re-uploads a note it just downloaded (prod 2026-08-13, "122 files to upload" from
-an empty local vault), and `canSendLive` holds its live `crdt_msg` sends. Fixed by
-moving `markServerKnown` AFTER the stamp; `hasServerNote` is now asserted in the
-unit test. **If you add a field to a `stampSyncedRow` call site, check what the
-replace drops.**
+**Room count needs n≥3.** Single runs range 0-4 on identical code; one run "proving"
+a win is noise.
 
 ## Gotchas
-- **Judge a fix by room STARTS and peak RSS during the sync**, not steady-state
-  RSS — it does not return to baseline regardless (allocator carriers stay held),
-  and peak residency here stayed at 1-3 with zero errors either way.
-- **`tests/test_34_folder_rename_propagation.py` fails when it runs after
+- `stampSyncedRow` REPLACES the row by contract — `crdtHead` lives in that same
+  row, so a `markServerKnown` before it is erased by the very next line, and
+  `markServerKnown` afterwards writes the CREATED sentinel over a hole where a
+  real head used to be. Use `patchSyncedRow` when the row must survive.
+- **`test_34_folder_rename_propagation` fails whenever it runs after
   `tests/crdt/`** — the 4 Playwright specs that always time out on this box leave
-  the browser/Obsidian state that starves it. Identical 6/24 failure set with and
-  without a sync-path change; test_34 passes solo in ~31 s. Control the batch, not
-  just the test, before believing a delivery regression.
-- Local attachment tests (`test_33`, `test_79`, `test_80`) fail with a server-side
-  `403 SignatureDoesNotMatch` — the stack's MinIO credentials have drifted. Env,
-  not code.
+  the state that starves it. Identical failure set with and without a sync-path
+  change; it passes solo in ~31 s. Control the batch, not just the test.
+- Local attachment tests (`test_33`, `test_79`, `test_80`) fail on a server-side
+  MinIO `403 SignatureDoesNotMatch`. Env drift, not code.
 
 ## References
-- Issue: `engram-app/Engram-obsidian#477`
+- Issue `engram-app/Engram-obsidian#477`, PR #478
 - The other ungated site: `crdt-createack-selfheal-ungated-enroll.md` (`#1409`, plugin `#474`)
 - `backend/docs/context/crdt-room-lifetime-and-drain.md` — drain phases, idle exit
 - `docs/context/local-crdt-e2e-repro.md` — stack bring-up, env vars, dead ends

--- a/docs/context/crdt-empty-placeholder-cold-rooms.md
+++ b/docs/context/crdt-empty-placeholder-cold-rooms.md
@@ -1,0 +1,118 @@
+# A 0-byte placeholder makes a first sync converge notes it already holds
+
+_Last verified: 2026-08-27_
+
+## Status
+Fixed on `fix/477-empty-placeholder-cold-rooms` — `Engram-obsidian#477`.
+Measured on a 150-note bulk first sync against `origin/main`: **2 handshake
+rooms → 0**, and ~20 notes/150 stop paying a `crdt_doc_state` round-trip for a
+body the feed row already carried.
+
+## What This Is
+`#477` was filed off a prod first sync that opened **833 rooms for ~1,000
+notes**. The room was never the defect — it was a **correct heal of a hole the
+client dug itself one pass earlier.**
+
+## The chain
+
+1. Device A pushes. The op-log feed emits a `v=1` create row whose `content` is
+   EMPTY (its `content_hash` is the empty-content hash — every such row shares
+   one hash, which is how you spot them in a log).
+2. Device B's catch-up hits the **discovery** leg (`applyChange`, "CRDT
+   discovery: enrolling new note"), which materializes the row's body — so it
+   writes a **0-byte file** and records that empty as the baseline.
+3. The real body lands server-side; a later row carries it with a fresh
+   `content_hash`.
+4. B's catch-up: hash differs → diverged, not live-bound. Disk (0b) ≠ row (39b),
+   so the quiet-record guard's `localNow === content` condition fails and the
+   note takes the cold-converge leg — a `crdt_doc_state` read, or a full room
+   handshake whenever that read falls back — to fetch a body **this very row
+   already carries.**
+
+Measured (150-note bulk first sync): 20 notes materialized empty; on the
+pre-`#474` tree 13-16 of them each bought a room, on `main` 2 did.
+
+## The fix
+Gate the cold leg on disk being non-empty:
+
+```ts
+} else if (noteId && localNow !== "") {   // cold converge (room-free or room)
+} else {                                  // backfill from the row's snapshot
+```
+
+An empty file has no content a converge could protect, so the empty case falls
+through to the existing snapshot backfill (`flushFromCrdt` + `markServerKnown` +
+`stampSyncedRow`) — the same write the discovery leg performs one pass earlier,
+for the same reason.
+
+This does **not** reopen the D2 stomp class the cold leg guards against: that
+guard protects *content on disk* from a checkpoint-lagged projection, and an
+empty file has none. A genuine local blanking never reaches the line — it trips
+`localDiverged` above and takes the drift-copy branch, which preserves the local
+edit.
+
+## Don't re-derive: the prod 833 is not main's number
+`origin/main` (plugin 1.24.3 + a backend that answers `crdt_doc_state`) allocates
+**2** handshake rooms per 150 notes — nowhere near 833/1,000. `#474`'s room-free
+cold-note path already removed the bulk of it. The prod observation must have run
+a client/server pair where that path fell back to rooms; treat 833 as a
+pre-`#474`-shaped number, not a main baseline. Re-measure before quoting it.
+
+Related: room count was never a RAM proxy (a room is ~85 KB; 52 draining
+released 4 MB) — see `project_1409_closed_premise_invalidated`.
+
+## How it was found (the method that worked)
+`enrollSites` buckets by **stack frame**, so it can only ever name
+`fireCrdtReHandshake`, the funnel every caller collapses into. Weeks of that
+named nothing. Two cheap instruments cracked it in one session:
+
+1. **`convergeSites`** — an explicit label string passed at each
+   `socketConverge` call site. That granularity names code to change; it
+   identified `catchup-diverged-cold`.
+2. **A per-condition miss counter** at the quiet-record guard, bucketing which
+   of its three conditions failed. Answer: **`disk-differs`, 100%** — killing
+   the standing hypothesis that a recorded `serverHash` was skipping the guard.
+
+Then `adapter.read` alongside `cachedRead` proved the file was *genuinely* 0
+bytes rather than a stale Obsidian cache. Don't skip that step — a `cachedRead`
+right after a create is exactly where you'd expect the cache to lie.
+
+Both instruments live on `chore/diag-enroll-all-devices` (commits marked "not
+for merge") if this class needs re-opening.
+
+## Repro loop
+~90 s per iteration, reproduces every run. Stack + env per
+`../../docs/context/local-crdt-e2e-repro.md`:
+
+```bash
+cd backend/e2e && env ENGRAM_API_URL=http://localhost:8100/api \
+  ENGRAM_PLUGIN_SRC=<plugin checkout> AUTH_PROVIDER=local E2E_ENABLE_CRDT=true \
+  E2E_WORKERS=1 CI_POSTGRES_CONTAINER=engram-crdt-postgres-1 \
+  CI_MINIO_CONTAINER=engram-crdt-minio-1 CI_ENGRAM_CONTAINER=engram-crdt-engram-1 \
+  E2E_BULK_NOTE_COUNT=150 \
+  python3 -m pytest tests/test_77_bulk_first_sync.py -s --reruns 0
+```
+
+`E2E_BULK_NOTE_COUNT` is a LOCAL override only (on the diag branch) — CI runs the
+full 1,000 and the default must never be lowered; the room bounds are calibrated
+to that size. Client `rlog()` lines land in `docker logs engram-crdt-engram-1` as
+`[client:*]`; their timestamps are ship-time, so never order by them.
+
+## Gotchas
+- **Judge a fix by room STARTS and peak RSS during the sync**, not steady-state
+  RSS — it does not return to baseline regardless (allocator carriers stay held),
+  and peak residency here stayed at 1-3 with zero errors either way.
+- **`tests/test_34_folder_rename_propagation.py` fails when it runs after
+  `tests/crdt/`** — the 4 Playwright specs that always time out on this box leave
+  the browser/Obsidian state that starves it. Identical 6/24 failure set with and
+  without a sync-path change; test_34 passes solo in ~31 s. Control the batch, not
+  just the test, before believing a delivery regression.
+- Local attachment tests (`test_33`, `test_79`, `test_80`) fail with a server-side
+  `403 SignatureDoesNotMatch` — the stack's MinIO credentials have drifted. Env,
+  not code.
+
+## References
+- Issue: `engram-app/Engram-obsidian#477`
+- The other ungated site: `crdt-createack-selfheal-ungated-enroll.md` (`#1409`, plugin `#474`)
+- `backend/docs/context/crdt-room-lifetime-and-drain.md` — drain phases, idle exit
+- `docs/context/local-crdt-e2e-repro.md` — stack bring-up, env vars, dead ends

--- a/docs/context/crdt-empty-placeholder-cold-rooms.md
+++ b/docs/context/crdt-empty-placeholder-cold-rooms.md
@@ -33,17 +33,27 @@ Measured (150-note bulk first sync): 20 notes materialized empty; on the
 pre-`#474` tree 13-16 of them each bought a room, on `main` 2 did.
 
 ## The fix
-Gate the cold leg on disk being non-empty:
+Route an empty local file that this row can fill into the snapshot backfill
+instead of the cold converge:
 
 ```ts
-} else if (noteId && localNow !== "") {   // cold converge (room-free or room)
-} else {                                  // backfill from the row's snapshot
+} else if (noteId && !(localNow === "" && content !== "")) {   // cold converge
+} else {                                                       // backfill
 ```
 
-An empty file has no content a converge could protect, so the empty case falls
-through to the existing snapshot backfill (`flushFromCrdt` + `markServerKnown` +
-`stampSyncedRow`) — the same write the discovery leg performs one pass earlier,
+An empty file has no content a converge could protect, so it falls through to the
+existing snapshot backfill (`flushFromCrdt` + `stampSyncedRow` +
+`markServerKnown`) — the same write the discovery leg performs one pass earlier,
 for the same reason.
+
+**Both halves of the condition are load-bearing** (adversarial review found this,
+not the first draft). With an EMPTY row, `flushFromCrdt` short-circuits on "disk
+already holds this content" and writes nothing, so the leg would stamp
+`serverHash` + `seq` for a note whose disk stayed empty. If such a row were a
+checkpoint-lagged projection (fresh hash, stale bytes — the test_82 "went deaf on
+the stale bytes" class), the note is recorded in sync while empty and every later
+catch-up compares equal and skips it. Permanently. An empty row keeps the
+converge, whose commit records only on proof.
 
 This does **not** reopen the D2 stomp class the cold leg guards against: that
 guard protects *content on disk* from a checkpoint-lagged projection, and an
@@ -97,6 +107,27 @@ cd backend/e2e && env ENGRAM_API_URL=http://localhost:8100/api \
 full 1,000 and the default must never be lowered; the room bounds are calibrated
 to that size. Client `rlog()` lines land in `docker logs engram-crdt-engram-1` as
 `[client:*]`; their timestamps are ship-time, so never order by them.
+
+## `markServerKnown` before `stampSyncedRow` is a no-op
+Same backfill leg, found by the same review. The order was:
+
+```ts
+this.markServerKnown(normalized);   // setCrdtHead -> patchSyncedRow (merge)
+this.stampSyncedRow(normalized, {…}); // REPLACES the row — head gone
+```
+
+`stampSyncedRow`'s contract is an explicit wholesale REPLACE ("prior bookkeeping
+(crdtHead, seq, version…) is deliberately dropped"), and `crdtHead` lives in that
+same `syncState` row — so the head was erased by the very next line. It went
+unnoticed because only the legacy no-`note_id` leg reached here, and
+`hasServerNote` is keyed by note_id, which a legacy note doesn't have.
+
+For a CRDT note it bites: no head → `pushFile` takes the genesis branch and
+re-uploads a note it just downloaded (prod 2026-08-13, "122 files to upload" from
+an empty local vault), and `canSendLive` holds its live `crdt_msg` sends. Fixed by
+moving `markServerKnown` AFTER the stamp; `hasServerNote` is now asserted in the
+unit test. **If you add a field to a `stampSyncedRow` call site, check what the
+replace drops.**
 
 ## Gotchas
 - **Judge a fix by room STARTS and peak RSS during the sync**, not steady-state

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3273,6 +3273,57 @@ export class SyncEngine {
 		this.pendingConvergence.set(noteId, { path, serverHash, content, version, seq });
 	}
 
+	/** Is `normalized` a 0-byte placeholder THIS device wrote and never
+	 *  converged — the only state in which filling it from a feed snapshot is
+	 *  legal (#477)?
+	 *
+	 *  An empty file is NOT on its own a license to write. Three ways it lies,
+	 *  each of which this predicate has to exclude:
+	 *
+	 *  1. **The emptiness IS the converged state.** A remote clear applied
+	 *     through `flushFromCrdt` calls `recordCrdtBaseline("")`, so
+	 *     `stored.hash === fnv1a("")` and `localDiverged` reads FALSE — the
+	 *     drift-copy escape hatch never fires. A later checkpoint-lagged row
+	 *     carrying the PRE-clear body would then resurrect deleted content.
+	 *     `crdtHead` separates the two: a converged note carries a REAL head
+	 *     recorded by the apply, while a discovery placeholder carries only the
+	 *     `CRDT_HEAD_CREATED` sentinel — "the server has this note, we have
+	 *     never applied its ops."
+	 *  2. **The doc holds local work.** `hasUndeliveredOps` is the same
+	 *     precondition `convergeColdNoteRoomFree` uses, and for the same reason:
+	 *     a snapshot write, like a `crdt_doc_state` read, cannot carry anything
+	 *     upward. A note with undelivered ops must take the bidirectional room.
+	 *     (Conservative by design — a never-handshaken doc reads as undelivered
+	 *     on registries that track it, and an absent probe answers "yes".)
+	 *  3. **The cache invented the emptiness.** `localNow` comes from
+	 *     `cachedRead`, and a `cachedRead` right after a create is exactly where
+	 *     Obsidian's cache lies. Proving the 0 bytes needed `adapter.read` during
+	 *     the #477 investigation; a whole-file overwrite deserves the same proof.
+	 *     Any read failure answers false — the converge is always CORRECT, just
+	 *     more expensive.
+	 *
+	 *  What survives all three is a file this device created empty from a
+	 *  content-less create row and has never merged a single server op into. */
+	private async isUnconvergedEmptyPlaceholder(
+		noteId: string,
+		normalized: string,
+		localNow: string | null,
+	): Promise<boolean> {
+		if (localNow !== "") return false;
+		if (this.getCrdtHead(normalized) !== CRDT_HEAD_CREATED) return false;
+		if (typeof this.crdt?.hasUndeliveredOps !== "function") return false;
+		if (this.crdt.hasUndeliveredOps(noteId)) return false;
+		try {
+			return (await this.app.vault.adapter.read(normalized)) === "";
+		} catch (e) {
+			rlog().warn(
+				"pull",
+				`empty-placeholder check could not read ${noteRef(normalized)} — converging instead: ${errMsg(e, normalized)}`,
+			);
+			return false;
+		}
+	}
+
 	/** Converge a diverged COLD note (nobody has it open) without allocating a
 	 *  server room — #1409's open half.
 	 *
@@ -8489,7 +8540,51 @@ export class SyncEngine {
 								version: change.version,
 								serverHash: change.content_hash,
 							});
-						} else if (noteId && !(localNow === "" && content !== "")) {
+						} else if (
+							noteId &&
+							content !== "" &&
+							(await this.isUnconvergedEmptyPlaceholder(noteId, normalized, localNow))
+						) {
+							// #477: this note is a 0-BYTE PLACEHOLDER this device wrote
+							// itself, and the row carries the body it was waiting for.
+							// Do exactly what the discovery leg does one pass earlier —
+							// write the body, flip the server-known oracle, record
+							// nothing else — instead of paying a `crdt_doc_state`
+							// round-trip (plus a room whenever that read falls back) to
+							// fetch a body this very row already carries.
+							//
+							// The bookkeeping is deliberately IDENTICAL to discovery's,
+							// which is what makes it safe: no `serverHash`, no `seq`. A
+							// row can lag its own `content_hash` (fresh hash, stale
+							// bytes — the test_82 deaf class), and recording that hash
+							// would mark the note in sync at bytes we cannot verify,
+							// after which every later row carrying that hash compares
+							// equal and is skipped. Permanently. Recording nothing keeps
+							// the note eligible for a real, proof-carrying converge.
+							//
+							// `isUnconvergedEmptyPlaceholder` is where the safety lives —
+							// see its contract for why an empty file is NOT on its own
+							// sufficient license to write.
+							rlog().info(
+								"pull",
+								`CRDT catch-up: filling empty placeholder from row ${noteRef(change.path)}`,
+							);
+							// A staged episode from an earlier pass is now superseded: its
+							// STEP2 would commit an OLDER serverHash/version/seq over what
+							// this row just materialized, walking `seq` backward and
+							// re-serving rows already consumed. `commitCrdtConvergence` is
+							// a no-op with nothing staged.
+							this.pendingConvergence.delete(noteId);
+							this.crdtRehandshakeAttempts.delete(noteId);
+							if (!(await this.flushFromCrdt(normalized, content))) return false;
+							// Same feed, same proof (#339): a row off the server's own
+							// op-log is the server telling us it holds this note. Merges
+							// (never replaces), so the placeholder's head survives.
+							this.markServerKnown(normalized);
+							// This leg WROTE the body to disk — report it (contract:
+							// "true when a file was actually created, modified…").
+							return true;
+						} else if (noteId) {
 							// CRDT-enrolled COLD note — nobody has this open in an
 							// editor. It still needs the server's Yjs ops (never the
 							// feed's plaintext `content`: that snapshot is
@@ -8519,43 +8614,12 @@ export class SyncEngine {
 								change.content_hash,
 							);
 						} else {
-							// Backfill from the row's own snapshot. Two callers land here,
-							// both holding nothing on disk a converge could protect:
-							//
-							// 1. No note_id (legacy GET /notes/changes path — no id to pull
-							//    a CRDT delta for), unchanged from before.
-							// 2. #477: disk holds a 0-BYTE file AND this row carries a
-							//    body. The discovery leg above materializes a content-less
-							//    create row as an EMPTY file (measured: 20 of 150 notes on
-							//    a bulk first sync, every one from a v=1 row whose
-							//    content_hash is the empty-content hash). The row carrying
-							//    the real body then reads as "diverged cold", and each such
-							//    note paid a `crdt_doc_state` round-trip — plus a room
-							//    whenever that read fell back — to fetch a body this very
-							//    row already carries.
-							//
-							//    BOTH halves of that condition are load-bearing. With an
-							//    EMPTY row, `flushFromCrdt` short-circuits on "disk already
-							//    holds this content" and writes nothing, so this leg would
-							//    stamp serverHash + seq for a note whose disk stayed empty.
-							//    If such a row were a checkpoint-lagged projection (fresh
-							//    hash, stale bytes — the test_82 "went deaf on the stale
-							//    bytes" class), the note is recorded in sync while empty and
-							//    every later catch-up compares equal and skips it,
-							//    permanently. An empty row keeps the converge, whose commit
-							//    records only on proof.
-							//
-							// Writing the snapshot here does NOT reopen the D2 stomp class
-							// the cold leg guards against: that guard protects CONTENT ON
-							// DISK from a checkpoint-lagged projection, and an empty file
-							// has none. A genuine local blanking never reaches this line —
-							// it trips `localDiverged` above and takes the drift-copy
-							// branch, which preserves the local edit. This is the same
-							// write the discovery leg performs one pass earlier, for the
-							// same reason: the feed already carries the authoritative body.
+							// No note_id (legacy GET /notes/changes path — no id to pull
+							// a CRDT delta for): fall back to the content-snapshot
+							// backfill, unchanged from before.
 							rlog().warn(
 								"pull",
-								`CRDT catch-up: pull backfilling diverged note (${noteId ? "empty local file" : "no note_id"}) ${noteRef(change.path)}`,
+								`CRDT catch-up: pull backfilling diverged note (no note_id) ${noteRef(change.path)}`,
 							);
 							// Gate the bookkeeping on the write, same as the discovery
 							// branch. Stamping a hash for content that never reached disk
@@ -8580,13 +8644,10 @@ export class SyncEngine {
 							//
 							// AFTER the stamp, not before: `stampSyncedRow` REPLACES the
 							// row by contract, so a head set first is dropped by the very
-							// next line. That went unnoticed while only the legacy no-id
-							// leg reached here — `hasServerNote` is keyed by note_id, and
-							// a legacy note has none. A CRDT note with no head routes
-							// pushFile down the genesis branch and re-uploads a note it
-							// just downloaded (prod 2026-08-13, "122 files to upload" from
-							// an empty local vault), and holds its live crdt_msg sends
-							// (`canSendLive`).
+							// next line. Inert on this leg — it is reached only with no
+							// note_id, and `crdtHead` is only ever written by paths that
+							// have one — but the ordering is the correct one to copy, and
+							// the wrong one is silent.
 							this.markServerKnown(normalized);
 							// This leg WROTE the body to disk — report it (contract:
 							// "true when a file was actually created, modified…").

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -8489,7 +8489,7 @@ export class SyncEngine {
 								version: change.version,
 								serverHash: change.content_hash,
 							});
-						} else if (noteId && localNow !== "") {
+						} else if (noteId && !(localNow === "" && content !== "")) {
 							// CRDT-enrolled COLD note — nobody has this open in an
 							// editor. It still needs the server's Yjs ops (never the
 							// feed's plaintext `content`: that snapshot is
@@ -8524,14 +8524,26 @@ export class SyncEngine {
 							//
 							// 1. No note_id (legacy GET /notes/changes path — no id to pull
 							//    a CRDT delta for), unchanged from before.
-							// 2. #477: disk holds a 0-BYTE file. The discovery leg above
-							//    materializes a content-less create row as an EMPTY file
-							//    (measured: 20 of 150 notes on a bulk first sync, every one
-							//    from a v=1 row whose content_hash is the empty-content
-							//    hash). The row carrying the real body then reads as
-							//    "diverged cold", and each such note paid a `crdt_doc_state`
-							//    round-trip — plus a room whenever that read fell back — to
-							//    fetch a body this very row already carries.
+							// 2. #477: disk holds a 0-BYTE file AND this row carries a
+							//    body. The discovery leg above materializes a content-less
+							//    create row as an EMPTY file (measured: 20 of 150 notes on
+							//    a bulk first sync, every one from a v=1 row whose
+							//    content_hash is the empty-content hash). The row carrying
+							//    the real body then reads as "diverged cold", and each such
+							//    note paid a `crdt_doc_state` round-trip — plus a room
+							//    whenever that read fell back — to fetch a body this very
+							//    row already carries.
+							//
+							//    BOTH halves of that condition are load-bearing. With an
+							//    EMPTY row, `flushFromCrdt` short-circuits on "disk already
+							//    holds this content" and writes nothing, so this leg would
+							//    stamp serverHash + seq for a note whose disk stayed empty.
+							//    If such a row were a checkpoint-lagged projection (fresh
+							//    hash, stale bytes — the test_82 "went deaf on the stale
+							//    bytes" class), the note is recorded in sync while empty and
+							//    every later catch-up compares equal and skips it,
+							//    permanently. An empty row keeps the converge, whose commit
+							//    records only on proof.
 							//
 							// Writing the snapshot here does NOT reopen the D2 stomp class
 							// the cold leg guards against: that guard protects CONTENT ON
@@ -8557,15 +8569,25 @@ export class SyncEngine {
 							// same reason flushFromCrdt itself stopped returning true
 							// for a gate-blocked no-op.
 							if (!(await this.flushFromCrdt(normalized, content))) return false;
-							// Same feed, same proof (#339): a backfilled row is still the
-							// server telling us it holds this note.
-							this.markServerKnown(normalized);
 							this.stampSyncedRow(normalized, {
 								hash: fnv1a(content),
 								version: change.version,
 								serverHash: change.content_hash,
 								seq: change.seq,
 							});
+							// Same feed, same proof (#339): a backfilled row is still the
+							// server telling us it holds this note.
+							//
+							// AFTER the stamp, not before: `stampSyncedRow` REPLACES the
+							// row by contract, so a head set first is dropped by the very
+							// next line. That went unnoticed while only the legacy no-id
+							// leg reached here — `hasServerNote` is keyed by note_id, and
+							// a legacy note has none. A CRDT note with no head routes
+							// pushFile down the genesis branch and re-uploads a note it
+							// just downloaded (prod 2026-08-13, "122 files to upload" from
+							// an empty local vault), and holds its live crdt_msg sends
+							// (`canSendLive`).
+							this.markServerKnown(normalized);
 							// This leg WROTE the body to disk — report it (contract:
 							// "true when a file was actually created, modified…").
 							return true;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -8489,7 +8489,7 @@ export class SyncEngine {
 								version: change.version,
 								serverHash: change.content_hash,
 							});
-						} else if (noteId) {
+						} else if (noteId && localNow !== "") {
 							// CRDT-enrolled COLD note — nobody has this open in an
 							// editor. It still needs the server's Yjs ops (never the
 							// feed's plaintext `content`: that snapshot is
@@ -8519,12 +8519,31 @@ export class SyncEngine {
 								change.content_hash,
 							);
 						} else {
-							// No note_id (legacy GET /notes/changes path — no id to pull
-							// a CRDT delta for): fall back to the content-snapshot
-							// backfill, unchanged from before.
+							// Backfill from the row's own snapshot. Two callers land here,
+							// both holding nothing on disk a converge could protect:
+							//
+							// 1. No note_id (legacy GET /notes/changes path — no id to pull
+							//    a CRDT delta for), unchanged from before.
+							// 2. #477: disk holds a 0-BYTE file. The discovery leg above
+							//    materializes a content-less create row as an EMPTY file
+							//    (measured: 20 of 150 notes on a bulk first sync, every one
+							//    from a v=1 row whose content_hash is the empty-content
+							//    hash). The row carrying the real body then reads as
+							//    "diverged cold", and each such note paid a `crdt_doc_state`
+							//    round-trip — plus a room whenever that read fell back — to
+							//    fetch a body this very row already carries.
+							//
+							// Writing the snapshot here does NOT reopen the D2 stomp class
+							// the cold leg guards against: that guard protects CONTENT ON
+							// DISK from a checkpoint-lagged projection, and an empty file
+							// has none. A genuine local blanking never reaches this line —
+							// it trips `localDiverged` above and takes the drift-copy
+							// branch, which preserves the local edit. This is the same
+							// write the discovery leg performs one pass earlier, for the
+							// same reason: the feed already carries the authoritative body.
 							rlog().warn(
 								"pull",
-								`CRDT catch-up: pull backfilling diverged note (no note_id) ${noteRef(change.path)}`,
+								`CRDT catch-up: pull backfilling diverged note (${noteId ? "empty local file" : "no note_id"}) ${noteRef(change.path)}`,
 							);
 							// Gate the bookkeeping on the write, same as the discovery
 							// branch. Stamping a hash for content that never reached disk

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -20,7 +20,7 @@ import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { NoteIdMap } from "../src/crdt/note-id-map";
-import { fnv1a, SyncEngine } from "../src/sync";
+import { CRDT_HEAD_CREATED, fnv1a, SyncEngine } from "../src/sync";
 import { DEFAULT_SETTINGS } from "../src/types";
 
 const mockApi = {
@@ -54,6 +54,7 @@ const mockApp = {
 		trash: mock().mockResolvedValue(undefined),
 		rename: mock().mockResolvedValue(undefined),
 		getName: mock().mockReturnValue("Test Vault"),
+		adapter: { read: mock().mockResolvedValue("") },
 	},
 	fileManager: { trashFile: mock().mockResolvedValue(undefined) },
 	workspace: { getActiveViewOfType: mock().mockReturnValue(null) },
@@ -91,6 +92,7 @@ beforeEach(() => {
 		.mockReturnValue(null);
 	(mockApp.vault.create as ReturnType<typeof mock>).mockReset().mockResolvedValue(undefined);
 	(mockApp.vault.cachedRead as ReturnType<typeof mock>).mockReset().mockResolvedValue("body");
+	(mockApp.vault.adapter.read as ReturnType<typeof mock>).mockReset().mockResolvedValue("");
 	(mockApp.vault.modify as ReturnType<typeof mock>).mockReset().mockResolvedValue(undefined);
 	(mockApp.vault.process as ReturnType<typeof mock>)
 		.mockReset()
@@ -305,55 +307,151 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		expect(mockApp.vault.modify).not.toHaveBeenCalled();
 	});
 
-	test("#477: EMPTY local placeholder + a row that carries the body — backfill from the row, no converge at all", async () => {
+	/** The #477 shape: a 0-byte placeholder this device wrote from a
+	 *  content-less create row (so `crdtHead` is the CREATED sentinel and no
+	 *  serverHash was ever recorded), with disk empty through BOTH readers. */
+	function emptyPlaceholder(overrides: { adapterRead?: string } = {}) {
+		const made = crdtEngine();
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		mockApp.vault.cachedRead.mockResolvedValue("");
+		mockApp.vault.adapter.read.mockResolvedValue(overrides.adapterRead ?? "");
+		made.engine.importSyncState({
+			"owned.md": { hash: fnv1a(""), crdtHead: CRDT_HEAD_CREATED },
+		});
+		return { ...made, localFile };
+	}
+
+	const BODY = "the body the create row never carried";
+	const bodyRow = {
+		path: "owned.md",
+		action: "upsert",
+		content: BODY,
+		content_hash: "new-hash",
+		version: 2,
+		seq: 12,
+		mtime: 50,
+	};
+
+	test("#477: EMPTY placeholder + a row that carries the body — fill it from the row, no converge at all", async () => {
 		// Measured on a 150-note bulk first sync (2026-08-26): the discovery leg
 		// materializes a content-less v=1 create row as a 0-BYTE file, and the
 		// row that later carries the real body then reads as "diverged cold" —
 		// paying a crdt_doc_state round-trip (and a room whenever that read
 		// falls back) to fetch a body the row itself already carries.
-		// Disk holds NOTHING, so there is no local content a converge could
-		// protect: write the body, exactly as the discovery leg does one pass
-		// earlier. A genuine local blanking never reaches here — it trips
-		// localDiverged above and takes the drift-copy branch.
-		const { engine, enroll, reset, applyRemoteUpdate } = crdtEngine();
+		const { engine, enroll, reset, applyRemoteUpdate, localFile } = emptyPlaceholder();
 		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree");
-		const localFile = new TFile("owned.md");
-		mockApp.vault.getFileByPath.mockReturnValue(localFile);
-		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
-		mockApp.vault.cachedRead.mockResolvedValue("");
-		// The baseline recorded when the empty placeholder was written.
-		engine.importSyncState({
-			"owned.md": { hash: fnv1a(""), version: 1, serverHash: "empty-row-hash" },
-		});
 
-		await engine.applyChange({
-			path: "owned.md",
-			action: "upsert",
-			content: "the body the create row never carried",
-			content_hash: "new-hash",
-			version: 2,
-			seq: 12,
-			mtime: 50,
-		} as any);
+		await engine.applyChange(bodyRow as any);
 
 		expect(coldConverge).not.toHaveBeenCalled();
 		expect(enroll).not.toHaveBeenCalled();
 		expect(reset).not.toHaveBeenCalled();
 		expect(applyRemoteUpdate).not.toHaveBeenCalled();
-		expect(mockApp.vault.modify).toHaveBeenCalledWith(
-			localFile,
-			"the body the create row never carried",
-		);
+		expect(mockApp.vault.modify).toHaveBeenCalledWith(localFile, BODY);
+		// Bookkeeping is IDENTICAL to the discovery leg's, and that is the
+		// safety property: a row can lag its own content_hash, so recording
+		// that hash would mark the note in sync at bytes we cannot verify and
+		// every later row carrying it would compare equal and be skipped.
 		const state = engine.exportSyncState()["owned.md"];
-		expect(state?.serverHash).toBe("new-hash");
-		expect(state?.seq).toBe(12);
-		// The row came off the server's own op-log feed, so the server
-		// demonstrably holds this note (#339). Without the head, pushFile's
-		// routing takes the genesis branch and re-uploads a note it just
-		// downloaded — prod 2026-08-13, "122 files to upload" from an empty
-		// local vault. `stampSyncedRow` REPLACES the row by contract, so the
-		// head has to be (re)established after it, not before.
+		expect(state?.hash).toBe(fnv1a(BODY));
+		expect(state?.serverHash).toBeUndefined();
+		expect(state?.seq).toBeUndefined();
+		// The server demonstrably holds this note (#339) — without the head,
+		// pushFile takes the genesis branch and re-uploads what it just
+		// downloaded (prod 2026-08-13, "122 files to upload" from an empty vault).
 		expect(engine.hasServerNote("note-id-1")).toBe(true);
+	});
+
+	test("#477: a CONVERGED empty note is not a placeholder — a lagged row must not resurrect cleared content", async () => {
+		// A remote clear applied through flushFromCrdt calls recordCrdtBaseline(""),
+		// so stored.hash === fnv1a("") and localDiverged reads FALSE — the
+		// drift-copy escape hatch never fires. What separates this from a
+		// placeholder is the head: a converged note carries a REAL one.
+		const { engine, localFile } = emptyPlaceholder();
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree").mockImplementation(
+			async () => {},
+		);
+		engine.importSyncState({
+			"owned.md": { hash: fnv1a(""), crdtHead: "a-real-server-head" },
+		});
+
+		await engine.applyChange(bodyRow as any);
+
+		expect(coldConverge).toHaveBeenCalledTimes(1);
+		expect(mockApp.vault.modify).not.toHaveBeenCalledWith(localFile, BODY);
+	});
+
+	test("#477: undelivered local ops force the room — a snapshot write cannot carry them upward", async () => {
+		// Same precondition convergeColdNoteRoomFree enforces for crdt_doc_state,
+		// and for the same reason: this path is write-DOWN only, so a note with
+		// local work must take the bidirectional handshake.
+		const { engine, localFile } = emptyPlaceholder();
+		engine.setCrdtManager({
+			...((engine as any).crdt as any),
+			hasUndeliveredOps: () => true,
+		} as any);
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree").mockImplementation(
+			async () => {},
+		);
+
+		await engine.applyChange(bodyRow as any);
+
+		expect(coldConverge).toHaveBeenCalledTimes(1);
+		expect(mockApp.vault.modify).not.toHaveBeenCalledWith(localFile, BODY);
+	});
+
+	test("#477: a cachedRead that invents the emptiness does not license the overwrite", async () => {
+		// cachedRead right after a create is exactly where Obsidian's cache lies —
+		// proving the 0 bytes took adapter.read during the investigation, and a
+		// whole-file overwrite deserves the same proof.
+		const { engine, localFile } = emptyPlaceholder({ adapterRead: "content the cache missed" });
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree").mockImplementation(
+			async () => {},
+		);
+
+		await engine.applyChange(bodyRow as any);
+
+		expect(coldConverge).toHaveBeenCalledTimes(1);
+		expect(mockApp.vault.modify).not.toHaveBeenCalledWith(localFile, BODY);
+	});
+
+	test("#477: an unreadable file converges rather than guessing — the room is always correct", async () => {
+		const { engine, localFile } = emptyPlaceholder();
+		mockApp.vault.adapter.read.mockRejectedValue(new Error("EIO"));
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree").mockImplementation(
+			async () => {},
+		);
+
+		await engine.applyChange(bodyRow as any);
+
+		expect(coldConverge).toHaveBeenCalledTimes(1);
+		expect(mockApp.vault.modify).not.toHaveBeenCalledWith(localFile, BODY);
+	});
+
+	test("#477: a superseded staged episode is dropped — its STEP2 must not patch older bookkeeping back", async () => {
+		// Pass 1 staged an episode and fell back to a room; pass 2 fills the file
+		// from a NEWER row. commitCrdtConvergence has no text-verify gate, so a
+		// surviving stage would patch its older serverHash/version/seq over what
+		// this row just materialized — walking seq backward and re-serving rows
+		// already consumed.
+		const { engine } = emptyPlaceholder();
+		(engine as any).pendingConvergence.set("note-id-1", {
+			path: "owned.md",
+			serverHash: "older-hash",
+			content: null,
+			version: 1,
+			seq: 4,
+		});
+
+		await engine.applyChange(bodyRow as any);
+		await engine.commitCrdtConvergence("note-id-1");
+
+		const state = engine.exportSyncState()["owned.md"];
+		expect(state?.serverHash).toBeUndefined();
+		expect(state?.seq).toBeUndefined();
+		expect(state?.hash).toBe(fnv1a(BODY));
 	});
 
 	test("#477 adversarial: empty disk AND an empty row still CONVERGES — never stamp a note we wrote no byte to", async () => {

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -334,6 +334,53 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		mtime: 50,
 	};
 
+	test("#477 end-to-end: the DISCOVERY leg produces the state the fill leg requires", async () => {
+		// The load-bearing link, and the one every other #477 test assumes by
+		// hand-building `{hash: fnv1a(""), crdtHead: CRDT_HEAD_CREATED}` via
+		// importSyncState. Without this test, a change to what discovery records
+		// — a real head instead of the sentinel, or a serverHash — leaves all of
+		// them green while the fill leg silently stops firing forever. That is
+		// the same blind spot the room metric had: "0 rooms" was equally
+		// consistent with "it worked" and "it never ran".
+		const { engine } = crdtEngine();
+		const created = new TFile("owned.md");
+		// Nothing on disk yet: this is the discovery leg's own precondition.
+		mockApp.vault.getFileByPath.mockReturnValue(null);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+		// Pass 1 — the content-less v=1 create row off the op-log feed.
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "",
+			content_hash: "the-empty-content-hash",
+			version: 1,
+			seq: 1,
+			mtime: 10,
+		} as any);
+
+		expect(mockApp.vault.create).toHaveBeenCalledWith("owned.md", "");
+		// THE CONTRACT the fill leg depends on: a 0-byte file, the CREATED
+		// sentinel (never a real head), and no serverHash ever recorded.
+		const placeholder = engine.exportSyncState()["owned.md"];
+		expect(placeholder?.hash).toBe(fnv1a(""));
+		expect(placeholder?.crdtHead).toBe(CRDT_HEAD_CREATED);
+		expect(placeholder?.serverHash).toBeUndefined();
+
+		// Pass 2 — the row carrying the body, against the file pass 1 created.
+		mockApp.vault.getFileByPath.mockReturnValue(created);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(created);
+		mockApp.vault.cachedRead.mockResolvedValue("");
+		mockApp.vault.adapter.read.mockResolvedValue("");
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree");
+
+		await engine.applyChange(bodyRow as any);
+
+		expect(coldConverge).not.toHaveBeenCalled();
+		expect(mockApp.vault.modify).toHaveBeenCalledWith(created, BODY);
+		expect(engine.exportSyncState()["owned.md"]?.hash).toBe(fnv1a(BODY));
+	});
+
 	test("#477: EMPTY placeholder + a row that carries the body — fill it from the row, no converge at all", async () => {
 		// Measured on a 150-note bulk first sync (2026-08-26): the discovery leg
 		// materializes a content-less v=1 create row as a 0-BYTE file, and the

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -16,7 +16,7 @@
  *    (30s TTL, already fetched for the destructive-op guard) against the last
  *    synced serverHash; mismatch forces a fresh CRDT handshake (reset+enroll).
  */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { TFile } from "obsidian";
 import type { EngramApi } from "../src/api";
 import { NoteIdMap } from "../src/crdt/note-id-map";
@@ -303,6 +303,50 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		// identical/diverged branches consume it properly.
 		expect(state?.seq).toBeUndefined();
 		expect(mockApp.vault.modify).not.toHaveBeenCalled();
+	});
+
+	test("#477: EMPTY local placeholder + a row that carries the body — backfill from the row, no converge at all", async () => {
+		// Measured on a 150-note bulk first sync (2026-08-26): the discovery leg
+		// materializes a content-less v=1 create row as a 0-BYTE file, and the
+		// row that later carries the real body then reads as "diverged cold" —
+		// paying a crdt_doc_state round-trip (and a room whenever that read
+		// falls back) to fetch a body the row itself already carries.
+		// Disk holds NOTHING, so there is no local content a converge could
+		// protect: write the body, exactly as the discovery leg does one pass
+		// earlier. A genuine local blanking never reaches here — it trips
+		// localDiverged above and takes the drift-copy branch.
+		const { engine, enroll, reset, applyRemoteUpdate } = crdtEngine();
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree");
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		mockApp.vault.cachedRead.mockResolvedValue("");
+		// The baseline recorded when the empty placeholder was written.
+		engine.importSyncState({
+			"owned.md": { hash: fnv1a(""), version: 1, serverHash: "empty-row-hash" },
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "the body the create row never carried",
+			content_hash: "new-hash",
+			version: 2,
+			seq: 12,
+			mtime: 50,
+		} as any);
+
+		expect(coldConverge).not.toHaveBeenCalled();
+		expect(enroll).not.toHaveBeenCalled();
+		expect(reset).not.toHaveBeenCalled();
+		expect(applyRemoteUpdate).not.toHaveBeenCalled();
+		expect(mockApp.vault.modify).toHaveBeenCalledWith(
+			localFile,
+			"the body the create row never carried",
+		);
+		const state = engine.exportSyncState()["owned.md"];
+		expect(state?.serverHash).toBe("new-hash");
+		expect(state?.seq).toBe(12);
 	});
 
 	test("cold diverged leg issues ZERO REST calls — no getUpdates, no fetch (Phase E3 purge regression)", async () => {

--- a/tests/sync-catchup.test.ts
+++ b/tests/sync-catchup.test.ts
@@ -347,6 +347,60 @@ describe("pull un-masking — CRDT-owned local note must catch up from /changes"
 		const state = engine.exportSyncState()["owned.md"];
 		expect(state?.serverHash).toBe("new-hash");
 		expect(state?.seq).toBe(12);
+		// The row came off the server's own op-log feed, so the server
+		// demonstrably holds this note (#339). Without the head, pushFile's
+		// routing takes the genesis branch and re-uploads a note it just
+		// downloaded — prod 2026-08-13, "122 files to upload" from an empty
+		// local vault. `stampSyncedRow` REPLACES the row by contract, so the
+		// head has to be (re)established after it, not before.
+		expect(engine.hasServerNote("note-id-1")).toBe(true);
+	});
+
+	test("#477 adversarial: empty disk AND an empty row still CONVERGES — never stamp a note we wrote no byte to", async () => {
+		// The #477 backfill is only legal when the row can actually FILL the
+		// empty file. With both sides empty, flushFromCrdt short-circuits on
+		// "disk already holds this content" and writes nothing — so taking the
+		// backfill would record serverHash + seq for a note whose disk stayed
+		// empty. If that row were a checkpoint-lagged projection (fresh hash,
+		// stale/empty bytes — the test_82 "went deaf on the stale bytes" class),
+		// the note is stamped in-sync while empty and every later catch-up
+		// compares equal and skips it. Permanently. Converge instead.
+		const { engine } = crdtEngine();
+		const coldConverge = spyOn(engine as any, "convergeColdNoteRoomFree").mockImplementation(
+			async () => {},
+		);
+		const localFile = new TFile("owned.md");
+		mockApp.vault.getFileByPath.mockReturnValue(localFile);
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(localFile);
+		mockApp.vault.cachedRead.mockResolvedValue("");
+		// Baseline says we HELD content while disk reads empty, so neither the
+		// baseline-echo branch (which needs fnv1a(content) === stored.hash) nor
+		// localDiverged (which needs localNow !== content) fires — this is the
+		// state that actually reaches the leg under test.
+		engine.importSyncState({
+			"owned.md": {
+				hash: fnv1a("a body we no longer have"),
+				version: 1,
+				serverHash: "old-hash",
+			},
+		});
+
+		await engine.applyChange({
+			path: "owned.md",
+			action: "upsert",
+			content: "",
+			content_hash: "hash-that-claims-content",
+			version: 2,
+			seq: 12,
+			mtime: 50,
+		} as any);
+
+		expect(coldConverge).toHaveBeenCalledTimes(1);
+		// Nothing recorded: the converge's own commit is what records, once it
+		// has proof the doc holds the server's state.
+		const state = engine.exportSyncState()["owned.md"];
+		expect(state?.serverHash).toBe("old-hash");
+		expect(state?.seq).toBeUndefined();
 	});
 
 	test("cold diverged leg issues ZERO REST calls — no getUpdates, no fetch (Phase E3 purge regression)", async () => {


### PR DESCRIPTION
## Summary

- **What the defect is:** the discovery leg materializes a content-less `v=1` create row as a **0-byte file** (measured: 20 of 150 notes on a first sync). The row that later carries the body then reads as "diverged cold" and converges to fetch a body that very row already carries.
- **The fix:** fill the placeholder from the row it was waiting for — but only when the empty file provably *is* a placeholder, and recording nothing that cannot be verified.
- **Both benefits this PR originally claimed have now been measured, and neither survived.** See "What this is actually worth" — read that before merging.

### An empty file lies three ways

`isUnconvergedEmptyPlaceholder` exists to exclude each. Every one of these has a unit test that fails without its guard:

1. **The emptiness IS the converged state.** A remote clear applied via `flushFromCrdt` calls `recordCrdtBaseline("")`, so `stored.hash === fnv1a("")` and `localDiverged` reads FALSE — the drift-copy escape hatch never fires, and a checkpoint-lagged row carrying the pre-clear body would resurrect deleted content. `crdtHead` separates them: a converged note has a REAL head, a placeholder has only the `CRDT_HEAD_CREATED` sentinel.
2. **The doc holds local work.** `hasUndeliveredOps` — the same precondition `convergeColdNoteRoomFree` enforces, for the same reason: this path is write-down only and cannot carry ops upward.
3. **The cache invented it.** `localNow` is a `cachedRead`; proving the 0 bytes took `adapter.read` during the investigation, so a whole-file overwrite demands the same proof. A read failure converges instead.

### And it records nothing it cannot verify

The leg records exactly what the discovery leg records — `hash` + `markServerKnown`, no `serverHash`, no `seq`. A row can lag its own `content_hash` (the test_82 deaf-on-stale-bytes class); recording that hash marks the note in sync at bytes we cannot verify, after which every later row carrying it compares equal and is skipped. Permanently. It also drops any staged `pendingConvergence` episode, whose STEP2 would otherwise commit older bookkeeping over this row and walk `seq` backward.

The legacy no-`note_id` leg is restored to its original contract — it no longer serves CRDT notes.

### What this is actually worth

**Not room count.**

150-note bulk first sync, n=3 each:

| build | rooms |
|---|---|
| plain `main` | 1, 3, 1 |
| first cut (recorded `serverHash`) | 0, 0, 0 |
| this | 0, 3, 4, 3 |

**The consistent 0 came entirely from recording an unverifiable hash** — i.e. from suppressing all future convergence for those notes, which was the defect review caught. Once that stops, rooms are indistinguishable from `main`. The leg still fires (7-20 notes per 150, confirmed with a probe log); it moves the body one pass earlier rather than removing the converge.

**Not a visible empty-note window either.** I wrote a first-sync e2e asserting "B holds no 0-byte notes after its catch-up" and ran it against both builds: it passes on plain `main` too, twice. The cold converge fills the placeholder inside the same `trigger_full_sync()`, so the empty window is sub-pass, not a settled state — and no e2e oracle at this granularity separates the builds. The test was deleted rather than shipped; one that cannot fail reads as coverage.

**What is left:** ~13% of a first sync's notes stop paying a `crdt_doc_state` round-trip for a body the row already carried. That is the whole benefit. It is real but modest, and reviewers should weigh it against the added predicate.

Related correction: don't quote #477's 833/1,000 — `main` allocates ~1-3 per 150 because #474's room-free path already removed the bulk. That figure is pre-#474-shaped.

## Test plan

- [x] `bun test` — 2962 pass, 0 fail. Seven `#477` tests: the fill, one per excluded lie (converged clear, undelivered ops, lying cache, unreadable file), one for the superseded stage, and one tying the fill leg to what the **discovery leg actually produces** — without it, a change to discovery's bookkeeping leaves every other test green while the leg silently stops firing.
- [x] **Each guard verified load-bearing** — removed one at a time, confirmed the matching test goes red.
- [x] Leg confirmed to actually fire in e2e via a probe log (7/150), not merely "0 rooms".
- [x] `test_77` (n=4), `test_82`, `test_98`, `test_37`, `test_27_empty_note_sync` — pass
- [x] `tsc` + `biome check` clean

Local-stack caveats, both reproduced on plain `main`: attachment tests fail on a server-side MinIO `403 SignatureDoesNotMatch`, and `test_34_folder_rename_propagation` fails whenever it runs after `tests/crdt/` (passes solo in ~31 s).

Context doc: `docs/context/crdt-empty-placeholder-cold-rooms.md`, indexed in `CLAUDE.md`.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp
