### PR TITLE
fix(crdt): a tombstoned id must not start a reconcile

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1066,6 +1066,22 @@ export class SyncEngine {
 		// run that while the sync gate is closed. Callers may also gate for
 		// their own reasons, but safety must not depend on them remembering.
 		if (this.syncBlocked) return;
+		// Same rule, second trigger (#491): a note THIS device just deleted is
+		// not map drift. `note_not_found` for a tombstoned id is the server
+		// answering CORRECTLY — the row is gone because we removed it — and the
+		// frame that provokes it is routine (a still-bound editor's in-flight
+		// crdt_msg, which also throws NoteDestroyedError once teardownCrdtDoc
+		// has run). Reconciling on it spends a whole-vault manifest sweep that
+		// MOVES files (set → onRelocate → renameFollowingIdentity) and TRASHES
+		// them (sweepPendingOrphans) to answer a question we already know the
+		// answer to. Users saw a note flash into existence and delete itself.
+		//
+		// The delete unmaps the id, so the `pathForId` early return below stops
+		// covering exactly the ids that need covering — this must come first.
+		// `applyLiveOpWithSeq`'s fan-out path already gates on the same
+		// tombstone, by the same key, before it calls this; the check belongs
+		// HERE so no caller has to remember (see the gate note above).
+		if (this.recentlyDeleted.has(noteId)) return;
 		if (this.noteIdMap.pathForId(noteId) !== null) return; // already mapped
 		if (this.idMapReconcileInflight) {
 			this.idMapReconcileQueued = true;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1021,6 +1021,19 @@ export class SyncEngine {
 		const manifestPaths = new Set(manifest.notes.map((n) => n.path));
 		for (const note of manifest.notes) {
 			if (!note.id) continue; // pre-T3.6 backend omitted id — cannot map it
+			// A note THIS device just deleted must not be re-mapped, however this
+			// reconcile was reached. `ensureNoteIdMapped` skips tombstoned ids so
+			// a `note_not_found` costs no fetch, but the other three callers
+			// (wiring's stranded-flush drain, main's cold-start and manual
+			// reconciles) come straight here — and a manifest fetched inside the
+			// delete-wins window still lists the note, because the delete has not
+			// landed or the snapshot predates it. Re-`set`ting it undoes
+			// `handleDelete`'s `release()`: `sweepPendingOrphans` then sees the
+			// path as locally claimed and skips it, and a later recreate at that
+			// path adopts the buried id through `getOrMint` instead of minting.
+			// Reconciling ANY id against a snapshot older than our own delete is
+			// the engine believing stale news over a fact it authored (#491).
+			if (this.recentlyDeleted.has(note.id)) continue;
 			const localPath = this.noteIdMap.pathForId(note.id);
 			if (localPath === note.path) continue; // already correct — nothing to do
 			if (localPath !== null && !manifestPaths.has(localPath)) {
@@ -1078,9 +1091,13 @@ export class SyncEngine {
 		//
 		// The delete unmaps the id, so the `pathForId` early return below stops
 		// covering exactly the ids that need covering — this must come first.
-		// `applyLiveOpWithSeq`'s fan-out path already gates on the same
+		// `applyPushedNoteUpdate`'s fan-out path already gates on the same
 		// tombstone, by the same key, before it calls this; the check belongs
 		// HERE so no caller has to remember (see the gate note above).
+		//
+		// This one saves the pointless manifest FETCH. It is not the safety
+		// boundary — `reconcileNoteIdMapFromManifest` has three other callers
+		// and carries its own tombstone skip; see there.
 		if (this.recentlyDeleted.has(noteId)) return;
 		if (this.noteIdMap.pathForId(noteId) !== null) return; // already mapped
 		if (this.idMapReconcileInflight) {

--- a/tests/note-id-map-hygiene.test.ts
+++ b/tests/note-id-map-hygiene.test.ts
@@ -14,6 +14,12 @@
  * 3. ensureNoteIdMapped must be intrinsically gate-safe: its reconcile can
  *    reach sweepPendingOrphans (trashFile), so relying on every CALLER to
  *    check isSyncBlocked is fragile — the check belongs inside.
+ * 4. Same reason, second trigger (#491): a note THIS device just deleted must
+ *    not start a reconcile. The server answering note_not_found for a
+ *    tombstoned id is CORRECT, not map drift, and reconciling on it runs a
+ *    whole-vault manifest sweep that moves files (onRelocate →
+ *    renameFollowingIdentity) and trashes them (sweepPendingOrphans) — the
+ *    "note flashes into existence then deletes itself" report.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import type { EngramApi } from "../src/api";
@@ -186,5 +192,56 @@ describe("ensureNoteIdMapped is intrinsically gate-safe", () => {
 
 		expect(mockApi.getManifest).not.toHaveBeenCalled();
 		expect(map.pathForId("x-1")).toBeNull();
+	});
+
+	// #491. The delete unmaps the id, so the `pathForId !== null` early return
+	// stops covering it, and the id is exactly the one a still-bound editor's
+	// in-flight crdt_msg gets note_not_found for. Without a tombstone check the
+	// reconcile fires on every fast delete. Guarded here rather than at the
+	// wiring.ts caller for the same reason as the gate check above: the
+	// destructive work is inside, so the guard must be too.
+	test("does nothing for an id this device just deleted (tombstoned)", async () => {
+		const engine = createEngine();
+		const map = new NoteIdMap();
+		engine.setNoteIdMap(map);
+		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValue({
+			notes: [{ id: "dead-1", path: "Untitled.md", content_hash: "h" }],
+			attachments: [],
+			total_notes: 1,
+			total_attachments: 0,
+			change_seq: 1,
+		});
+		(mockApi.getManifest as ReturnType<typeof mock>).mockClear();
+
+		// The local delete: tombstone the id and drop its mapping, exactly as
+		// handleDelete does before the server round trip.
+		(engine as any).markRecentlyDeleted("dead-1", "Untitled.md");
+
+		// The server's note_not_found for the still-in-flight op lands here.
+		engine.ensureNoteIdMapped("dead-1");
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(mockApi.getManifest).not.toHaveBeenCalled();
+		expect(map.pathForId("dead-1")).toBeNull();
+	});
+
+	test("still reconciles an id with no tombstone (the drift case it exists for)", async () => {
+		const engine = createEngine();
+		const map = new NoteIdMap();
+		engine.setNoteIdMap(map);
+		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValue({
+			notes: [{ id: "live-1", path: "Live.md", content_hash: "h" }],
+			attachments: [],
+			total_notes: 1,
+			total_attachments: 0,
+			change_seq: 1,
+		});
+		(mockApi.getManifest as ReturnType<typeof mock>).mockClear();
+
+		engine.ensureNoteIdMapped("live-1");
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(mockApi.getManifest).toHaveBeenCalled();
+		expect(map.pathForId("live-1")).toBe("Live.md");
 	});
 });

--- a/tests/note-id-map-hygiene.test.ts
+++ b/tests/note-id-map-hygiene.test.ts
@@ -225,6 +225,38 @@ describe("ensureNoteIdMapped is intrinsically gate-safe", () => {
 		expect(map.pathForId("dead-1")).toBeNull();
 	});
 
+	// Review finding: the guard above only saves a fetch. The reconcile has
+	// three OTHER callers (wiring's stranded-flush drain, main's cold-start and
+	// manual reconciles) that reach the manifest loop without passing it, so the
+	// skip that actually protects data has to live in the loop.
+	test("the reconcile itself refuses to re-map a tombstoned id, however it was reached", async () => {
+		const engine = createEngine();
+		const map = new NoteIdMap();
+		engine.setNoteIdMap(map);
+		// A manifest fetched inside the delete-wins window still lists the note.
+		(mockApi.getManifest as ReturnType<typeof mock>).mockResolvedValue({
+			notes: [
+				{ id: "dead-2", path: "Untitled.md", content_hash: "h" },
+				{ id: "live-2", path: "Other.md", content_hash: "h" },
+			],
+			attachments: [],
+			total_notes: 2,
+			total_attachments: 0,
+			change_seq: 1,
+		});
+		(engine as any).markRecentlyDeleted("dead-2", "Untitled.md");
+
+		// Called directly, as main.ts and wiring.ts do — bypassing
+		// ensureNoteIdMapped's tombstone skip entirely.
+		await engine.reconcileNoteIdMapFromManifest();
+
+		// The deleted note stays unmapped: re-setting it would undo
+		// handleDelete's release() and let a recreate adopt the buried id.
+		expect(map.pathForId("dead-2")).toBeNull();
+		// ...and the rest of the manifest still reconciles normally.
+		expect(map.pathForId("live-2")).toBe("Other.md");
+	});
+
 	test("still reconciles an id with no tombstone (the drift case it exists for)", async () => {
 		const engine = createEngine();
 		const map = new NoteIdMap();


### PR DESCRIPTION
Closes #491.

## Symptom

After deleting a note, an `Untitled` document appears on its own for about a second, then deletes itself.

## Cause

1. Delete a note → the id is unmapped and `teardownCrdtDoc` destroys the Y.Doc.
2. A still-bound editor's in-flight `crdt_msg` reaches the server → `note_not_found`. (The same id throws `NoteDestroyedError` in the reading view — evidence the view outlives the teardown.)
3. `channel.ts:1242` → `wiring.ts:492` → `ensureNoteIdMapped(docId)`. Its `pathForId(id) !== null` early return no longer applies, because step 1 unmapped the id — so the full reconcile runs.
4. `reconcileNoteIdMapFromManifest` walks the whole manifest calling `noteIdMap.set(path, id)`, which fires `onRelocate` → `renameFollowingIdentity` — **a real file move on disk** — and ends in `sweepPendingOrphans()` → `trashFile`.

One reconcile both places a file and trashes one. `wiring.ts:490` already warned it could:

> `ensureNoteIdMapped` is NOT disk-write-free (its reconcile can reach `sweepPendingOrphans` → `trashFile`)

and `sync.ts:744` names the shape: *"That is the 'it deleted and remade my note' …"*

## Fix

`note_not_found` for a tombstoned id is not drift. One line, next to the existing `syncBlocked` gate:

```ts
if (this.recentlyDeleted.has(noteId)) return;
```

`applyLiveOpWithSeq`'s fan-out path (`sync.ts:6180`) already gates on this same tombstone, by the same key, before it calls `ensureNoteIdMapped`. The `note_not_found` path didn't. Putting the check inside rather than at the `wiring.ts` caller follows the rule that method already states for its gate check — the destructive work is in here, so safety must not depend on callers remembering.

## Evidence

Prod Loki, one device: 8 fresh ids took this path in 100 seconds while reproducing, against 3 in the preceding 21 hours.

## Gates

`tests/note-id-map-hygiene.test.ts` — the tombstoned id must not fetch the manifest, plus a control that an untombstoned id still reconciles (so the guard can't pass by disabling the feature). Mutation-proven: reverting the one line turns exactly one test red out of 3015.

## Not fixed here

The `NoteDestroyedError` burst is a separate bug — a reading view outliving `teardownCrdtDoc` and still pushing ops into a destroyed doc. That is what *generates* these frames; this PR stops them being destructive. Worth its own issue.

## Relationship to #490

Independent, and #490 need not merge first. #490 made this fire more often (deletes now actually land, so ids get unmapped), but the reconcile hazard predates it.