### PR TITLE
fix(copy): purge dead limit reasons and stale plan claims

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,7 +42,7 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.9",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "js-yaml": "^4.3.1",
     "minimatch": "^10.0.1",
     "picomatch": "^2.3.2",
@@ -410,7 +410,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fastest-levenshtein": ["fastest-levenshtein@1.0.16", "", {}, "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "minimatch": "^10.0.1",
     "picomatch": "^2.3.2",
     "js-yaml": "^4.3.1",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "postcss": "^8.5.23"
   }
 }

--- a/src/limit-copy.ts
+++ b/src/limit-copy.ts
@@ -12,16 +12,34 @@ const TABLE: Record<string, string> = {
 	notes_cap_exceeded: "Note limit reached. Upgrade to keep adding notes.",
 	// CRDT channel variant of the note-cap reject (crdt_channel.ex): same copy.
 	notes_cap_reached: "Note limit reached. Upgrade to keep adding notes.",
-	vaults_cap_exceeded: "Free tier includes 1 vault. Upgrade for more.",
-	attachment_must_be_text: "Free syncs notes only — images & PDFs need a paid plan.",
-	attachments_disabled: "Attachment sync needs a paid plan.",
+	// Do NOT name a tier here. `vaults_cap` is per-tier (Free 1, Starter 10,
+	// Pro unlimited), so hardcoding "Free" told a Starter user at 10 vaults
+	// that their Free plan allowed 10. The web app hit the same bug and fixed
+	// it by naming the user's actual plan; the plugin has no plan label at this
+	// call site, so it says nothing about the tier instead of saying the wrong
+	// thing.
+	vaults_cap_exceeded: "Vault limit reached. Upgrade for more vaults.",
+	// A capability gate (self-host / storage config), NOT the Free-tier policy
+	// it used to be. `attachments_all_types` has been true on every tier since
+	// 2026-08-24, so the old "Free syncs notes only" copy named a rule that no
+	// longer exists.
+	attachment_must_be_text: "This file type isn't accepted by this server.",
+	attachments_disabled: "Attachment sync is disabled for this account.",
 	attachments_quota_exceeded: "Attachment storage is full — upgrade for more.",
 	file_too_large: "File too large for your plan.",
 	concurrent_devices_exceeded: "Already signed in on another device. Upgrade for multi-device.",
 	device_swap_cooldown: "Device swap cooldown active. Wait or upgrade.",
-	ai_conversations_per_day_exceeded: "Daily AI limit reached.",
-	ai_queries_per_conversation_exceeded: "Conversation length limit reached.",
-	ai_queries_per_day_exceeded: "Daily AI query limit reached.",
+	obsidian_connections_exceeded: "Too many connected Obsidian vaults. Disconnect one or upgrade.",
+	mcp_connections_exceeded: "Too many connected AI clients. Disconnect one or upgrade.",
+	// ONE key, replacing `ai_conversations_per_day_exceeded`,
+	// `ai_queries_per_conversation_exceeded` and `ai_queries_per_day_exceeded`.
+	// Those three were dead strings: the backend deleted the keys behind them
+	// when `ai_searches_per_day` consolidated six meters into one, so the only
+	// AI cap a user can now hit fell through to the generic fallback. Emitted
+	// by `search_controller.ex`. Copy tracks the web app's wording so the same
+	// limit does not read as two different products.
+	ai_searches_per_day_exceeded:
+		"Daily AI search limit reached. Free includes 20 per day across Obsidian, the web app and MCP. Upgrade for unlimited.",
 	// Server rejects an API-key-authed socket or REST call outright: Cloud
 	// gates API keys behind Pro. Point at sign-in, which works on every plan,
 	// rather than at a generic "upgrade".

--- a/src/tabs/about-tab.ts
+++ b/src/tabs/about-tab.ts
@@ -105,19 +105,33 @@ export function renderAboutTab(ctx: TabContext): void {
 		const list = card.createEl("ul", { cls: "engram-plan-features" });
 		for (const feature of features) list.createEl("li", { text: feature });
 	};
+	// Every line here must be checkable against `Engram.Billing.LimitKeys` in
+	// the backend. This block drifted badly once: it claimed 1 device (it is 2),
+	// read-only AI (MCP `create_note`/`write_note` have no tier gate at all),
+	// and "Full API" on Starter when API keys went Pro-only on 2026-08-24.
+	//
+	// The search lines deliberately name COVERAGE, not the retrieval mechanism.
+	// That is the pricing v3.1 positioning (ranking differences are single-digit
+	// and imperceptible; "found my note" vs "cannot find my note" is not), and
+	// it also keeps this copy true across the pending Free semantic-search flip.
 	plan("Free", [
-		"1 vault, 1 device",
-		"Auto sync",
-		"Read-only AI access",
-		"Semantic search + MCP",
+		"1 vault, 2 devices",
+		"Real-time sync",
+		"Search your 2,000 most recent notes",
+		"Connect any AI (MCP)",
 	]);
 	plan("Starter", [
-		"Multiple vaults, all devices",
-		"Real-time sync",
-		"Full API + MCP",
-		"Higher daily AI limit",
+		"10 vaults, unlimited devices",
+		"Search all your notes",
+		"10 GB attachments",
+		"Unlimited AI searches",
 	]);
-	plan("Pro", ["Unlimited notes", "Unlimited AI (fair use)", "Priority support"]);
+	plan("Pro", [
+		"Unlimited vaults",
+		"Search across all vaults at once",
+		"50 GB attachments",
+		"API access",
+	]);
 
 	const pricing = containerEl.createEl("p", { cls: "engram-about-link" });
 	externalLink(pricing, "See full pricing", ENGRAM_PRICING_URL);

--- a/src/tabs/about-tab.ts
+++ b/src/tabs/about-tab.ts
@@ -117,7 +117,7 @@ export function renderAboutTab(ctx: TabContext): void {
 	plan("Free", [
 		"1 vault, 2 devices",
 		"Real-time sync",
-		"Search your 2,000 most recent notes",
+		"2,000 notes searchable",
 		"Connect any AI (MCP)",
 	]);
 	plan("Starter", [

--- a/tests/limit-copy.test.ts
+++ b/tests/limit-copy.test.ts
@@ -11,12 +11,44 @@ describe("limit-copy", () => {
 		expect(msg.toLowerCase()).toMatch(/note limit/);
 	});
 
-	test("maps attachments_disabled", () => {
-		expect(toastFor("attachments_disabled").toLowerCase()).toMatch(/attachment.*paid plan/);
+	// NEITHER of these is a tier gate any more. `attachments_enabled` and
+	// `attachments_all_types` are both `true` on Free, Starter and Pro as of
+	// 2026-08-24, so on SaaS these reasons cannot fire at all — they are
+	// self-host capability gates. These assertions used to pin "paid plan"
+	// wording, which sent a self-hoster to a pricing page for a setting on
+	// their own server, and told a Free user their own attachments needed an
+	// upgrade they already had.
+	test("maps attachments_disabled without naming a tier", () => {
+		const msg = toastFor("attachments_disabled").toLowerCase();
+		expect(msg).toMatch(/attachment sync is disabled/);
+		expect(msg).not.toMatch(/paid plan|upgrade/);
 	});
 
-	test("maps attachment_must_be_text (capability copy)", () => {
-		expect(toastFor("attachment_must_be_text").toLowerCase()).toMatch(/notes only.*paid plan/);
+	test("maps attachment_must_be_text as a capability, not a tier", () => {
+		const msg = toastFor("attachment_must_be_text").toLowerCase();
+		expect(msg).toMatch(/file type/);
+		expect(msg).not.toMatch(/paid plan|notes only/);
+	});
+
+	// The one AI cap a user can actually hit. Three predecessors
+	// (`ai_conversations_per_day`, `ai_queries_per_conversation`,
+	// `ai_queries_per_day`) were deleted backend-side when `ai_searches_per_day`
+	// consolidated six meters into one, leaving this reason with no copy and
+	// falling through to the generic fallback.
+	test("maps ai_searches_per_day_exceeded with the real number", () => {
+		const msg = toastFor("ai_searches_per_day_exceeded").toLowerCase();
+		expect(msg).toMatch(/20 per day/);
+		expect(msg).toMatch(/upgrade/);
+	});
+
+	test("dead AI reasons are gone from the table", () => {
+		for (const dead of [
+			"ai_conversations_per_day_exceeded",
+			"ai_queries_per_conversation_exceeded",
+			"ai_queries_per_day_exceeded",
+		]) {
+			expect(toastFor(dead)).toMatch(/Limit reached\. Upgrade to continue\./);
+		}
 	});
 
 	test("maps attachments_quota_exceeded (quota copy)", () => {


### PR DESCRIPTION
Sweep of every tier claim in the plugin against `Engram.Billing.LimitKeys`. Decision log: engram-app/engram-workspace#191. Web-app counterpart: engram-app/Engram#1566.

## Dead AI reasons — a real user-facing bug

`src/limit-copy.ts` carried three reasons the backend can never emit again:

- `ai_conversations_per_day_exceeded`
- `ai_queries_per_conversation_exceeded`
- `ai_queries_per_day_exceeded`

All three were deleted backend-side when `ai_searches_per_day` consolidated six meters into one. What it did **not** carry is `ai_searches_per_day_exceeded`, which is what `search_controller.ex:157` actually emits.

**So the one AI cap a user can actually hit fell through to the generic "Limit reached. Upgrade to continue." fallback — on the primary product surface.** The web app has had correct copy for this the whole time (`frontend/src/billing/limit-copy.ts`); the plugin now matches its wording so the same limit does not read as two different products.

## Attachment copy named a reversed policy

`attachments_disabled` and `attachment_must_be_text` both said "paid plan". Both are gated on `attachments_enabled` and `attachments_all_types`, which are `true` on **every** tier since 2026-08-24, so neither can fire on SaaS at all. They are self-host capability gates.

The old copy sent a self-hoster to a pricing page for a setting on their own server. Their tests pinned that wording, one of them under a title that already said "(capability copy)" while asserting `/notes only.*paid plan/`. Both tests now assert the capability framing **and** assert the absence of tier language, so this cannot silently regress.

## A tier named in a per-tier limit

`vaults_cap_exceeded` read "Free tier includes 1 vault. Upgrade for more." `vaults_cap` is per-tier (Free 1, Starter 10, Pro unlimited), so a Starter user at their cap was told their Free plan allowed 10.

This is the same bug the web app already fixed in `active-vaults-section.tsx`, where it names the user's actual plan. The plugin has no plan label at this call site, so it names no tier at all rather than naming the wrong one.

## Missing connection reasons

Added `obsidian_connections_exceeded` and `mcp_connections_exceeded`, both emitted by `EnforceConnectionCap` and both previously falling through to the generic string.

## About tab

The Plans table claimed:

| Said | Reality |
|---|---|
| Free "1 device" | 2 devices |
| Free "Read-only AI access" | `create_note` / `write_note` have **no tier gate** |
| Starter "Full API + MCP" | API keys went Pro-only on 2026-08-24 |
| Starter "Higher daily AI limit" | paid is uncapped, not higher |

Now carries v3.1 values (Free 1 vault / 2 devices, Starter 10 vaults / 10 GB, Pro unlimited vaults / 50 GB / API access) and describes search by **coverage** rather than mechanism. That is the shipped positioning and it also keeps this copy true across the pending Free semantic-search flip, so it will not need a second edit.

## Verification

- `bun run build` (tsc + esbuild) clean
- `biome check` clean over 276 files
- **3059 tests pass**, including 4 new limit-copy tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sq94KcAKwjNcmHxetPwzMp