### PR TITLE
fix(crdt): review follow-ups on room-free queue delivery

### DIFF
--- a/src/crdt/provider-registry.ts
+++ b/src/crdt/provider-registry.ts
@@ -587,8 +587,15 @@ export class ProviderRegistry {
 	}
 
 	// --- Synced bookkeeping -----------------------------------------------------
-	// The provider owns its own `synced` flag (set on syncStep2), so markSynced is
-	// a no-op kept for call-surface compatibility; isSynced reads the provider.
+	// `markSynced` is NOT the setter for `isSynced` and never has been, whatever
+	// the pairing suggests: `synced` is the provider's own flag, set on syncStep2,
+	// and `isSynced` reads it. What `markSynced` does is fire `onSynced` ->
+	// `commitCrdtConvergence`, which COMMITS a staged catch-up episode. That makes
+	// it valid only for a caller that has already APPLIED the server's state
+	// (`convergeColdNoteRoomFree`), and wrong for one that merely delivered its
+	// own (see the note at the room-free write in `sync.ts`). Calling it "a no-op
+	// kept for call-surface compatibility" — as this comment used to — is what
+	// makes it look safe to call, or safe to delete.
 
 	markSynced(noteId: string): void {
 		this.opts.onSynced?.(noteId);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3312,21 +3312,21 @@ export class SyncEngine {
 		try {
 			await send(noteId, frame);
 			this.docUpdateTimeouts = 0;
-			// RECORD IT, or the room saving is handed straight back. The server
-			// now holds this doc's full state, but nothing local said so: the
-			// provider's `synced` flag is only set by an inbound syncStep2, so
-			// `hasUndeliveredOps` stays TRUE. That is the precondition
-			// `convergeColdNoteRoomFree` refuses on, so the very next catch-up
-			// takes the room handshake for this note — one room each, which is
-			// the cost this whole path exists to avoid. It also keeps
-			// `isFullySynced()` false, so the doc can never hibernate and the
-			// registry holds it for the session.
+			// NOT `markSynced` here, however tempting. Despite the name it does
+			// NOT set the provider's `synced` flag (see `ProviderRegistry`: "the
+			// provider owns its own `synced` flag (set on syncStep2), so
+			// markSynced is a no-op kept for call-surface compatibility"). All it
+			// does is fire `onSynced` -> `commitCrdtConvergence`, which COMMITS a
+			// staged catch-up episode — recording the note converged at a
+			// serverHash whose content was never applied, after which every later
+			// catch-up compares equal hashes and skips it. That is the deaf-note
+			// class, and it turned two fan-out e2e tests red when tried.
 			//
-			// `markSynced` is honest here for the same reason it is in
-			// `convergeColdNoteRoomFree`: the ack is the server confirming it
-			// merged the FULL state we just sent, which is the same fact a
-			// syncStep2 would have proven.
-			this.crdt?.markSynced?.(noteId);
+			// The real gap is still open (engram#1493 follow-up): the server holds
+			// our state but nothing local records it, so `hasUndeliveredOps` stays
+			// true and the next catch-up takes a room for this note. Closing it
+			// needs a primitive that sets the flag WITHOUT the convergence commit;
+			// there isn't one, and inventing it belongs in its own change.
 			return true;
 		} catch (e) {
 			this.noteDocUpdateFailure(e, entry.path);

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -341,6 +341,11 @@ const DOC_STATE_FRAME = "crdt_doc_state";
 /** Room-free full Yjs state for one note — see `CrdtChannel.crdtDocState`. */
 type CrdtDocStateFn = (docId: string) => Promise<{ b64: string; head: string }>;
 
+/** Byte size at or below which a `Yjs.encodeStateAsUpdate` result carries no
+ *  content. An empty v1 update is a 2-byte header (`0x00 0x00`), so anything
+ *  this small is a doc with nothing in it rather than a small note. */
+const EMPTY_YJS_UPDATE_BYTES = 2;
+
 /** Socket frame name for the room-free doc WRITE, latched in
  *  `unsupportedFrames` alongside the read. */
 const DOC_UPDATE_FRAME = "crdt_doc_update";
@@ -506,6 +511,17 @@ export class SyncEngine {
 				`sweep(${event}): ${failures.length} entr${failures.length === 1 ? "y" : "ies"} ` +
 					`failed but the rest were swept — ${failures.join("; ")}`,
 			);
+		}
+
+		// `track()` only sweeps COLLECTIONS. The capability-latch strike counters
+		// are plain numbers, so they survived a vault change that clears
+		// `unsupportedFrames` — leaving a carried strike to latch a perfectly
+		// good backend off after a single timeout on the new vault. Both
+		// counters' own doc comments claimed this reset already happened; it did
+		// not, which is the failure mode where the comment is the bug.
+		if (event === "vault") {
+			this.docStateTimeouts = 0;
+			this.docUpdateTimeouts = 0;
 		}
 	}
 
@@ -3267,6 +3283,21 @@ export class SyncEngine {
 			// rather than putting an unbounded frame on an 8 MB socket — an
 			// oversized note still delivers, it just pays for a room to do it.
 			if (state.byteLength > MAX_CRDT_NOTE_BYTES) return false;
+			// AN EMPTY DOC IS NOT A DELIVERY. `encodeStateAsUpdate` on a doc that
+			// never hydrated (destroyed, evicted, or an IndexedDB replay that has
+			// not finished) yields a no-op update the server acks happily — and
+			// the ack is what dequeues the entry, so the queued edit would be
+			// dropped as "delivered" having moved nothing. The handshake this
+			// replaces would additionally have PULLED the server's copy, so the
+			// fallback is strictly better here, not merely equivalent.
+			if (state.byteLength <= EMPTY_YJS_UPDATE_BYTES) {
+				rlog().warn(
+					"queue",
+					`Room-free delivery skipped for ${noteRef(entry.path)} — the local doc encoded ` +
+						`empty (${state.byteLength}B); falling back to the room handshake`,
+				);
+				return false;
+			}
 			frame = encodeUpdateFrame(state);
 		} catch (e) {
 			// Doc destroyed mid-encode, or an IndexedDB fault. The room path
@@ -3281,6 +3312,21 @@ export class SyncEngine {
 		try {
 			await send(noteId, frame);
 			this.docUpdateTimeouts = 0;
+			// RECORD IT, or the room saving is handed straight back. The server
+			// now holds this doc's full state, but nothing local said so: the
+			// provider's `synced` flag is only set by an inbound syncStep2, so
+			// `hasUndeliveredOps` stays TRUE. That is the precondition
+			// `convergeColdNoteRoomFree` refuses on, so the very next catch-up
+			// takes the room handshake for this note — one room each, which is
+			// the cost this whole path exists to avoid. It also keeps
+			// `isFullySynced()` false, so the doc can never hibernate and the
+			// registry holds it for the session.
+			//
+			// `markSynced` is honest here for the same reason it is in
+			// `convergeColdNoteRoomFree`: the ack is the server confirming it
+			// merged the FULL state we just sent, which is the same fact a
+			// syncStep2 would have proven.
+			this.crdt?.markSynced?.(noteId);
 			return true;
 		} catch (e) {
 			this.noteDocUpdateFailure(e, entry.path);
@@ -3300,13 +3346,21 @@ export class SyncEngine {
 	private noteDocUpdateFailure(e: unknown, path: string): void {
 		const detail = errMsg(e, path);
 
-		if (/timeout/i.test(detail)) {
+		// `bad_frame` is the OTHER shape an unsupporting backend answers with, and
+		// it is the likelier one: `CrdtChannel`'s catch-all `handle_in/3` replies
+		// to any unknown event INSTANTLY. Latching only on timeouts meant the
+		// latch never engaged against such a server — every queued note paid a
+		// wasted round trip, a remote warn line, and an extra :handshake rate
+		// token, on the very lane whose starvation the 2026-07-07 incident was
+		// about. Structured refusals that prove the frame IS implemented
+		// (rate_limited, note_not_found, doc_update_failed) still must not latch.
+		if (/timeout/i.test(detail) || /bad_frame/i.test(detail)) {
 			this.docUpdateTimeouts += 1;
 			if (this.docUpdateTimeouts >= SyncEngine.DOC_STATE_TIMEOUT_LATCH) {
 				this.unsupportedFrames.add(DOC_UPDATE_FRAME);
 				rlog().warn(
 					"crdt",
-					`crdt_doc_update went unanswered ${this.docUpdateTimeouts}x — disabling room-free ` +
+					`crdt_doc_update unsupported ${this.docUpdateTimeouts}x — disabling room-free ` +
 						`queue delivery for this session and falling back to the room handshake.`,
 				);
 			}
@@ -5609,7 +5663,8 @@ export class SyncEngine {
 	private unsupportedFrames = this.track(["vault", "destroy"], new Set<string>());
 
 	/** Consecutive unanswered `crdt_doc_state` frames. Reset by any success, and
-	 *  by a vault change (a different vault can mean a different backend). */
+	 *  by a vault change (a different vault can mean a different backend) — see
+	 *  the explicit reset in `sweep()`, which `track()` cannot do for a scalar. */
 	private docStateTimeouts = 0;
 
 	private crdtDocUpdate: CrdtDocUpdateFn | null = null;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -342,8 +342,14 @@ const DOC_STATE_FRAME = "crdt_doc_state";
 type CrdtDocStateFn = (docId: string) => Promise<{ b64: string; head: string }>;
 
 /** Byte size at or below which a `Yjs.encodeStateAsUpdate` result carries no
- *  content. An empty v1 update is a 2-byte header (`0x00 0x00`), so anything
- *  this small is a doc with nothing in it rather than a small note. */
+ *  content. An empty v1 update is a 2-byte header (`0x00 0x00`) and the
+ *  smallest one carrying a single character is 11B, so there is no small note
+ *  this can misread as empty.
+ *
+ *  Pinned to encodeStateAsUpdate WITHOUT a state vector, and to v1: the same
+ *  empty doc encodes to 13B under `encodeStateAsUpdateV2`, and a FULL doc
+ *  encodes to 2B when diffed against its own state vector. Either change turns
+ *  this constant from a guard into a silent no-op or a false positive. */
 const EMPTY_YJS_UPDATE_BYTES = 2;
 
 /** Socket frame name for the room-free doc WRITE, latched in
@@ -511,17 +517,6 @@ export class SyncEngine {
 				`sweep(${event}): ${failures.length} entr${failures.length === 1 ? "y" : "ies"} ` +
 					`failed but the rest were swept — ${failures.join("; ")}`,
 			);
-		}
-
-		// `track()` only sweeps COLLECTIONS. The capability-latch strike counters
-		// are plain numbers, so they survived a vault change that clears
-		// `unsupportedFrames` — leaving a carried strike to latch a perfectly
-		// good backend off after a single timeout on the new vault. Both
-		// counters' own doc comments claimed this reset already happened; it did
-		// not, which is the failure mode where the comment is the bug.
-		if (event === "vault") {
-			this.docStateTimeouts = 0;
-			this.docUpdateTimeouts = 0;
 		}
 	}
 
@@ -3181,12 +3176,43 @@ export class SyncEngine {
 		return null;
 	}
 
-	/** How many consecutive unanswered `crdt_doc_state` frames disable the read.
-	 *  ONE is too few: a modern backend produces the identical signal whenever
-	 *  the channel dies (phx_error does not reject pending replies, so a crash
-	 *  surfaces as a timeout), and under the bulk-import load this feature exists
-	 *  for, a single slow reply is entirely reachable. */
-	private static readonly DOC_STATE_TIMEOUT_LATCH = 2;
+	/** How many consecutive unsupported-looking replies disable a room-free
+	 *  frame. ONE is too few: a modern backend produces the identical signal
+	 *  whenever the channel dies (phx_error does not reject pending replies, so
+	 *  a crash surfaces as a timeout), and under the bulk-import load this
+	 *  feature exists for, a single slow reply is entirely reachable. */
+	private static readonly FRAME_UNSUPPORTED_LATCH = 2;
+
+	/** Score one reply against `frame`'s capability latch; true when THIS reply
+	 *  latched it off. Two signals count, and neither is proof on its own:
+	 *
+	 *  - a TIMEOUT means the server never answered at all, which is what an
+	 *    older backend does with an unknown event — but a crashing channel looks
+	 *    identical from here.
+	 *  - `bad_frame` is the reply `CrdtChannel`'s catch-all `handle_in/3` gives
+	 *    INSTANTLY, and it is the likelier shape: latching on timeouts alone
+	 *    meant the latch never engaged against such a server, so every note paid
+	 *    a wasted round trip and an extra `:handshake` rate token, on the very
+	 *    lane whose starvation the 2026-07-07 incident was about. It is not
+	 *    exclusive to an old backend either — the same catch-all answers a
+	 *    malformed payload on a frame the server DOES implement.
+	 *
+	 *  Repeated strikes are what make the ambiguity tolerable. A STRUCTURED
+	 *  reject (rate_limited, note_not_found, doc_update_failed) is a real answer
+	 *  from a server that implements the frame and must never latch.
+	 *
+	 *  ONE predicate for both frames on purpose: it shipped on the write frame
+	 *  alone and left the read — the higher-volume caller — matching timeouts
+	 *  only, so against a backend predating both, the write latched off after
+	 *  two strikes while the read probed every cold note forever. */
+	private strikeFrame(frame: string, detail: string): boolean {
+		if (!/timeout/i.test(detail) && !/bad_frame/i.test(detail)) return false;
+		const strikes = (this.frameStrikes.get(frame) ?? 0) + 1;
+		this.frameStrikes.set(frame, strikes);
+		if (strikes < SyncEngine.FRAME_UNSUPPORTED_LATCH) return false;
+		this.unsupportedFrames.add(frame);
+		return true;
+	}
 
 	/** The ONE place `crdt_doc_state` is called.
 	 *
@@ -3211,29 +3237,20 @@ export class SyncEngine {
 			// A success proves the frame is supported — clear any partial strike
 			// count so one slow reply mid-import cannot accumulate toward a latch
 			// across an otherwise healthy session.
-			this.docStateTimeouts = 0;
+			this.frameStrikes.delete(DOC_STATE_FRAME);
 			return state;
 		} catch (e) {
 			const detail = errMsg(e, path);
 
-			// A TIMEOUT means the server never answered at all — an older backend
-			// does that with an unknown event. It is NOT proof of an old backend
-			// though: a channel crash looks identical from here, which is why the
-			// log below states the observation and not a diagnosis, and why it
-			// takes repeated strikes. A structured reject (rate limit, auth) is a
-			// real answer from a server that DOES implement the frame, and must
-			// never latch.
-			if (/timeout/i.test(detail)) {
-				this.docStateTimeouts += 1;
-				if (this.docStateTimeouts >= SyncEngine.DOC_STATE_TIMEOUT_LATCH) {
-					this.unsupportedFrames.add(DOC_STATE_FRAME);
-					rlog().warn(
-						"crdt",
-						`crdt_doc_state went unanswered ${this.docStateTimeouts}x — disabling room-free ` +
-							`doc reads for this session. Either the backend predates the frame or the ` +
-							`channel is crashing; both look like this from the client.`,
-					);
-				}
+			// The log states the OBSERVATION, not a diagnosis: an old backend and
+			// a crashing channel are indistinguishable from here.
+			if (this.strikeFrame(DOC_STATE_FRAME, detail)) {
+				rlog().warn(
+					"crdt",
+					`crdt_doc_state unsupported ${SyncEngine.FRAME_UNSUPPORTED_LATCH}x — disabling ` +
+						`room-free doc reads for this session. Either the backend predates the frame ` +
+						`or the channel is crashing; both look like this from the client.`,
+				);
 			}
 
 			rlog().warn("crdt", `crdt_doc_state failed for ${noteRef(path)}: ${detail}`);
@@ -3273,29 +3290,49 @@ export class SyncEngine {
 		const noteId = entry.noteId;
 		const send = this.crdtDocUpdate;
 		if (!noteId || !send || this.unsupportedFrames.has(DOC_UPDATE_FRAME)) return false;
-		if (typeof this.crdt?.encodeStateAsUpdate !== "function") return false;
+		// Capture the registry BEFORE the encode, and refuse if a vault change
+		// swapped it underneath — the same fence `adoptServerLineage` takes, and
+		// it matters MORE here for the reason `setCrdtPorts` gives: this is a
+		// WRITE. `setCrdtPorts` reassigns `this.crdt` on a vault change, and the
+		// port's own guard cannot catch it because both sides of that comparison
+		// (channel vault, settings vault) read LIVE at call time, so once the
+		// switch completes they agree again and vault A's Yjs bytes land in
+		// vault B's note of the same id. note_ids are unique only WITHIN a vault.
+		const crdt = this.crdt;
+		if (typeof crdt?.encodeStateAsUpdate !== "function") return false;
 
 		let frame: string;
 		try {
-			const state = await this.crdt.encodeStateAsUpdate(noteId);
+			const state = await crdt.encodeStateAsUpdate(noteId);
+			if (this.crdt !== crdt) return false;
 			// A doc's full state carries its history and tombstones, so it can
 			// dwarf the note's text. Same budget the genesis frame is held to
 			// rather than putting an unbounded frame on an 8 MB socket — an
 			// oversized note still delivers, it just pays for a room to do it.
-			if (state.byteLength > MAX_CRDT_NOTE_BYTES) return false;
-			// AN EMPTY DOC IS NOT A DELIVERY. `encodeStateAsUpdate` on a doc that
-			// never hydrated (destroyed, evicted, or an IndexedDB replay that has
-			// not finished) yields a no-op update the server acks happily — and
+			if (state.byteLength > MAX_CRDT_NOTE_BYTES) {
+				rlog().anomaly("crdt", "roomfree_state_over_cap");
+				return false;
+			}
+			// AN EMPTY DOC IS NOT A DELIVERY. A no-op update is acked happily, and
 			// the ack is what dequeues the entry, so the queued edit would be
 			// dropped as "delivered" having moved nothing. The handshake this
 			// replaces would additionally have PULLED the server's copy, so the
 			// fallback is strictly better here, not merely equivalent.
+			//
+			// The reachable cause is a note whose doc was never persisted:
+			// `ensureEntrySync` MINTS an empty `Y.Doc` on a cache miss, which is
+			// what a queue entry restored from `data.json` finds when IndexedDB
+			// does not have its doc (a second machine, a cleared cache, storage
+			// eviction). Not the other candidates — a destroyed doc throws out of
+			// `assertAlive` into the catch below, an evicted one rehydrates from
+			// IndexedDB, and `entry()` awaits `whenSynced`, so a half-finished
+			// replay is not observable from here.
+			//
+			// Counter, not a log line: the trigger is a whole restored queue at
+			// once, and one remote warn per note would flood the drain this
+			// feature exists to make cheap. Same call the sibling caps make.
 			if (state.byteLength <= EMPTY_YJS_UPDATE_BYTES) {
-				rlog().warn(
-					"queue",
-					`Room-free delivery skipped for ${noteRef(entry.path)} — the local doc encoded ` +
-						`empty (${state.byteLength}B); falling back to the room handshake`,
-				);
+				rlog().anomaly("crdt", "roomfree_state_empty");
 				return false;
 			}
 			frame = encodeUpdateFrame(state);
@@ -3311,16 +3348,16 @@ export class SyncEngine {
 
 		try {
 			await send(noteId, frame);
-			this.docUpdateTimeouts = 0;
-			// NOT `markSynced` here, however tempting. Despite the name it does
-			// NOT set the provider's `synced` flag (see `ProviderRegistry`: "the
-			// provider owns its own `synced` flag (set on syncStep2), so
-			// markSynced is a no-op kept for call-surface compatibility"). All it
-			// does is fire `onSynced` -> `commitCrdtConvergence`, which COMMITS a
-			// staged catch-up episode — recording the note converged at a
-			// serverHash whose content was never applied, after which every later
-			// catch-up compares equal hashes and skips it. That is the deaf-note
-			// class, and it turned two fan-out e2e tests red when tried.
+			this.frameStrikes.delete(DOC_UPDATE_FRAME);
+			// NOT `markSynced` here, however tempting. It does not set the
+			// provider's `synced` flag; it fires `onSynced` ->
+			// `commitCrdtConvergence`, which COMMITS a staged catch-up episode —
+			// recording the note converged at a serverHash whose content was
+			// never applied, after which every later catch-up compares equal
+			// hashes and skips it. That is the deaf-note class, and it turned two
+			// fan-out e2e tests red when tried. `convergeColdNoteRoomFree` may
+			// call it because it APPLIED the server's state first; this path only
+			// sent its own.
 			//
 			// The real gap is still open (engram#1493 follow-up): the server holds
 			// our state but nothing local records it, so `hasUndeliveredOps` stays
@@ -3334,36 +3371,21 @@ export class SyncEngine {
 		}
 	}
 
-	/** Strike accounting for `crdt_doc_update`, mirroring `readServerDocState`.
-	 *
-	 *  A backend that predates the frame never answers, so without a latch every
-	 *  queued note pays a full request timeout before falling back — a slower
-	 *  drain than not having the feature at all. A TIMEOUT is the only signal
-	 *  that looks like an old backend; a structured reject (rate limit, unknown
-	 *  note, refused write) is a real answer from a server that DOES implement
-	 *  it and must never latch. It takes repeated strikes because a crashing
-	 *  channel is indistinguishable from an old backend here. */
+	/** Log + strike accounting for a failed `crdt_doc_update`, mirroring the
+	 *  same two steps in `readServerDocState`. Which replies count toward the
+	 *  latch is `strikeFrame`'s call, not this function's — that is the point of
+	 *  the shared predicate. Without a latch, a backend predating the frame
+	 *  makes every queued note pay a round trip before falling back, a slower
+	 *  drain than not having the feature at all. */
 	private noteDocUpdateFailure(e: unknown, path: string): void {
 		const detail = errMsg(e, path);
 
-		// `bad_frame` is the OTHER shape an unsupporting backend answers with, and
-		// it is the likelier one: `CrdtChannel`'s catch-all `handle_in/3` replies
-		// to any unknown event INSTANTLY. Latching only on timeouts meant the
-		// latch never engaged against such a server — every queued note paid a
-		// wasted round trip, a remote warn line, and an extra :handshake rate
-		// token, on the very lane whose starvation the 2026-07-07 incident was
-		// about. Structured refusals that prove the frame IS implemented
-		// (rate_limited, note_not_found, doc_update_failed) still must not latch.
-		if (/timeout/i.test(detail) || /bad_frame/i.test(detail)) {
-			this.docUpdateTimeouts += 1;
-			if (this.docUpdateTimeouts >= SyncEngine.DOC_STATE_TIMEOUT_LATCH) {
-				this.unsupportedFrames.add(DOC_UPDATE_FRAME);
-				rlog().warn(
-					"crdt",
-					`crdt_doc_update unsupported ${this.docUpdateTimeouts}x — disabling room-free ` +
-						`queue delivery for this session and falling back to the room handshake.`,
-				);
-			}
+		if (this.strikeFrame(DOC_UPDATE_FRAME, detail)) {
+			rlog().warn(
+				"crdt",
+				`crdt_doc_update unsupported ${SyncEngine.FRAME_UNSUPPORTED_LATCH}x — disabling ` +
+					`room-free queue delivery for this session and falling back to the room handshake.`,
+			);
 		}
 
 		rlog().warn("queue", `Room-free delivery failed for ${noteRef(path)}: ${detail}`);
@@ -5662,18 +5684,20 @@ export class SyncEngine {
 	 *  self-host and SaaS are different servers at different versions. */
 	private unsupportedFrames = this.track(["vault", "destroy"], new Set<string>());
 
-	/** Consecutive unanswered `crdt_doc_state` frames. Reset by any success, and
-	 *  by a vault change (a different vault can mean a different backend) — see
-	 *  the explicit reset in `sweep()`, which `track()` cannot do for a scalar. */
-	private docStateTimeouts = 0;
+	/** Consecutive unsupported-looking replies, keyed BY FRAME. Per-frame on
+	 *  purpose: the two room-free frames shipped in different releases, so a
+	 *  backend can serve one and not the other, and a shared count would let the
+	 *  read's strikes latch off the write (or the reverse).
+	 *
+	 *  A Map rather than two scalars so it sweeps with `unsupportedFrames` on
+	 *  the SAME events. As scalars they survived the vault change that clears
+	 *  the latch Set, leaving a carried strike to latch a perfectly good backend
+	 *  off after one timeout on the new vault — and the fix for that was a
+	 *  hand-written `if (event === "vault")` list in `sweep()`, i.e. exactly the
+	 *  drift `track()` exists to abolish. */
+	private frameStrikes = this.track(["vault", "destroy"], new Map<string, number>());
 
 	private crdtDocUpdate: CrdtDocUpdateFn | null = null;
-
-	/** Consecutive unanswered `crdt_doc_update` frames. Counted SEPARATELY from
-	 *  the read's strikes: the two frames shipped in different releases, so a
-	 *  backend can serve one and not the other, and a shared counter would let
-	 *  the read's slow replies latch off the write (or the reverse). */
-	private docUpdateTimeouts = 0;
 
 	setCrdtCatchupSince(fn: CrdtCatchupSinceFn): void {
 		this.setCrdtPorts({ catchupSince: fn });

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -361,7 +361,7 @@ describe("room-free queue delivery (#1493)", () => {
 	}) {
 		const crdt = {
 			applyLocalEdit: async () => true,
-			encodeStateAsUpdate: opts.encode ?? (async () => new Uint8Array([1, 2, 3, 4, 5, 6])),
+			encodeStateAsUpdate: opts.encode ?? (async () => new Uint8Array([1, 2, 3])),
 			markSynced: opts.markSynced ?? (() => {}),
 		};
 		const enroll = mock();
@@ -399,15 +399,10 @@ describe("room-free queue delivery (#1493)", () => {
 		// while nothing moved — and the handshake it replaces would also have
 		// pulled the server's copy back.
 		const docUpdate = mock(async () => ({ head: "h1" }));
-		const {
-			e,
-			enqueue: _e,
-			...rest
-		} = queuedEngine({
+		const { e, enroll, reset } = queuedEngine({
 			docUpdate,
 			encode: async () => new Uint8Array([0, 0]),
 		});
-		void rest;
 		await enqueueOne(e);
 
 		const flushed = await e.flushQueue();
@@ -415,11 +410,41 @@ describe("room-free queue delivery (#1493)", () => {
 		expect(docUpdate).not.toHaveBeenCalled();
 		expect(flushed).toBe(0);
 		expect(e.queue.size).toBe(1);
+		// Skipping is only half the contract: the edit still has to converge, so
+		// the room handshake must actually fire. Without this the entry could be
+		// stranded in the queue forever and the three assertions above would not
+		// notice.
+		expect(reset).toHaveBeenCalledWith("id-1");
+		expect(enroll).toHaveBeenCalledWith("id-1");
+	});
+
+	test("a VAULT SWITCH during the encode refuses the write instead of sending it to the new vault", async () => {
+		// note_ids are unique only WITHIN a vault, so vault A's Yjs bytes merged
+		// into vault B's note of the same id is a cross-vault write. The port's
+		// own guard cannot catch this: it compares the channel's vault to the
+		// settings vault, and BOTH read live, so once the switch completes they
+		// agree again and the stale payload sails through.
+		const docUpdate = mock(async () => ({ head: "h1" }));
+		const { e, enroll } = queuedEngine({
+			docUpdate,
+			encode: async () => {
+				e.setCrdtManager(null);
+				return new Uint8Array([1, 2, 3]);
+			},
+		});
+		await enqueueOne(e);
+
+		const flushed = await e.flushQueue();
+
+		expect(docUpdate).not.toHaveBeenCalled();
+		expect(flushed).toBe(0);
+		expect(enroll).toHaveBeenCalledWith("id-1");
 	});
 
 	test("an IDLE note delivers over crdt_doc_update, dequeues on the ack, and fires NO handshake", async () => {
 		const docUpdate = mock(async () => ({ head: "h1" }));
-		const { e, enroll, reset } = queuedEngine({ docUpdate });
+		const markSynced = mock();
+		const { e, enroll, reset } = queuedEngine({ docUpdate, markSynced });
 		await enqueueOne(e);
 
 		const flushed = await e.flushQueue();
@@ -433,6 +458,11 @@ describe("room-free queue delivery (#1493)", () => {
 		// THE assertion: no room was asked for.
 		expect(reset).not.toHaveBeenCalled();
 		expect(enroll).not.toHaveBeenCalled();
+		// And NOT markSynced. It reads like the missing "record the delivery"
+		// call and is not: it commits a staged catch-up episode at a serverHash
+		// whose content this path never applied, which is the deaf-note class.
+		// Adding it once cost two fan-out e2e tests and a revert.
+		expect(markSynced).not.toHaveBeenCalled();
 	});
 
 	test("a LIVE-BOUND note keeps the handshake — its room already exists", async () => {
@@ -491,6 +521,63 @@ describe("room-free queue delivery (#1493)", () => {
 		}
 
 		expect(docUpdate).toHaveBeenCalledTimes(2);
+	});
+
+	test("repeated bad_frame latches too — it is how the catch-all answers, and INSTANTLY", async () => {
+		// The likelier shape against an old backend: `handle_in/3`'s catch-all
+		// replies immediately rather than letting the request time out, so a
+		// timeout-only latch never engaged and every note kept paying.
+		const docUpdate = mock(async () => {
+			throw new Error('request failed: {"reason":"bad_frame"}');
+		});
+		const { e } = queuedEngine({ docUpdate });
+
+		for (const path of ["A.md", "B.md", "C.md", "D.md"]) {
+			await enqueueOne(e, path);
+			await e.flushQueue();
+		}
+
+		expect(docUpdate).toHaveBeenCalledTimes(2);
+	});
+
+	test("a STRUCTURED refusal never latches, however often it repeats", async () => {
+		// `rate_limited` is a real answer from a server that DOES implement the
+		// frame. Latching on it would disable room-free delivery against a
+		// healthy backend for the session — under load, which is exactly when
+		// the room saving matters most.
+		const docUpdate = mock(async () => {
+			throw new Error('request failed: {"reason":"rate_limited"}');
+		});
+		const { e } = queuedEngine({ docUpdate });
+		await enqueueOne(e);
+
+		// One entry, four flushes — a refused write leaves it queued, so each
+		// flush retries it. Four attempts means the latch (2) never engaged.
+		for (let i = 0; i < 4; i++) await e.flushQueue();
+
+		expect(docUpdate).toHaveBeenCalledTimes(4);
+	});
+
+	test("a SUCCESS clears partial strikes, so slow replies cannot accumulate across a session", async () => {
+		let fail = true;
+		const docUpdate = mock(async () => {
+			if (fail) throw new Error("sendRequest timeout: crdt_doc_update");
+			return { head: "h1" };
+		});
+		const { e } = queuedEngine({ docUpdate });
+
+		await enqueueOne(e, "A.md");
+		await e.flushQueue();
+		fail = false;
+		await e.flushQueue();
+		fail = true;
+		await enqueueOne(e, "B.md");
+		await e.flushQueue();
+		await enqueueOne(e, "C.md");
+		await e.flushQueue();
+
+		// 1 strike, cleared, then 2 more to latch — 4 attempts, not 3.
+		expect(docUpdate).toHaveBeenCalledTimes(4);
 	});
 
 	test("a rejected write must NOT dequeue — the edit is only durable while queued", async () => {

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -394,20 +394,6 @@ describe("room-free queue delivery (#1493)", () => {
 		});
 	}
 
-	test("an acked delivery is RECORDED, so the next catch-up needs no room", async () => {
-		// Without this the provider's `synced` flag stays false, `hasUndeliveredOps`
-		// stays true, and `convergeColdNoteRoomFree` refuses — handing back the
-		// room-per-note this path exists to avoid, one catch-up later.
-		const docUpdate = mock(async () => ({ head: "h1" }));
-		const markSynced = mock();
-		const { e } = queuedEngine({ docUpdate, markSynced });
-		await enqueueOne(e);
-
-		await e.flushQueue();
-
-		expect(markSynced).toHaveBeenCalledWith("id-1");
-	});
-
 	test("an EMPTY local doc is not reported as delivered", async () => {
 		// A no-op update the server acks would dequeue the entry as delivered
 		// while nothing moved — and the handshake it replaces would also have

--- a/tests/sync-crdt-ops.test.ts
+++ b/tests/sync-crdt-ops.test.ts
@@ -357,10 +357,12 @@ describe("room-free queue delivery (#1493)", () => {
 		docUpdate?: (docId: string, b64: string) => Promise<{ head: string }>;
 		liveBound?: (path: string) => boolean;
 		encode?: (noteId: string) => Promise<Uint8Array>;
+		markSynced?: (noteId: string) => void;
 	}) {
 		const crdt = {
 			applyLocalEdit: async () => true,
-			encodeStateAsUpdate: opts.encode ?? (async () => new Uint8Array([1, 2, 3])),
+			encodeStateAsUpdate: opts.encode ?? (async () => new Uint8Array([1, 2, 3, 4, 5, 6])),
+			markSynced: opts.markSynced ?? (() => {}),
 		};
 		const enroll = mock();
 		const reset = mock();
@@ -391,6 +393,43 @@ describe("room-free queue delivery (#1493)", () => {
 			vaultId: "v",
 		});
 	}
+
+	test("an acked delivery is RECORDED, so the next catch-up needs no room", async () => {
+		// Without this the provider's `synced` flag stays false, `hasUndeliveredOps`
+		// stays true, and `convergeColdNoteRoomFree` refuses — handing back the
+		// room-per-note this path exists to avoid, one catch-up later.
+		const docUpdate = mock(async () => ({ head: "h1" }));
+		const markSynced = mock();
+		const { e } = queuedEngine({ docUpdate, markSynced });
+		await enqueueOne(e);
+
+		await e.flushQueue();
+
+		expect(markSynced).toHaveBeenCalledWith("id-1");
+	});
+
+	test("an EMPTY local doc is not reported as delivered", async () => {
+		// A no-op update the server acks would dequeue the entry as delivered
+		// while nothing moved — and the handshake it replaces would also have
+		// pulled the server's copy back.
+		const docUpdate = mock(async () => ({ head: "h1" }));
+		const {
+			e,
+			enqueue: _e,
+			...rest
+		} = queuedEngine({
+			docUpdate,
+			encode: async () => new Uint8Array([0, 0]),
+		});
+		void rest;
+		await enqueueOne(e);
+
+		const flushed = await e.flushQueue();
+
+		expect(docUpdate).not.toHaveBeenCalled();
+		expect(flushed).toBe(0);
+		expect(e.queue.size).toBe(1);
+	});
 
 	test("an IDLE note delivers over crdt_doc_update, dequeues on the ack, and fires NO handshake", async () => {
 		const docUpdate = mock(async () => ({ head: "h1" }));

--- a/tests/sync-socket-catchup.test.ts
+++ b/tests/sync-socket-catchup.test.ts
@@ -1363,6 +1363,57 @@ describe("convergeColdNoteRoomFree (#1409 — cold notes converge without a room
 		expect(converge.mock.calls[0]).toEqual(["Notes/a.md", "id-a"]);
 	});
 
+	test("latches the READ frame off after two unsupported-looking replies, on bad_frame as well as on timeouts", async () => {
+		// This is the higher-volume of the two room-free frames: every diverged
+		// cold note calls it. Against a backend predating it, the catch-all
+		// `handle_in/3` answers `bad_frame` INSTANTLY — so a timeout-only latch
+		// never engaged and every note kept paying a round trip and a
+		// :handshake token, forever. The write frame's latch was fixed first and
+		// this one was left behind; both now share one predicate.
+		const engine = coldEngine([]);
+		const docState = mock().mockRejectedValue(
+			new Error('request failed: {"reason":"bad_frame"}'),
+		);
+		engine.setCrdtPorts({ docState });
+		const converge = spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		for (let i = 0; i < 4; i++) {
+			await (engine as any).convergeColdNoteRoomFree(
+				"id-a",
+				"Notes/a.md",
+				CHANGE,
+				"server body",
+				"H2",
+			);
+		}
+
+		expect(docState).toHaveBeenCalledTimes(2);
+		// Convergence still happens every time — the latch drops the
+		// optimization, never the correctness.
+		expect(converge).toHaveBeenCalledTimes(4);
+	});
+
+	test("a structured refusal of the READ frame never latches it", async () => {
+		const engine = coldEngine([]);
+		const docState = mock().mockRejectedValue(
+			new Error('request failed: {"reason":"rate_limited"}'),
+		);
+		engine.setCrdtPorts({ docState });
+		spyOn(engine as any, "socketConverge").mockImplementation(() => {});
+
+		for (let i = 0; i < 4; i++) {
+			await (engine as any).convergeColdNoteRoomFree(
+				"id-a",
+				"Notes/a.md",
+				CHANGE,
+				"server body",
+				"H2",
+			);
+		}
+
+		expect(docState).toHaveBeenCalledTimes(4);
+	});
+
 	test("falls back to the room handshake when the port is unwired entirely", async () => {
 		const engine = coldEngine([]);
 		engine.setCrdtPorts({ docState: null });


### PR DESCRIPTION
Review follow-ups on #496 (room-free queue delivery), plus the fixes an adversarial review of this PR's own first pass turned up.

## What landed

**One capability latch, not two hand-copied ones.** `crdt_doc_state` and `crdt_doc_update` each had their own copy of "did this reply mean the backend lacks the frame". The first pass taught the *write* copy that `bad_frame` counts — the catch-all `handle_in/3` answers it INSTANTLY, so a timeout-only latch never engaged against an unsupporting server — and left the *read* copy, which this file's own comment calls the higher-volume caller, matching timeouts only. Both now call `strikeFrame(frame, detail)`.

**Strike counters are a tracked Map.** As scalars they survived the vault sweep that clears `unsupportedFrames`, so a carried strike could latch a healthy backend off after one timeout on the new vault. The first pass fixed that with an `if (event === "vault")` field list inside `sweep()` — the exact drift `track()` exists to abolish. One tracked Map sweeps on both events and is covered by the reflective sweep-registry test.

**A vault fence across the encode await.** `adoptServerLineage` takes one and documents why; this path did not. The port's own guard cannot substitute: both sides of its comparison read live, so once a vault switch completes they agree again and vault A's Yjs bytes land in vault B's note of the same id.

**An empty local doc is not a delivery.** A no-op update is acked, and the ack is what dequeues, so the queued edit would be dropped as delivered having moved nothing.

**Telemetry consistency.** The empty and oversized skips are anomaly counters (matching the genesis siblings) rather than one remote warn line per note across a 1.4k-note drain.

## What did NOT land, deliberately

An acked room-free delivery is still not recorded locally, so `hasUndeliveredOps` stays true and the next catch-up takes a room for that note. The obvious call, `markSynced`, is wrong: despite the name it does not set the provider's `synced` flag, it fires `onSynced` -> `commitCrdtConvergence`, committing a staged episode at a serverHash whose content this path never applied. That is the deaf-note class, and it turned two fan-out e2e tests red when tried. Closing the gap needs a primitive that records delivery without the convergence commit; there isn't one. Tracked under engram#1493. `ProviderRegistry`'s comment calling `markSynced` "a no-op kept for call-surface compatibility" was false and is corrected at the source — it is what made the call look safe.

## Tests

Mutation-checked, each one: the `bad_frame` latch (both frames), the structured-refusal non-latch, strike clearing on success, the vault fence, and the empty-doc guard. The read frame's latch had no coverage at all before this. The empty-doc test asserts the room fallback it is named for rather than only the skip, and asserts `markSynced` is NOT called — so re-adding it fails in `bun test` instead of in two fan-out e2e tests one CI round trip later.

Refs #1493