### PR TITLE
fix(crdt): table-cell editor corruption + trim redundant sync status surfaces

### DIFF
--- a/docs/context/live-binding-table-cell-editor.md
+++ b/docs/context/live-binding-table-cell-editor.md
@@ -1,0 +1,69 @@
+# Context Doc: Live-binding attached to the table-cell editor — whole document adopted into one cell
+
+_Last verified: 2026-08-31_
+
+## Status
+Fixed (PR #487)
+
+## Symptom
+Click into a table cell in Live Preview. The entire note body is inserted into
+that cell, Obsidian freezes, and the corruption is written to disk and synced to
+the server. Reliably reproducible; hit in production on
+`30 Growth/Launch/Video 1 - Beta Invite Intro (script).md`, where six table rows
+each grew to ~17,900 characters holding the whole body with newlines serialized
+as `<br>`.
+
+## Mechanism
+`this.registerEditorExtension([liveBindingPlugin])` (`src/main.ts`) installs the
+binding into **every** CM6 `EditorView` Obsidian builds — not just the leaf's
+markdown editor.
+
+Obsidian's Live Preview table widget builds a nested `EditorView` per cell
+(`editor.tableCell.cm` in `app.js`) and constructs it with the **parent editor's
+`owner`**. `editorInfoField` inside a cell therefore resolves to the very same
+`MarkdownView`, carrying the very same `file.path`.
+
+The old `editorPath()` keyed only off that path, so the cell's `EditorView` bound
+to the whole note's `Y.Text`:
+
+1. `attach()` -> `resolveId(path)` -> `residentText(noteId)` = the full note body.
+2. `preEditText` = the **cell's** text; `dirtySinceAttach` = false.
+3. `decideReconcile(cellText, fullBody, false)` -> `adopt` — "the editor is stale
+   disk, the doc is authoritative".
+4. `paintEditor()` dispatches that diff into the cell, replacing a few words with
+   the entire document.
+5. Obsidian's table code round-trips the cell back into the real document, which
+   the sync engine then pushes.
+
+The freeze is downstream: a multi-KB cell forces a table rebuild, which the 3s
+drift check keeps re-triggering.
+
+## Fix
+`ownedMarkdownPath(view, info)` in `src/crdt/live/live-binding-decisions.ts`.
+Bind only when the `EditorView` **is** the owner's own editor:
+
+```ts
+if (!info || info.editor?.cm !== view) return null;
+```
+
+This is the guard Relay has always had (`LiveViews.ts findView`: `cm === cmEditor`),
+which is why Relay never had this bug. It covers every nested editor Obsidian
+builds off a parent owner, not just table cells.
+
+## Gotcha: construction-time null
+The `ViewPlugin` constructor runs **inside** `new EditorView(...)`, before
+Obsidian assigns `owner.editor.cm`. So `ownedMarkdownPath` returns null on the
+first `attach()` even for the real editor. That is fine and deliberate:
+`update()` re-resolves on every `ViewUpdate` and `needsReattach` fires on the
+null -> path transition, so the binding attaches on the first update (Obsidian's
+own file-load dispatch guarantees one). Do not "fix" this by weakening the check
+to a path comparison.
+
+## How to verify a change here
+`tests/crdt-live-binding-decisions.test.ts` -> `describe("ownedMarkdownPath")`
+covers the own-editor, inherited-cell-info, missing-file, non-markdown, and
+unassigned-`cm` cases. No CodeMirror mount needed.
+
+## Related
+- `crdt-editor-bind-race-pollution.md` — the other cross-file pollution class
+  (reused EditorView across a file switch). Different trigger, same blast radius.

--- a/src/crdt/live/live-binding-decisions.ts
+++ b/src/crdt/live/live-binding-decisions.ts
@@ -2,8 +2,39 @@
 // reconcile + re-attach logic is unit-testable without mounting a real CodeMirror
 // editor. The ViewPlugin (live-binding.ts) executes whatever these return.
 import { diff_match_patch } from "diff-match-patch";
+import { isMarkdownPath } from "../../file-kind";
 import { splitFrontmatter } from "../frontmatter-codec";
 import { type CmChangeSpec, textDiffToChangeSpec } from "./cm-yjs-bridge";
+
+/** The shape of Obsidian's `editorInfoField` that the binding actually reads. */
+export interface EditorOwnerInfo {
+	file?: { path?: string } | null;
+	editor?: { cm?: unknown };
+}
+
+/** The markdown path `view` is the note editor FOR, or null when it must not bind.
+ *
+ *  The identity check is the whole point. Obsidian registers plugin editor
+ *  extensions into EVERY CM6 EditorView it builds, and it builds the Live Preview
+ *  table-cell editor with the PARENT editor's `owner` — so `editorInfoField`
+ *  inside a cell resolves to the very same MarkdownView, with the very same file.
+ *  Keying off the path alone bound the cell's tiny EditorView to the whole note's
+ *  Y.Text; the initial reconcile then saw "editor is stale disk, doc is
+ *  authoritative", adopted the ENTIRE document into that one cell, and the table
+ *  round-tripped it into the file and out to the server. Only the view that IS the
+ *  owner's own editor is the note. (Relay guards the same way, via findView.)
+ *
+ *  Null while `owner.editor.cm` is still unassigned: the ViewPlugin constructor
+ *  runs inside `new EditorView(...)`, before Obsidian stores the reference. The
+ *  binding re-resolves on every update, so it attaches on the first ViewUpdate. */
+export function ownedMarkdownPath(
+	view: unknown,
+	info: EditorOwnerInfo | null | undefined,
+): string | null {
+	if (!info || info.editor?.cm !== view) return null;
+	const path = info.file?.path ?? null;
+	return path && isMarkdownPath(path) ? path : null;
+}
 
 /** A dedicated dmp instance for the 3-way merge, tuned MUCH stricter than the
  *  defaults (Match_Threshold 0.5 / Patch_DeleteThreshold 0.5). Fuzzy patching

--- a/src/crdt/live/live-binding.ts
+++ b/src/crdt/live/live-binding.ts
@@ -23,7 +23,6 @@ import { Annotation } from "@codemirror/state";
 import { type EditorView, type PluginValue, ViewPlugin, type ViewUpdate } from "@codemirror/view";
 import { editorInfoField } from "obsidian";
 import type * as Y from "yjs";
-import { isMarkdownPath } from "../../file-kind";
 import { noteRef } from "../../note-ref";
 import { rlog } from "../../remote-log";
 import {
@@ -36,9 +35,11 @@ import {
 import {
 	classifyEditSpan,
 	decideReconcile,
+	type EditorOwnerInfo,
 	fmCreationBodyDiff,
 	frontmatterPrefixLen,
 	needsReattach,
+	ownedMarkdownPath,
 } from "./live-binding-decisions";
 
 /** Interval for the drift backstop (Relay's DRIFT_CHECK_DELAY is 3000ms). */
@@ -77,11 +78,12 @@ export function setLiveBindingCoordinator(c: LiveBindingCoordinator | null): voi
 
 let viewSeq = 0;
 
-/** The markdown file path this editor currently shows, or null (non-md / no file). */
+/** The markdown file path this editor currently shows, or null when it is not the
+ *  leaf's own markdown editor (non-md, no file, or a nested editor such as the
+ *  Live Preview table cell — see ownedMarkdownPath). */
 function editorPath(editor: EditorView): string | null {
-	const info = editor.state.field(editorInfoField, false);
-	const path = info?.file?.path ?? null;
-	return path && isMarkdownPath(path) ? path : null;
+	const info = editor.state.field(editorInfoField, false) as EditorOwnerInfo | undefined;
+	return ownedMarkdownPath(editor, info);
 }
 
 class LiveBindingValue implements PluginValue {

--- a/src/sync-center-render.ts
+++ b/src/sync-center-render.ts
@@ -87,7 +87,6 @@ const QUEUED_REASON_TEXT: Record<QueuedReason, string> = {
 };
 
 function renderHeader(parent: HTMLElement, plugin: EngramSyncPlugin): void {
-	const header = parent.createDiv({ cls: "engram-sync-center-header" });
 	const status = plugin.syncEngine.getStatus();
 	const all = plugin.syncEngine.issues.all();
 	// Three independent buckets, one per disposition. Informational (plan-limit)
@@ -103,12 +102,16 @@ function renderHeader(parent: HTMLElement, plugin: EngramSyncPlugin): void {
 		(i) => issueDisposition(i.category, i.parseReason) === "transient",
 	).length;
 	const ignoredCount = plugin.syncEngine.ignoredFiles.size();
+	// Say WHY the queue is holding rather than leaving a bare count that reads
+	// as a hang. "waiting" is the case that previously showed an unexplained
+	// spinner: online, unblocked, nothing in flight, work still sitting there.
+	const reason = plugin.syncEngine.queuedReason();
 
-	const dot = header.createSpan({ cls: `engram-sync-center-dot is-${status.state}` });
-	dot.setText("●");
+	// ponytail: badges only — the settings status strip above already shows
+	// state + last sync. Nothing to badge means no empty box.
+	if (!planSkipCount && !attentionCount && !retryingCount && !ignoredCount && !reason) return;
 
-	const title = header.createSpan({ cls: "engram-sync-center-title" });
-	title.setText(`Engram Sync — ${status.state}`);
+	const header = parent.createDiv({ cls: "engram-sync-center-header" });
 
 	if (planSkipCount > 0) {
 		const badge = header.createSpan({ cls: "engram-sync-center-plan-badge" });
@@ -127,10 +130,6 @@ function renderHeader(parent: HTMLElement, plugin: EngramSyncPlugin): void {
 		badge.setText(`${ignoredCount} ignored`);
 	}
 
-	// Say WHY the queue is holding rather than leaving a bare count that reads
-	// as a hang. "waiting" is the case that previously showed an unexplained
-	// spinner: online, unblocked, nothing in flight, work still sitting there.
-	const reason = plugin.syncEngine.queuedReason();
 	if (reason) {
 		const badge = header.createSpan({ cls: "engram-sync-center-queued-badge" });
 		badge.setText(`${status.queued} queued — ${QUEUED_REASON_TEXT[reason]}`);
@@ -577,18 +576,14 @@ function renderStats(parent: HTMLElement, plugin: EngramSyncPlugin): void {
 		else noteCount++;
 	}
 
-	const lastSync = plugin.syncEngine.getLastSync();
 	const vaultId = plugin.settings.vaultId;
 
+	// Static facts only. Live counters (last sync, socket, queue, issues,
+	// ignored) are already on the status strip and in their own sections.
 	addStat(grid, "Local notes", String(noteCount));
 	addStat(grid, "Local attachments", String(attCount));
 	addStat(grid, "Vault", plugin.app.vault.getName());
 	addStat(grid, "Vault ID", vaultId ? String(vaultId) : "—");
-	addStat(grid, "Last sync", lastSync ? formatRelative(new Date(lastSync).getTime()) : "never");
-	addStat(grid, "Live (WebSocket)", plugin.isLiveConnected() ? "connected" : "disconnected");
-	addStat(grid, "Pending in queue", String(plugin.syncEngine.queue.size));
-	addStat(grid, "Issues", String(plugin.syncEngine.issues.count()));
-	addStat(grid, "Ignored", String(plugin.syncEngine.ignoredFiles.size()));
 }
 
 function addStat(parent: HTMLElement, label: string, value: string): void {

--- a/src/tabs/advanced-tab.ts
+++ b/src/tabs/advanced-tab.ts
@@ -23,25 +23,6 @@ const PROBLEMATIC_DIRS = [
 export function renderAdvancedTab(ctx: TabContext): void {
 	const { containerEl, app, plugin, redisplay } = ctx;
 
-	// ── Sync behavior ──
-	new Setting(containerEl).setName("Sync behavior").setHeading();
-
-	new Setting(containerEl)
-		.setName("Debounce (ms)")
-		.setDesc("Delay after editing before pushing. Prevents flooding during typing.")
-		.addText((text) =>
-			text
-				.setPlaceholder("2000")
-				.setValue(String(plugin.settings.debounceMs))
-				.onChange(async (value) => {
-					const num = Number.parseInt(value, 10);
-					if (!Number.isNaN(num) && num >= 100) {
-						plugin.settings.debounceMs = num;
-						await plugin.saveSettings();
-					}
-				}),
-		);
-
 	// ── Ignore patterns ──
 	new Setting(containerEl).setName("Ignore patterns").setHeading();
 

--- a/styles.css
+++ b/styles.css
@@ -873,29 +873,6 @@ body.is-mobile .engram-support-buttons > a {
 	box-shadow: var(--shadow-s);
 }
 
-.engram-sync-center-dot {
-	font-size: 14px;
-	line-height: 1;
-}
-
-.engram-sync-center-dot.is-idle {
-	color: var(--color-green);
-}
-
-.engram-sync-center-dot.is-syncing {
-	color: var(--color-blue);
-}
-
-.engram-sync-center-dot.is-offline,
-.engram-sync-center-dot.is-error {
-	color: var(--color-red);
-}
-
-.engram-sync-center-title {
-	font-weight: 600;
-	flex: 1;
-}
-
 .engram-sync-center-issue-badge {
 	background: var(--background-modifier-error);
 	color: var(--text-on-accent);

--- a/tests/crdt-live-binding-decisions.test.ts
+++ b/tests/crdt-live-binding-decisions.test.ts
@@ -6,6 +6,7 @@ import {
 	fmCreationBodyDiff,
 	frontmatterPrefixLen,
 	needsReattach,
+	ownedMarkdownPath,
 } from "../src/crdt/live/live-binding-decisions";
 
 describe("frontmatterPrefixLen", () => {
@@ -316,3 +317,45 @@ function applyCm(
 	}
 	return out;
 }
+
+describe("ownedMarkdownPath", () => {
+	const file = { path: "Notes/table.md" };
+
+	it("returns the path for the leaf's OWN editor view", () => {
+		const view = { id: "main" };
+		const info = { file, editor: { cm: view } };
+		expect(ownedMarkdownPath(view, info)).toBe("Notes/table.md");
+	});
+
+	it("returns null inside a table-cell editor that inherited the parent's info", () => {
+		// Obsidian builds the Live Preview table-cell editor with the PARENT
+		// editor's owner, so editorInfoField resolves to the same MarkdownView and
+		// the same file — but info.editor.cm is still the OUTER view. Binding here
+		// adopted the whole note body into one cell.
+		const main = { id: "main" };
+		const cell = { id: "table-cell" };
+		const info = { file, editor: { cm: main } };
+		expect(ownedMarkdownPath(cell, info)).toBeNull();
+	});
+
+	it("returns null when the info field is absent or has no file", () => {
+		const view = { id: "main" };
+		expect(ownedMarkdownPath(view, null)).toBeNull();
+		expect(ownedMarkdownPath(view, undefined)).toBeNull();
+		expect(ownedMarkdownPath(view, { file: null, editor: { cm: view } })).toBeNull();
+	});
+
+	it("returns null for a non-markdown file", () => {
+		const view = { id: "main" };
+		const info = { file: { path: "board.canvas" }, editor: { cm: view } };
+		expect(ownedMarkdownPath(view, info)).toBeNull();
+	});
+
+	it("returns null while the owner's editor reference is not yet assigned", () => {
+		// The ViewPlugin constructor runs INSIDE `new EditorView(...)`, before
+		// Obsidian assigns `owner.editor.cm`. No bind now; update() re-attaches.
+		const view = { id: "main" };
+		expect(ownedMarkdownPath(view, { file, editor: undefined })).toBeNull();
+		expect(ownedMarkdownPath(view, { file, editor: { cm: undefined } })).toBeNull();
+	});
+});


### PR DESCRIPTION
## 1. Table-cell editor corruption (prod, reproducible)

Clicking a table cell in Live Preview inserted the **entire note body** into that
cell, froze Obsidian, and synced the corruption to the server.

`registerEditorExtension` installs the live binding into **every** CM6
`EditorView` Obsidian builds. The Live Preview table widget builds a nested
`EditorView` per cell (`editor.tableCell.cm`) and constructs it with the
**parent editor's `owner`** - so `editorInfoField` inside a cell resolves to the
same `MarkdownView` and the same `file.path`.

`editorPath()` keyed only off that path, so the cell's view bound to the whole
note's `Y.Text`. The initial reconcile then read "editor is stale disk, doc is
authoritative", took the `adopt` branch, and painted the entire document into the
cell - which Obsidian's table code round-tripped into the real file.

`ownedMarkdownPath()` binds only when the `EditorView` **is** the owner's own
editor (`info.editor.cm === view`). Same guard Relay's `findView` has always had,
which is why Relay never had this bug. Covers every nested editor built off a
parent owner, not just table cells.

Note the check is null at construction time (the `ViewPlugin` constructor runs
inside `new EditorView(...)`, before Obsidian assigns `owner.editor.cm`);
`update()` re-resolves and `needsReattach` fires on the null -> path transition,
so the real editor binds on its first `ViewUpdate`.

Prod evidence: `30 Growth/Launch/Video 1 - Beta Invite Intro (script).md` has six
table rows each grown to ~17,900 chars holding the whole body, newlines
serialized as `<br>`. **That file still needs repairing - this PR only stops it
happening again.**

Context doc: `docs/context/live-binding-table-cell-editor.md`.

## 2. Advanced tab: debounce control removed

The 2s modify debounce is an internal sync tuning knob, not a preference worth
exposing. `debounceMs` stays in settings at its 2000 default (sync.ts still reads
it, ~60 tests still set it) - only the text field and its now-empty "Sync
behavior" heading are gone.

## 3. Sync Center: duplicate status readouts removed

The tab showed connection state twice - the settings status strip at the top of
the pane, and the Sync Center header's own dot + `Engram Sync - <state>` line.
The header is badges only now (plan-skip / needs-attention / retrying / ignored /
queued-reason), and it does not render at all when there is nothing to badge.

Same reasoning drops five live counters from Stats: Last sync, Live (WebSocket),
Pending in queue, Issues, Ignored. Each is on the status strip or has its own
section directly above it. Stats is static vault facts now: Local notes, Local
attachments, Vault, Vault ID.

## Verification

- `bun run build` clean (tsc + esbuild)
- `bun test` 3012 pass, 1 skip, 0 fail
- biome clean
- New coverage: `tests/crdt-live-binding-decisions.test.ts` -> `describe("ownedMarkdownPath")`, 5 cases (own editor, inherited cell info, missing file, non-markdown, unassigned `cm`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTroEXqCfFBz6YyEtH5bEC
