### PR TITLE
fix(push): don't drop a real edit when the mint is refused

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -4446,6 +4446,44 @@ export class SyncEngine {
 					// MINT REFUSAL (issue #972, e2e test_34) — see shouldDeferMint.
 					// Skip the push: the relocation/pull owns this path's fate.
 					if (this.shouldDeferMint(file.path)) {
+						// ...but "don't mint" is NOT "throw the edit away" (#1503). The
+						// guard fires on `unmapped + engine-flushed`, and a path can be
+						// transiently unmapped for reasons that have nothing to do with a
+						// relocation — a full sync rebuilding the map is the proven one
+						// (#1489). A real local edit landing in that window used to return
+						// here with no queue entry and no retry, so it survived only if an
+						// unrelated PushModified sweep happened to re-pick the file later.
+						// In CI that was 107s; with no sweep it is silent data loss.
+						//
+						// The two cases are separable by CONTENT. #972 is our own
+						// flushFromCrdt write echoing back: disk still holds exactly what
+						// the engine wrote, and the relocation evicted the baseline, so
+						// there is nothing to compare and nothing worth saving — the old
+						// path is dead and re-queueing it would resurrect the note the
+						// guard exists to suppress. A genuine edit is the opposite: the
+						// baseline SURVIVES and disk has moved off it. `hash` is already
+						// computed above, so this costs no extra read.
+						const stored = this.syncState.get(normalizePath(file.path));
+						const movedOffBaseline = stored?.hash !== undefined && stored.hash !== hash;
+						if (movedOffBaseline) {
+							rlog().warn(
+								"push",
+								`Mint refused but edit PRESERVED (unmapped path, local edit): ${noteRef(file.path)}`,
+							);
+							// Content-free, exactly like the retry-after-failure enqueue
+							// below: the body is re-read at flush time, by which point the
+							// map has settled and runFlushQueue re-resolves the id. Its own
+							// shouldDeferMint check keeps the entry queued if it has not.
+							await this.enqueueChange({
+								path: file.path,
+								action: "upsert",
+								kind: "note",
+								mtime: file.stat.mtime / 1000,
+								timestamp: Date.now(),
+								vaultId: this.settings.vaultId ?? undefined,
+							});
+							return false;
+						}
 						rlog().info(
 							"push",
 							`Mint refused (engine-flushed file, id relocated away): ${noteRef(file.path)}`,

--- a/tests/sync.test.ts
+++ b/tests/sync.test.ts
@@ -566,6 +566,48 @@ describe("SyncEngine.applySyncChange (apply behavior)", () => {
 
 		expect(mockApi.pushNote).not.toHaveBeenCalled();
 		expect(noteIdMap.get(oldPath)).toBeNull(); // no fresh mint
+		// Relocated away means the old path is DEAD — re-queueing it would
+		// resurrect exactly what #972 exists to prevent. Dropping is correct here.
+		expect(engine.queue.size).toBe(0);
+	});
+
+	test("a genuine edit on an engine-flushed UNMAPPED path is queued, not dropped (#1503)", async () => {
+		// Same guard, opposite case. `_confirm_room_free`'s trigger_full_sync
+		// leaves a path transiently unmapped; a real user edit landing in that
+		// window hits shouldDeferMint (unmapped + flushed) and used to
+		// `return false` with no retry and no queue entry. The edit then sat
+		// undelivered until an unrelated PushModified sweep happened to re-pick
+		// the file — 107s in the CI capture, and never in the worst case.
+		//
+		// The discriminator against #972 above: there the disk content is still
+		// exactly what the engine flushed (a pure echo of our own write, and the
+		// relocation evicted the baseline). Here the content has MOVED off the
+		// recorded baseline, which is proof of a real local edit.
+		const engine = createEngine();
+		const noteIdMap = new NoteIdMap();
+		engine.setNoteIdMap(noteIdMap);
+		const path = "E2E/Crdt/FanoutColdSend.md";
+
+		// Engine materializes the note and records its baseline.
+		noteIdMap.set(path, "id-true");
+		await engine.flushFromCrdt(path, "origin\n");
+
+		// A full sync transiently drops the path's mapping (#1489). The
+		// syncState baseline SURVIVES — this is not a relocation.
+		noteIdMap.delete(path);
+
+		// The user edits the note for real while the map is still unmapped.
+		const file = new TFile(path);
+		mockApp.vault.cachedRead.mockResolvedValue("origin\nCOLD_SEND_FROM_B\n");
+		await (engine as unknown as { pushFile(f: TFile): Promise<boolean> }).pushFile(file);
+
+		// Still no mint — the guard's job is intact.
+		expect(noteIdMap.get(path)).toBeNull();
+		// But the edit is NOT lost: it is queued for a retry that re-resolves
+		// the id once the map settles (runFlushQueue's own mint check).
+		expect(engine.queue.size).toBe(1);
+		const queued = engine.queue.all();
+		expect(queued[0]).toMatchObject({ path, action: "upsert", kind: "note" });
 	});
 
 	test("a CRDT-delivered note is trashed (not resurrected) when the server tombstones it", async () => {


### PR DESCRIPTION
Fixes the root cause of `engram-app/engram#1503` (p1, `test_cold_send_over_fanout_opens_no_room`, failing ~50% on backend main since Aug 28).

## The failure is a dropped SEND, not a broken fan-out

From the e2e debug artifact on run [33307044318](https://github.com/engram-app/engram/actions/runs/33307044318), note `n9` = `01a05242-dc6d-…`, device B = `b76e1809`, A = `95d7089e`:

```
10:42:03.586  B  [client:vault] modify path=E2E/Crdt/FanoutColdSend.md bytes=24
10:42:03.586  B  [client:push] Push start: n9 | type=note | active=1
10:42:03.586  B  [client:push] Mint refused (engine-flushed file, id relocated away): n9
                 ← 107 seconds, no server-side emit for this note ────────
10:43:50.614  -  sync broadcast emit ... note_yjs_update note_id=01a05242-dc6d-…
10:43:51.725  A  [client:vault] modify path=E2E/Crdt/FanoutColdSend.md bytes=24
10:43:52.396  B  [client:push] CRDT push ok: n9
```

B's edit never left the device. The server had nothing to fan out, which is why A saw nothing — A didn't drop a frame, no frame existed.

This rules out both hypotheses on the issue:

- **Not the FanoutPacer.** `@default_drain_interval_ms 100`, batch 20. A 107s gap is four orders of magnitude off a drain tick, and the pacer emitted other notes normally throughout the window.
- **Not a subscribe/emit ordering race on A.** The emit timestamps leave nothing to race. The `GET /api/notes/…` probe that pointed there was taken after the timeout, so it measured B's eventual retry, not the failure.

## Root cause

`shouldDeferMint` refuses a mint when a path is `unmapped + engine-flushed`, and `pushFile` returned `false` — no queue entry, no retry, no dirty mark. The edit survived only because an unrelated `PushModified` sweep re-picked the file 107s later. With no such sweep it is silent data loss.

A path can be transiently unmapped for reasons that have nothing to do with a relocation. The proven one is a full sync rebuilding the map, which is what `_confirm_room_free`'s `trigger_full_sync()` does one line before the write — and is separately filed as `engram-app/engram#1489` ("device never maps note_id after trigger_full_sync"). **#1503 and #1489 are the same bug from two angles**, and #1514 is already a confirmed duplicate of #1503.

Notably, the durable-replay path at the other `shouldDeferMint` call site already handles this correctly — it `continue`s, leaving the entry queued, with a comment saying the next flush re-resolves against the settled map. Only the live push path threw the edit away.

## Fix

The two cases separate by content:

| | #972 (relocation) | #1503 (transient) |
|---|---|---|
| disk content | still exactly what the engine flushed | moved off the baseline |
| `syncState` baseline | evicted by the relocation | survives |
| correct action | drop — the old path is dead, re-queueing resurrects it | preserve — it's a real edit |

`hash` is already computed above the guard, so the check costs no extra read. On a genuine edit, enqueue instead of dropping — content-free, matching the retry-after-failure enqueue below it. The body is re-read at flush time, when the map has settled and `runFlushQueue` re-resolves the id; its own `shouldDeferMint` keeps the entry queued if it hasn't.

## Tests

New test pins that a genuine edit on an unmapped engine-flushed path is queued rather than dropped; the existing #972 test gains an assertion that the relocation case still queues **nothing**.

Mutation-checked rather than assumed green: forcing the discriminator `true` breaks the #972 test, forcing it `false` breaks the new one.

`bun test` 3004 pass / 0 fail · `bun run build` (tsc + esbuild) clean · `biome check` clean · `lint:obsidian` clean.

## What this does not fix

The unmapped window itself (#1489). This makes a false positive cost latency instead of the edit; it does not stop the map from briefly emptying during a full sync. That's worth closing separately — but the silent-drop path was reachable by any user editing a recently-synced note at the wrong moment, independent of the cause.

Refs engram-app/engram#1503, engram-app/engram#1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp