### PR TITLE
feat(crdt): deliver queued edits for idle notes without a room

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -638,6 +638,33 @@ export class NoteChannel {
 		};
 	}
 
+	/** ROOM-FREE delivery of this device's pending ops for an IDLE note (#1493) —
+	 *  the send half of the pair `crdtDocState` opened on the read side.
+	 *
+	 *  Every `crdt_msg` frame routes through the server's `ensure_room`,
+	 *  including a plain sync_update for a note nobody has open, so the durable
+	 *  queue's only delivery route (a full re-handshake per entry) allocated one
+	 *  room per queued note. A 1.4k-note flush put resident rooms at 314 against
+	 *  a cap of 64 in prod.
+	 *
+	 *  `b64` must be a `sync_update` message, NOT a syncStep1 — the server
+	 *  refuses a step1 here (`not_sync_update`) precisely because answering one
+	 *  would allocate the room this frame exists to avoid.
+	 *
+	 *  This is a WRITE, so unlike `crdtDocState` it needs no local precondition
+	 *  about undelivered work: a Yjs update carries our ops upward and the
+	 *  server merges. What it does NOT do is bring anything back — the down
+	 *  direction stays with catch-up + fan-out.
+	 *
+	 *  Callers fall back to the room re-handshake on ANY reject, including the
+	 *  `unmatched_topic`-shaped one from a backend too old to know the frame.
+	 *  Convergence is the invariant; the room saving is the optimization. */
+	async crdtDocUpdate(docId: string, b64: string): Promise<{ head: string }> {
+		return (await this.sendRequest("crdt_doc_update", { doc_id: docId, b64 })) as {
+			head: string;
+		};
+	}
+
 	/** Seq-ordered op-log page after `cursorSeq` (single-path catch-up). Each op
 	 *  carries FULL content (a SyncNoteChange or SyncAttachmentChange — the
 	 *  merged notes+attachments feed), so it is causally complete and can

--- a/src/main.ts
+++ b/src/main.ts
@@ -2499,6 +2499,16 @@ export default class EngramSyncPlugin extends Plugin {
 						}
 						return channel.crdtDocState(id);
 					},
+					// Room-free delivery of a queued edit for an IDLE note (#1493).
+					// Same vault guard, and it matters MORE here than on the read:
+					// a stale channel would apply this device's ops into the WRONG
+					// vault's note, which is a write, not a wasted fetch.
+					docUpdate: (id, b64) => {
+						if (channel.getVaultId() !== this.settings.vaultId) {
+							throw new Error("crdt_doc_update: channel vault mismatch");
+						}
+						return channel.crdtDocUpdate(id, b64);
+					},
 					// #1409: release the server's room as soon as this device is
 					// done with the note, instead of leaving it to the 5-minute
 					// idle drain. Same vault guard as the two above — releasing

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -341,6 +341,14 @@ const DOC_STATE_FRAME = "crdt_doc_state";
 /** Room-free full Yjs state for one note — see `CrdtChannel.crdtDocState`. */
 type CrdtDocStateFn = (docId: string) => Promise<{ b64: string; head: string }>;
 
+/** Socket frame name for the room-free doc WRITE, latched in
+ *  `unsupportedFrames` alongside the read. */
+const DOC_UPDATE_FRAME = "crdt_doc_update";
+
+/** Room-free delivery of this device's ops for one note — see
+ *  `CrdtChannel.crdtDocUpdate`. */
+type CrdtDocUpdateFn = (docId: string, b64: string) => Promise<{ head: string }>;
+
 /** Late-injection wiring for the CRDT stack (#376 prerequisite 2). main.ts
  *  wires these in stages — boot, channel join, teardown — each stage passing
  *  only its subset to `setCrdtPorts`. A key must be PRESENT in the patch to
@@ -376,6 +384,10 @@ export interface CrdtPorts {
 	 *  old to serve `crdt_doc_state`; callers fall back to the room
 	 *  handshake, so an unwired port costs rooms, never convergence. */
 	docState?: CrdtDocStateFn | null;
+	/** Room-FREE delivery of a queued edit for an IDLE note (#1493). Null on a
+	 *  backend too old to serve `crdt_doc_update`; the caller falls back to the
+	 *  room re-handshake, so an unwired port costs rooms, never delivery. */
+	docUpdate?: CrdtDocUpdateFn | null;
 	/** #1409: tell the server this device is done with a note's room, so its
 	 *  `auto_exit` can fire now instead of after the 5-minute idle drain. */
 	release?: ((docId: string) => void) | null;
@@ -657,6 +669,7 @@ export class SyncEngine {
 		if ("liveBound" in ports) this.isLiveBound = ports.liveBound ?? (() => false);
 		if ("catchupSince" in ports) this.crdtCatchupSince = ports.catchupSince ?? null;
 		if ("docState" in ports) this.crdtDocState = ports.docState ?? null;
+		if ("docUpdate" in ports) this.crdtDocUpdate = ports.docUpdate ?? null;
 		if ("release" in ports) this.crdtRelease = ports.release ?? null;
 	}
 
@@ -3127,6 +3140,96 @@ export class SyncEngine {
 		}
 	}
 
+	/** Deliver this device's pending ops for ONE queued note without allocating
+	 *  a server room (#1493) — the send-side twin of `convergeColdNoteRoomFree`.
+	 *
+	 *  The path it replaces is `socketConverge` -> `fireCrdtReHandshake`: reset +
+	 *  enroll fires a STEP1, the server answers `[STEP2, server-STEP1]`, and the
+	 *  client's reply to that second step carries the pending ops. That works,
+	 *  and every one of those STEP1s routes through the backend's `ensure_room`,
+	 *  so a durable-queue drain over a large vault asks for a room per note. Prod
+	 *  measured 314 resident against a cap of 64 on a 1.4k-note sync.
+	 *
+	 *  `crdt_doc_update` carries the same ops as a plain Yjs update and the
+	 *  server merges it into a doc owned by a short-lived applier, so no room is
+	 *  left behind. It sends the doc's FULL state rather than a delta: without a
+	 *  handshake we do not know the server's state vector, and a Yjs merge of
+	 *  full state is idempotent — larger on the wire, never wrong.
+	 *
+	 *  Unlike the READ twin this needs NO `hasUndeliveredOps` precondition. That
+	 *  gate exists because `crdt_doc_state` cannot carry anything upward; this
+	 *  frame is the upward direction, so holding local work is the reason to use
+	 *  it, not a reason to refuse.
+	 *
+	 *  Returns true only when the server ACKED the write — that ack is what
+	 *  licenses the dequeue, exactly as an inbound frame licenses it on the room
+	 *  path. ANY failure returns false and the caller re-handshakes; the room is
+	 *  always CORRECT, just more expensive. */
+	private async deliverQueuedOpsRoomFree(entry: {
+		path: string;
+		noteId?: string;
+	}): Promise<boolean> {
+		const noteId = entry.noteId;
+		const send = this.crdtDocUpdate;
+		if (!noteId || !send || this.unsupportedFrames.has(DOC_UPDATE_FRAME)) return false;
+		if (typeof this.crdt?.encodeStateAsUpdate !== "function") return false;
+
+		let frame: string;
+		try {
+			const state = await this.crdt.encodeStateAsUpdate(noteId);
+			// A doc's full state carries its history and tombstones, so it can
+			// dwarf the note's text. Same budget the genesis frame is held to
+			// rather than putting an unbounded frame on an 8 MB socket — an
+			// oversized note still delivers, it just pays for a room to do it.
+			if (state.byteLength > MAX_CRDT_NOTE_BYTES) return false;
+			frame = encodeUpdateFrame(state);
+		} catch (e) {
+			// Doc destroyed mid-encode, or an IndexedDB fault. The room path
+			// re-resolves the doc itself, so let it try.
+			devLog().log(
+				"crdt",
+				`room-free delivery: encode failed for ${entry.path} — ${errMsg(e)}`,
+			);
+			return false;
+		}
+
+		try {
+			await send(noteId, frame);
+			this.docUpdateTimeouts = 0;
+			return true;
+		} catch (e) {
+			this.noteDocUpdateFailure(e, entry.path);
+			return false;
+		}
+	}
+
+	/** Strike accounting for `crdt_doc_update`, mirroring `readServerDocState`.
+	 *
+	 *  A backend that predates the frame never answers, so without a latch every
+	 *  queued note pays a full request timeout before falling back — a slower
+	 *  drain than not having the feature at all. A TIMEOUT is the only signal
+	 *  that looks like an old backend; a structured reject (rate limit, unknown
+	 *  note, refused write) is a real answer from a server that DOES implement
+	 *  it and must never latch. It takes repeated strikes because a crashing
+	 *  channel is indistinguishable from an old backend here. */
+	private noteDocUpdateFailure(e: unknown, path: string): void {
+		const detail = errMsg(e, path);
+
+		if (/timeout/i.test(detail)) {
+			this.docUpdateTimeouts += 1;
+			if (this.docUpdateTimeouts >= SyncEngine.DOC_STATE_TIMEOUT_LATCH) {
+				this.unsupportedFrames.add(DOC_UPDATE_FRAME);
+				rlog().warn(
+					"crdt",
+					`crdt_doc_update went unanswered ${this.docUpdateTimeouts}x — disabling room-free ` +
+						`queue delivery for this session and falling back to the room handshake.`,
+				);
+			}
+		}
+
+		rlog().warn("queue", `Room-free delivery failed for ${noteRef(path)}: ${detail}`);
+	}
+
 	private async seedBodyAfterCreate(opts: {
 		effectiveId: string;
 		normalized: string;
@@ -5423,6 +5526,14 @@ export class SyncEngine {
 	/** Consecutive unanswered `crdt_doc_state` frames. Reset by any success, and
 	 *  by a vault change (a different vault can mean a different backend). */
 	private docStateTimeouts = 0;
+
+	private crdtDocUpdate: CrdtDocUpdateFn | null = null;
+
+	/** Consecutive unanswered `crdt_doc_update` frames. Counted SEPARATELY from
+	 *  the read's strikes: the two frames shipped in different releases, so a
+	 *  backend can serve one and not the other, and a shared counter would let
+	 *  the read's slow replies latch off the write (or the reverse). */
+	private docUpdateTimeouts = 0;
 
 	setCrdtCatchupSince(fn: CrdtCatchupSinceFn): void {
 		this.setCrdtPorts({ catchupSince: fn });
@@ -10434,6 +10545,27 @@ export class SyncEngine {
 						// it up. (A noteId-less crdt entry — ancient plugin versions —
 						// still falls through to the one-shot content replay below.)
 						if (this.crdt && (this.crdtLive?.() ?? false)) {
+							// Room-FREE first (#1493). This drain is what put 314 rooms
+							// resident against a cap of 64: one re-handshake per queued
+							// note, each allocating a server room for a note nobody has
+							// open. A LIVE-BOUND note keeps the handshake — it already
+							// has the room, so the round trip costs no extra residency,
+							// and its ops ride the live socket either way.
+							//
+							// The server's ack IS the delivery proof, so this leg
+							// dequeues inline rather than parking in
+							// `pendingQueueDeliveries` to wait for an inbound frame that
+							// a room-free write never produces.
+							if (
+								!this.isLiveBound(normalizePath(entry.path)) &&
+								(await this.deliverQueuedOpsRoomFree(entry))
+							) {
+								await this.queue.dequeue(entry.path, this.entryVaultId(entry));
+								this.issues.clear(entry.path);
+								flushed++;
+								continue;
+							}
+
 							this.pendingQueueDeliveries.set(entry.noteId, {
 								path: entry.path,
 								vaultId: this.entryVaultId(entry),

--- a/tests/source-compliance.test.ts
+++ b/tests/source-compliance.test.ts
@@ -437,6 +437,22 @@ describe("privacy — no content retention for export", () => {
 		const crdtCreateWireStatement =
 			/^asynccrdtCreate\(docId:string,path:string,b64\?:string\):Promise<CrdtCreateResult>\{constres=\(awaitthis\.sendRequest\("",\{doc_id:docId,path,\.\.\.\(b64===undefined\?\{\}:\{b64\}\),\}\)\)asCrdtCreateReply;$/;
 
+		// The FOURTH legitimate wire send (#1493): `NoteChannel.crdtDocUpdate`'s
+		// room-free delivery of a queued edit. Like `crdtCreate` it is a plain
+		// `sendRequest`, so it gets its own exact form for the same reason —
+		// widening `crdtCreateWireStatement` to cover both would exempt any
+		// `sendRequest` carrying a `b64`, which is most of what this check is
+		// for. Same "whole statement, literal text" principle: a wrapper around
+		// the payload, an extra argument or a reordering all stop matching.
+		//
+		// It ends at `as{head:string;` rather than a closing brace because the
+		// extractor slices to the next `;`, and the first one here is INSIDE the
+		// return type literal. Same reason `crdtCreateWireStatement` swallows a
+		// whole method signature: the forms are transcriptions of what the
+		// extractor actually produces, not of what the source looks like.
+		const crdtDocUpdateWireStatement =
+			/^asynccrdtDocUpdate\(docId:string,b64:string\):Promise<\{head:string\}>\{return\(awaitthis\.sendRequest\("",\{doc_id:docId,b64\}\)\)as\{head:string;$/;
+
 		const findings: Finding[] = [];
 		for (const f of sources) {
 			const stripped = stripCommentsAndStrings(f.text);
@@ -457,7 +473,8 @@ describe("privacy — no content retention for export", () => {
 					if (
 						!wireStatement.test(statement) &&
 						!indexWireStatement.test(statement) &&
-						!crdtCreateWireStatement.test(statement)
+						!crdtCreateWireStatement.test(statement) &&
+						!crdtDocUpdateWireStatement.test(statement)
 					) {
 						findings.push({
 							file: f.rel,

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -347,6 +347,143 @@ describe("channel-down CRDT edit routes through the durable queue, delivered ove
 });
 
 // ---------------------------------------------------------------------------
+// #1493: the drain above is correct and allocates a server room PER QUEUED
+// NOTE, because every `crdt_msg` routes through the backend's `ensure_room`.
+// A 1.4k-note flush put prod at 314 resident rooms against a cap of 64.
+// `crdt_doc_update` delivers the same ops without leaving a room behind.
+// ---------------------------------------------------------------------------
+describe("room-free queue delivery (#1493)", () => {
+	function queuedEngine(opts: {
+		docUpdate?: (docId: string, b64: string) => Promise<{ head: string }>;
+		liveBound?: (path: string) => boolean;
+		encode?: (noteId: string) => Promise<Uint8Array>;
+	}) {
+		const crdt = {
+			applyLocalEdit: async () => true,
+			encodeStateAsUpdate: opts.encode ?? (async () => new Uint8Array([1, 2, 3])),
+		};
+		const enroll = mock();
+		const reset = mock();
+		const e = engine({
+			api: {
+				pushNote: async () => {
+					throw new Error("must not legacy-push a crdt entry");
+				},
+			} as Partial<EngramApi>,
+			crdt,
+		});
+		e.setCrdtEnrollment({ enroll, reset } as any);
+		e.setCrdtLiveCheck(() => true);
+		e.setCrdtPorts({
+			...(opts.docUpdate ? { docUpdate: opts.docUpdate } : {}),
+			...(opts.liveBound ? { liveBound: opts.liveBound } : {}),
+		});
+		return { e, enroll, reset };
+	}
+
+	async function enqueueOne(e: SyncEngine, path = "T.md") {
+		await e.queue.enqueue({
+			path,
+			action: "upsert",
+			noteId: "id-1",
+			crdt: true,
+			timestamp: 1,
+			vaultId: "v",
+		});
+	}
+
+	test("an IDLE note delivers over crdt_doc_update, dequeues on the ack, and fires NO handshake", async () => {
+		const docUpdate = mock(async () => ({ head: "h1" }));
+		const { e, enroll, reset } = queuedEngine({ docUpdate });
+		await enqueueOne(e);
+
+		const flushed = await e.flushQueue();
+
+		expect(docUpdate).toHaveBeenCalledTimes(1);
+		expect(docUpdate.mock.calls[0]?.[0]).toBe("id-1");
+		// The ack IS the delivery proof — unlike the handshake path there is no
+		// inbound frame to wait for, so the entry settles inline.
+		expect(flushed).toBe(1);
+		expect(e.queue.size).toBe(0);
+		// THE assertion: no room was asked for.
+		expect(reset).not.toHaveBeenCalled();
+		expect(enroll).not.toHaveBeenCalled();
+	});
+
+	test("a LIVE-BOUND note keeps the handshake — its room already exists", async () => {
+		const docUpdate = mock(async () => ({ head: "h1" }));
+		const { e, enroll, reset } = queuedEngine({ docUpdate, liveBound: () => true });
+		await enqueueOne(e);
+
+		await e.flushQueue();
+
+		// Nothing is saved by going room-free on a note that already holds a
+		// room, and the handshake also pulls, so the live path stays as it was.
+		expect(docUpdate).not.toHaveBeenCalled();
+		expect(reset).toHaveBeenCalledWith("id-1");
+		expect(enroll).toHaveBeenCalledWith("id-1");
+	});
+
+	test("a REFUSED write falls back to the re-handshake and leaves the entry queued", async () => {
+		const docUpdate = mock(async () => {
+			throw new Error("rate_limited");
+		});
+		const { e, enroll, reset } = queuedEngine({ docUpdate });
+		await enqueueOne(e);
+
+		const flushed = await e.flushQueue();
+
+		// Convergence is the invariant; the room saving is the optimization.
+		expect(reset).toHaveBeenCalledWith("id-1");
+		expect(enroll).toHaveBeenCalledWith("id-1");
+		expect(flushed).toBe(0);
+		expect(e.queue.size).toBe(1);
+	});
+
+	test("an unwired port (backend too old) degrades straight to the handshake", async () => {
+		const { e, enroll, reset } = queuedEngine({});
+		await enqueueOne(e);
+
+		await e.flushQueue();
+
+		expect(reset).toHaveBeenCalledWith("id-1");
+		expect(enroll).toHaveBeenCalledWith("id-1");
+		expect(e.queue.size).toBe(1);
+	});
+
+	test("repeated TIMEOUTS latch the frame off, so an old backend is paid for twice, not once per note", async () => {
+		// Without the latch a backend that predates the frame costs a full
+		// request timeout on EVERY queued note — a slower drain than never
+		// having the feature.
+		const docUpdate = mock(async () => {
+			throw new Error("sendRequest timeout: crdt_doc_update");
+		});
+		const { e } = queuedEngine({ docUpdate });
+
+		for (const path of ["A.md", "B.md", "C.md", "D.md"]) {
+			await enqueueOne(e, path);
+			await e.flushQueue();
+		}
+
+		expect(docUpdate).toHaveBeenCalledTimes(2);
+	});
+
+	test("a rejected write must NOT dequeue — the edit is only durable while queued", async () => {
+		// The failure that matters: dequeuing on anything short of an ack loses
+		// the edit if the fallback handshake never round-trips.
+		const docUpdate = mock(async () => {
+			throw new Error("doc_update_failed");
+		});
+		const { e } = queuedEngine({ docUpdate });
+		await enqueueOne(e);
+
+		await e.flushQueue();
+
+		expect(e.queue.all().find((q) => q.path === "T.md")?.noteId).toBe("id-1");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Task 5 (folded into Task 3, same pushFile branch): a stale PRE-AWAIT
 // `crdtLive` snapshot must not decide live-vs-durable-queue. The channel can
 // drop DURING the awaited `routeModify` seed; pushFile must re-check liveness


### PR DESCRIPTION
Client half of engram-app/engram#1493. Pairs with backend PR engram-app/engram#1547 — **that one merges first**; this degrades to today's behaviour against a backend without the frame, so the order is about the feature working, not about safety.

## Why

The durable op-queue's only delivery route was a full re-handshake per entry: `reset` + `enroll` fires a STEP1, the server answers `[STEP2, server-STEP1]`, and the reply to that second step carries the pending ops.

That works. And every one of those STEP1s routes through the backend's `ensure_room`, so a 1.4k-note flush asked for a room per note — prod measured **314 resident against a cap of 64**.

Gating `fireCrdtReHandshake` is not available: it is the delivery path for idle notes' queued edits, so gating it strands them. What was missing was a route that delivers *without leaving a room behind*.

## How

`crdt_doc_update` carries the same ops as a plain Yjs update; the server merges them through a short-lived applier and no room survives.

It sends the doc's **full state**, not a delta — without a handshake we do not know the server's state vector, and a Yjs merge of full state is idempotent: larger on the wire, never wrong. Held to the same `MAX_CRDT_NOTE_BYTES` budget as the genesis frame, since full state carries history and tombstones and can dwarf the note's text.

Unlike the room-free **read**, this needs no `hasUndeliveredOps` precondition. That gate exists because `crdt_doc_state` cannot carry anything upward. This frame *is* the upward direction, so holding local work is the reason to use it, not a reason to refuse.

## The three rules that keep it safe

- **A live-bound note keeps the handshake.** It already has a room, so there is no residency to save, and the handshake also pulls.
- **The ack is the delivery proof.** This leg dequeues inline rather than parking in `pendingQueueDeliveries` waiting for an inbound frame that a room-free write never produces. Anything short of an ack leaves the entry queued — the edit is only durable while it is there.
- **Any reject falls back to the handshake.** Rate limit, unknown note, refused write, old backend: the room is always correct, merely more expensive. Convergence is the invariant; the room saving is the optimization.

Repeated **timeouts** latch the frame off for the session (same shape as `readServerDocState`), so a backend that predates it costs two request timeouts rather than one per queued note — otherwise the feature would drain slower than not having it. Strikes are counted separately from the read's: the two frames shipped in different releases, so a backend can serve one and not the other.

The `docUpdate` port carries the same vault-mismatch guard as `docState`, and it matters more here — a stale channel would apply this device's ops into the *wrong vault's* note, which is a write, not a wasted fetch.

## Note on the compliance lint

`tests/source-compliance.test.ts` pins every wire send carrying a `b64` as an exact whole-statement literal. This adds a fourth exemption, transcribed from what the extractor actually produces (it ends mid-type-literal, because the slice stops at the first `;`) rather than from what the source looks like. It will fail on any reformat of `crdtDocUpdate` — intended, but easy to misread as a flake.

## Test

New `room-free queue delivery (#1493)` block in `tests/sync-crdt-ops.test.ts`: an idle note delivers over the frame and fires no handshake, a live-bound note keeps the handshake, a refused write falls back and leaves the entry queued, an unwired port degrades straight to the handshake, repeated timeouts latch after two, and a rejected write never dequeues.

Full suite **3027 pass / 0 fail**; `tsc`, `biome check`, `bun run build` clean.

Refs engram-app/engram#1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp