### PR TITLE
feat(search): tell Free users which notes are outside the index cap

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -979,6 +979,7 @@ export default class EngramSyncPlugin extends Plugin {
 					this.api,
 					this.settings.searchDefaultMode,
 					this.persistSearchMode,
+					() => this.syncEngine?.getPlanState()?.indexedNotesCap ?? null,
 				),
 		);
 
@@ -991,6 +992,7 @@ export default class EngramSyncPlugin extends Plugin {
 					this.api,
 					this.settings.searchDefaultMode,
 					this.persistSearchMode,
+					() => this.syncEngine?.getPlanState()?.indexedNotesCap ?? null,
 				).open();
 			},
 		});

--- a/src/plan-state.ts
+++ b/src/plan-state.ts
@@ -3,6 +3,8 @@ export interface PlanState {
 	attachmentsTextOnly: boolean;
 	maxFileBytes: number;
 	attachmentBytesCap: number | null;
+	/** How many notes the plan indexes for search. null == uncapped. */
+	indexedNotesCap: number | null;
 	updatedAt: number;
 }
 
@@ -32,6 +34,13 @@ export function parsePlanState(raw: unknown, now: number): PlanState | null {
 		maxFileBytes: typeof r.max_file_bytes === "number" ? r.max_file_bytes : 0,
 		attachmentBytesCap:
 			typeof r.attachment_bytes_cap === "number" ? r.attachment_bytes_cap : null,
+		// Absent on a backend older than the free keyword-only tier → treat as
+		// uncapped, matching this file's "unknown plan → permissive" direction.
+		// A negative value is the backend's "unlimited" sentinel, not a cap of -1.
+		indexedNotesCap:
+			typeof r.indexed_notes_cap === "number" && r.indexed_notes_cap >= 0
+				? r.indexed_notes_cap
+				: null,
 		updatedAt: now,
 	};
 }

--- a/src/search-modal.ts
+++ b/src/search-modal.ts
@@ -10,6 +10,7 @@ export class SearchModal extends Modal {
 	private api: EngramApi;
 	private defaultMode: SearchMode;
 	private onModeChange: (mode: SearchMode) => void;
+	private indexedNotesCap?: () => number | null;
 	private panel: SearchPanel | null = null;
 
 	constructor(
@@ -17,11 +18,13 @@ export class SearchModal extends Modal {
 		api: EngramApi,
 		defaultMode: SearchMode,
 		onModeChange: (mode: SearchMode) => void,
+		indexedNotesCap?: () => number | null,
 	) {
 		super(app);
 		this.api = api;
 		this.defaultMode = defaultMode;
 		this.onModeChange = onModeChange;
+		this.indexedNotesCap = indexedNotesCap;
 	}
 
 	onOpen(): void {
@@ -34,6 +37,7 @@ export class SearchModal extends Modal {
 			{
 				defaultMode: this.defaultMode,
 				onModeChange: this.onModeChange,
+				indexedNotesCap: this.indexedNotesCap,
 				onResultOpened: () => this.close(),
 			},
 		);

--- a/src/search-ui.ts
+++ b/src/search-ui.ts
@@ -24,6 +24,30 @@ export interface SearchPanelOpts {
 	onModeChange?: (mode: SearchMode) => void;
 	/** Called after a result is opened (e.g. so the modal can close itself). */
 	onResultOpened?: () => void;
+	/** Current `indexed_notes_cap` from plan state, or null when uncapped.
+	 *  A getter, not a value: plan state arrives over the WebSocket and can
+	 *  change while the panel is open. */
+	indexedNotesCap?: () => number | null;
+}
+
+/**
+ * The "not everything is searchable" line, or null when it should stay quiet.
+ *
+ * Notes past the plan's indexed-note cap sync normally but are not searchable.
+ * Without this the only signal is an empty result list, which reads as "search
+ * is broken" rather than "this note isn't indexed" — and because the cap keeps
+ * the OLDEST notes, the ones that fall outside it are the user's newest work,
+ * which is the opposite of what anyone expects.
+ *
+ * Split out from the renderer because the panel only renders under Obsidian's
+ * HTMLElement extensions, which the unit suite does not have.
+ */
+export function capHintText(cap: number | null, total: number): string | null {
+	// null == uncapped plan. A negative value is the backend's "unlimited"
+	// sentinel, never a cap of -1.
+	if (cap === null || cap < 0) return null;
+	if (total <= cap) return null;
+	return `Searching ${cap.toLocaleString()} of ${total.toLocaleString()} notes. Upgrade to search everything.`;
 }
 
 export class SearchPanel {
@@ -343,12 +367,23 @@ export class SearchPanel {
 		}
 	}
 
+	private renderCapHint(): void {
+		const text = capHintText(
+			this.opts.indexedNotesCap?.() ?? null,
+			this.ctx.app.vault?.getMarkdownFiles?.().length ?? 0,
+		);
+		if (text === null) return;
+		this.resultsEl.createEl("p", { text, cls: "engram-search-cap-hint" });
+	}
+
 	private renderResults(query: string): void {
 		this.resultsEl.empty();
 		if (!this.results.length) {
 			this.resultsEl.createEl("p", { text: "No results found", cls: "engram-search-empty" });
+			this.renderCapHint();
 			return;
 		}
+		this.renderCapHint();
 		// Relative strength across the displayed set — drives the per-result bar.
 		const strengths = matchStrengths(this.results.map((r) => r.score));
 		this.results.forEach((result, i) => {

--- a/src/search-view.ts
+++ b/src/search-view.ts
@@ -13,6 +13,7 @@ export class SearchView extends ItemView {
 	private api: EngramApi;
 	private defaultMode: SearchMode;
 	private onModeChange: (mode: SearchMode) => void;
+	private indexedNotesCap?: () => number | null;
 	private panel: SearchPanel | null = null;
 
 	constructor(
@@ -20,11 +21,13 @@ export class SearchView extends ItemView {
 		api: EngramApi,
 		defaultMode: SearchMode,
 		onModeChange: (mode: SearchMode) => void,
+		indexedNotesCap?: () => number | null,
 	) {
 		super(leaf);
 		this.api = api;
 		this.defaultMode = defaultMode;
 		this.onModeChange = onModeChange;
+		this.indexedNotesCap = indexedNotesCap;
 	}
 
 	getViewType(): string {
@@ -48,6 +51,7 @@ export class SearchView extends ItemView {
 			{
 				defaultMode: this.defaultMode,
 				onModeChange: this.onModeChange,
+				indexedNotesCap: this.indexedNotesCap,
 			},
 		);
 	}

--- a/tests/plan-state.test.ts
+++ b/tests/plan-state.test.ts
@@ -111,3 +111,22 @@ describe("parsePlanState — attachments_all_types migration", () => {
 		expect(p?.attachmentsTextOnly).toBe(false);
 	});
 });
+
+describe("parsePlanState — indexed_notes_cap", () => {
+	test("reads a real cap", () => {
+		const p = parsePlanState({ tier: "free", indexed_notes_cap: 2000 }, 1);
+		expect(p?.indexedNotesCap).toBe(2000);
+	});
+
+	test("treats the -1 unlimited sentinel as uncapped", () => {
+		const p = parsePlanState({ tier: "pro", indexed_notes_cap: -1 }, 1);
+		expect(p?.indexedNotesCap).toBeNull();
+	});
+
+	test("treats an older backend (field absent) as uncapped", () => {
+		// Permissive on unknown, matching this module's existing direction —
+		// a stale plugin must not tell users their notes are unsearchable.
+		const p = parsePlanState({ tier: "starter" }, 1);
+		expect(p?.indexedNotesCap).toBeNull();
+	});
+});

--- a/tests/search-cap-hint.test.ts
+++ b/tests/search-cap-hint.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { capHintText } from "../src/search-ui";
+
+describe("capHintText", () => {
+	it("names both numbers when the vault exceeds the cap", () => {
+		// The whole point is specificity: "some notes aren't indexed" would not
+		// tell the user which ones, or that paying fixes it.
+		expect(capHintText(2000, 4312)).toBe(
+			"Searching 2,000 of 4,312 notes. Upgrade to search everything.",
+		);
+	});
+
+	it("stays quiet when every note is indexed", () => {
+		expect(capHintText(2000, 2000)).toBeNull();
+		expect(capHintText(2000, 812)).toBeNull();
+	});
+
+	it("stays quiet on an uncapped plan", () => {
+		expect(capHintText(null, 9999)).toBeNull();
+	});
+
+	it("treats a negative cap as unlimited, not as a cap of -1", () => {
+		// -1 is the backend's "unlimited" sentinel. Reading it as a literal cap
+		// would claim every note is unsearchable on the most permissive plan —
+		// the same inversion that made `attachments_text_only` block self-host
+		// attachments.
+		expect(capHintText(-1, 9999)).toBeNull();
+	});
+});


### PR DESCRIPTION
Plugin half of the Free keyword-only tier (engram-app/Engram#1478, PR engram-app/Engram#1486).

The Free tier indexes only a user's first N notes. The rest sync normally but are **not searchable** — and because the cap keeps the OLDEST notes, the ones outside it are the user's **newest work**. That's the opposite of what anyone expects, and without a signal the only symptom is an empty result list, which reads as "Engram's search is broken".

The search panel now shows, alongside results and on the empty state:

> Searching 2,000 of 4,312 notes. Upgrade to search everything.

## No new endpoint

The cap rides on the `plan_state` the backend already pushes over the WebSocket, and the plugin already knows its own vault size — so the "of 4,312" half needs nothing from the server. One new field, no new request, no polling.

## Two deliberate shapes

**`capHintText/2` is a pure exported function, not inline in the renderer.** `SearchPanel` only renders under Obsidian's `HTMLElement` extensions, which the unit suite does not have — `tests/search-ui.test.ts` self-skips for exactly this reason. Logic left in the renderer would have shipped untested.

**A negative cap parses to `null`, not to a literal cap of -1.** `-1` is the backend's "unlimited" sentinel. Reading it literally would tell users on the *most permissive* plan that none of their notes are searchable. This is the same inversion that made `attachments_text_only` block self-host attachments, and it already bit the backend side of this feature once during #1486 — so it's covered by a named test here.

An older backend that doesn't send the field reads as **uncapped**, matching this module's existing "unknown plan → permissive" direction: a stale plugin must never tell users their notes are unsearchable.

## Verification

- `bun test` — 2968 pass, 1 skip, 0 fail
- `bun run build` (tsc + esbuild) — clean
- `biome check` — clean
- New: `tests/search-cap-hint.test.ts` (4 cases incl. the -1 sentinel), plus 3 cases in `tests/plan-state.test.ts`

## Merge order

**Depends on engram-app/Engram#1486**, which adds the `indexed_notes_cap` limit key and the `plan_state` field. Merging this first is harmless — the field is absent, so the hint stays silent — but it does nothing until the backend lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTroEXqCfFBz6YyEtH5bEC