### PR TITLE
docs(crdt): the room-free fence catches drops, not just vaults

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3290,14 +3290,21 @@ export class SyncEngine {
 		const noteId = entry.noteId;
 		const send = this.crdtDocUpdate;
 		if (!noteId || !send || this.unsupportedFrames.has(DOC_UPDATE_FRAME)) return false;
-		// Capture the registry BEFORE the encode, and refuse if a vault change
-		// swapped it underneath — the same fence `adoptServerLineage` takes, and
-		// it matters MORE here for the reason `setCrdtPorts` gives: this is a
-		// WRITE. `setCrdtPorts` reassigns `this.crdt` on a vault change, and the
-		// port's own guard cannot catch it because both sides of that comparison
-		// (channel vault, settings vault) read LIVE at call time, so once the
-		// switch completes they agree again and vault A's Yjs bytes land in
-		// vault B's note of the same id. note_ids are unique only WITHIN a vault.
+		// Capture the registry BEFORE the encode and refuse if it was swapped
+		// underneath — the same fence `adoptServerLineage` takes, and it matters
+		// MORE here for the reason `setCrdtPorts` gives: this is a WRITE.
+		//
+		// TWO reassignments reach `this.crdt`, and the fence covers both:
+		//
+		// - A VAULT CHANGE, the dangerous one. The port's own guard cannot catch
+		//   it because both sides of its comparison (channel vault, settings
+		//   vault) read LIVE at call time, so once the switch completes they
+		//   agree again and vault A's Yjs bytes land in vault B's note of the
+		//   same id. note_ids are unique only WITHIN a vault.
+		// - A SOCKET DROP, the common one: `main.ts` sets `manager: null` on
+		//   disconnect and restores it on reconnect. Refusing is right here too
+		//   — the send would fail against a manager that is gone — and the room
+		//   handshake this falls back to re-resolves the doc itself.
 		const crdt = this.crdt;
 		if (typeof crdt?.encodeStateAsUpdate !== "function") return false;
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3302,9 +3302,10 @@ export class SyncEngine {
 		//   settings vault) read LIVE at call time, so once the switch completes
 		//   they agree again and vault A's Yjs bytes land in vault B's note of
 		//   the same id. note_ids are unique only WITHIN a vault.
-		// - A DOWNGRADE TO THE LEGACY PATH, when the server never confirmed CRDT
-		//   support: a disconnect before the `crdt:` join, or a refused join.
-		//   Both null the manager, and sending into one that is gone is not a
+		// - A DOWNGRADE TO THE LEGACY PATH: a disconnect BEFORE the `crdt:` join,
+		//   or a join the server refuses — including a REJOIN refused after an
+		//   earlier successful one, which force-resets `crdtEverJoined`. Both
+		//   null the manager, and sending into one that is gone is not a
 		//   delivery — the room handshake this falls back to re-resolves the doc.
 		//
 		// NOT a plain post-join socket drop. That deliberately RETAINS the

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -3294,17 +3294,23 @@ export class SyncEngine {
 		// underneath — the same fence `adoptServerLineage` takes, and it matters
 		// MORE here for the reason `setCrdtPorts` gives: this is a WRITE.
 		//
-		// TWO reassignments reach `this.crdt`, and the fence covers both:
+		// Every reassignment routes through the single `setCrdtPorts` site, so
+		// one identity comparison covers all of them. What they are:
 		//
-		// - A VAULT CHANGE, the dangerous one. The port's own guard cannot catch
-		//   it because both sides of its comparison (channel vault, settings
-		//   vault) read LIVE at call time, so once the switch completes they
-		//   agree again and vault A's Yjs bytes land in vault B's note of the
-		//   same id. note_ids are unique only WITHIN a vault.
-		// - A SOCKET DROP, the common one: `main.ts` sets `manager: null` on
-		//   disconnect and restores it on reconnect. Refusing is right here too
-		//   — the send would fail against a manager that is gone — and the room
-		//   handshake this falls back to re-resolves the doc itself.
+		// - A VAULT / IDENTITY CHANGE, the dangerous one. The port's own guard
+		//   cannot catch it because both sides of its comparison (channel vault,
+		//   settings vault) read LIVE at call time, so once the switch completes
+		//   they agree again and vault A's Yjs bytes land in vault B's note of
+		//   the same id. note_ids are unique only WITHIN a vault.
+		// - A DOWNGRADE TO THE LEGACY PATH, when the server never confirmed CRDT
+		//   support: a disconnect before the `crdt:` join, or a refused join.
+		//   Both null the manager, and sending into one that is gone is not a
+		//   delivery — the room handshake this falls back to re-resolves the doc.
+		//
+		// NOT a plain post-join socket drop. That deliberately RETAINS the
+		// manager so edits keep accumulating in the Y.Doc and IndexedDB, and the
+		// reconnect handshake carries them up. The fence must not fire there,
+		// and does not, because `this.crdt` is untouched.
 		const crdt = this.crdt;
 		if (typeof crdt?.encodeStateAsUpdate !== "function") return false;
 


### PR DESCRIPTION
Follow-up to #498. Comment only — no behaviour change.

The vault fence in `deliverQueuedOpsRoomFree` compares `this.crdt` across the encode await and refuses if it changed. Its comment explained that in terms of a vault switch, which is the dangerous case but not the common one.

`main.ts` also reassigns `this.crdt` on the socket lifecycle: `manager: null` on disconnect (2180, 2406, 2764), restored on reconnect (2716). So a dropped socket mid-encode trips the fence far more often than a vault change does. Refusing is correct there too — the send would fail against a manager that is gone, and the room handshake it falls back to re-resolves the doc itself — but a reader tracing a fallback would not learn that from the comment, and might narrow the check to a vault comparison and reintroduce a send through a dead manager.

The comment now names both reassignments and why each one earns the refusal.