### PR TITLE
docs: remove stale REST cursor-pull / device-watermark references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,12 +80,12 @@ Don't hardcode test counts here — they drift. Run `bun test` for the live tota
 and `ls tests/*.test.ts` for the current file list. Coverage roughly tracks
 ~89% funcs / ~97% lines but check `bun test --coverage` for the real number.
 
-Broad areas under test: SyncEngine (ignore/modify/delete/rename, pull, cursor-pull,
-WebSocket events, echo suppression, 3-way merge, state export/import), the cursor
-+ manifest reconciliation path, the offline queue, the API client (incl. batch
-push + `/sync/changes`), auth (ApiKey + OAuth device flow), the Phoenix channel,
-diff/merge, remote logging, plan/limit state, and a set of compliance tests
-(manifest, license, README disclosures, source/styles hygiene, command IDs).
+Broad areas under test: SyncEngine (ignore/modify/delete/rename, pull, seq-replay
+catch-up, WebSocket events, echo suppression, 3-way merge, state export/import),
+manifest reconciliation, the offline queue, the API client, auth (ApiKey + OAuth
+device flow), the Phoenix channel, diff/merge, remote logging, plan/limit state,
+and a set of compliance tests (manifest, license, README disclosures,
+source/styles hygiene, command IDs).
 
 ### Test configuration
 

--- a/DEV.md
+++ b/DEV.md
@@ -49,7 +49,6 @@ src/
   conflict-modal.ts    Interactive conflict resolution UI
   search-modal.ts      Semantic search modal
   search-view.ts       Persistent search sidebar
-  cursor.ts            Sync-cursor helpers (cursor-pull + manifest reconcile)
   sync-center-render.ts  Sync Center dashboard rendering
   settings.ts + tabs/  Settings UI (tabs/: account, sync-center, self-hosted, advanced, about, start)
   offline-queue.ts     Persistent queue for offline edits
@@ -90,11 +89,11 @@ bun test --coverage   # check the report for the live coverage number (~89% func
 
 Don't hardcode counts; run `bun test` for the live total and `ls tests/*.test.ts`
 for the file list. The suite spans the SyncEngine (ignore/modify/delete/rename,
-pull, cursor-pull, WebSocket, echo suppression, 3-way merge, state export/import),
-cursor + manifest reconciliation, the API client (incl. batch push + `/sync/changes`),
-the offline queue, auth (ApiKey + OAuth device flow), the Phoenix channel, diff/merge,
-remote logging, plan/limit state, plus compliance tests (manifest, license, README
-disclosures, source/styles hygiene, command IDs).
+pull, seq-replay catch-up, WebSocket, echo suppression, 3-way merge, state export/import),
+manifest reconciliation, the API client, the offline queue, auth (ApiKey + OAuth
+device flow), the Phoenix channel, diff/merge, remote logging, plan/limit state,
+plus compliance tests (manifest, license, README disclosures, source/styles
+hygiene, command IDs).
 
 ### Test config
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -9,8 +9,7 @@ _Last verified: 2026-07-08_
 | File | Lines | Purpose |
 |------|-------|---------|
 | `src/main.ts` | ~1100 | Plugin lifecycle, vault event wiring, commands, status bar, settings I/O |
-| `src/sync.ts` | ~3500 | Core sync engine: push, pull, fullSync, cursor-pull, debounce, offline queue, conflicts, 3-way merge, request pacer |
-| `src/cursor.ts` | — | Sync-cursor helpers (cursor-pull bootstrap + manifest reconciliation) |
+| `src/sync.ts` | ~3500 | Core sync engine: push, pull, fullSync, seq-replay catch-up, manifest reconciliation, debounce, offline queue, conflicts, 3-way merge, request pacer |
 | `src/api.ts` | ~430 | HTTP client wrapping `requestUrl()` for all Engram REST calls |
 | `src/types.ts` | ~270 | All interfaces: settings, API responses, queue entries, sync status |
 | `src/settings.ts` + `src/tabs/` | — | Settings UI (PluginSettingTab) split into per-tab modules (Account, Sync Center, Self-hosted, Advanced, About, Start) |
@@ -72,7 +71,7 @@ All endpoints require `Authorization: Bearer <api_key>`. Path params use `encode
 | `POST` | `/notes` | `{path, content, mtime}` | `{note, chunks_indexed}` |
 | `GET` | `/notes/{path}` | — | Full note content |
 | `GET` | `/notes/changes?since={iso}` | — | `{changes[], server_time}` |
-| `GET` | `/sync/changes?cursor={c}&limit={n}` | cursor (opaque), limit (default 500) | `{changes[], cursor, has_more}` — cursor-pull (PR #109); tombstones included |
+| ~~`GET`~~ | ~~`/sync/changes?cursor={c}&limit={n}`~~ | — | **Removed** (backend REST-purge Bucket A, #1036) — catch-up now runs entirely over the socket (`catchupViaSeqReplay`) |
 | `GET` | `/sync/manifest` | — | Authoritative `{path, content_hash}` inventory for bootstrap/reconciliation |
 | `POST` | `/notes/batch` | `{notes: [{path, content, mtime}...]}` (≤100) | Bulk push (protocol rev) |
 | `DELETE` | `/notes/{path}` | — | `{deleted, path}` |
@@ -174,9 +173,8 @@ User patterns (from settings textarea, one per line):
 | `pushing` | `Set<path>` | Files currently being pushed (prevents re-entry) |
 | `recentlyPushed` | `Map<path, timeout>` | Echo suppression cooldowns (5s) |
 | `lastSync` | `string` | ISO 8601 timestamp, persisted to plugin data |
-| `syncCursor` | `string \| null` | Opaque cursor for cursor-pull via `GET /sync/changes` (PR #109); persisted under `syncCursor` key. `getSyncCursor()`/`setSyncCursor()` |
 | `syncState` | `Map<path, FileSyncState>` | Per-file synced state (replaced the old `syncedHashes` map). `exportSyncState()`/`importSyncState()` |
-| `syncStateVaultId` | `string \| null` | The server vaultId `syncState`/`lastSync`/`syncCursor` belong to; on vault change the stale state is invalidated |
+| `syncStateVaultId` | `string \| null` | The server vaultId `syncState`/`lastSync` belong to; on vault change the stale state is invalidated |
 | `offline` | `boolean` | Current connectivity state |
 | `healthCheckTimer` | `interval` | 30s poll when offline |
 | `ready` | `boolean` | Event handlers suppressed until true (ready gate) |

--- a/src/api.ts
+++ b/src/api.ts
@@ -118,7 +118,8 @@ export class EngramApi {
 		this.vaultId = id;
 	}
 
-	/** Set the per-install device id sent as X-Device-Id on cursor pulls. */
+	/** Set the per-install device id sent as X-Device-Id on every REST call
+	 *  (used for delete-broadcast echo suppression, #970). */
 	setDeviceId(id: string | null): void {
 		this.deviceId = id && id.length > 0 ? id : null;
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -497,7 +497,7 @@ export default class EngramSyncPlugin extends Plugin {
 			this.api.setVaultId(this.settings.vaultId);
 		}
 		// Wire the per-install device id (minted in loadSettings) onto the real
-		// api instance before any sync runs, so cursor pulls carry X-Device-Id.
+		// api instance before any sync runs, so every REST call carries X-Device-Id.
 		this.api.setDeviceId(this.deviceId);
 		this.api.setTracingEnabled(this.settings.diagnosticsEnabled);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,8 +95,9 @@ async function generateClientId(app: import("obsidian").App): Promise<string> {
 interface PluginData {
 	settings: EngramSyncSettings;
 	lastSync: string;
-	/** Per-install device id (random UUID). Sent as X-Device-Id on cursor pulls
-	 *  so the backend tracks its sync watermark per device. Device-local; NOT a
+	/** Per-install device id (random UUID). Sent as X-Device-Id on every REST
+	 *  call so the server can stamp it into `note_changed` delete broadcasts
+	 *  (#970), letting us drop our own fanout echoes. Device-local; NOT a
 	 *  user-facing setting. Distinct from settings.clientId (a path hash that
 	 *  collides across devices). */
 	deviceId?: string;
@@ -311,8 +312,9 @@ export default class EngramSyncPlugin extends Plugin {
 		this.indexChannel = null;
 	}
 	syncLog: SyncLog = new SyncLog();
-	/** Per-install device id sent as X-Device-Id so the backend attributes its
-	 *  sync watermark per device. Random UUID minted on first load, persisted
+	/** Per-install device id sent as X-Device-Id on every REST call so the
+	 *  server can stamp it into `note_changed` delete broadcasts (#970) for
+	 *  fanout-echo suppression. Random UUID minted on first load, persisted
 	 *  top-level in PluginData (device-local; NOT a user-facing setting). A
 	 *  reinstall/reset mints a new id → one clean re-bootstrap. */
 	deviceId: string | null = null;
@@ -1468,7 +1470,7 @@ export default class EngramSyncPlugin extends Plugin {
 		}
 		// Mint per-install device id on first load. Distinct from clientId (a
 		// path hash that collides across devices); device id is a fresh random
-		// UUID so the backend tracks its sync watermark per install.
+		// UUID sent as X-Device-Id for delete-broadcast echo suppression (#970).
 		this.deviceId = data?.deviceId ?? null;
 		if (!this.deviceId) {
 			this.deviceId = crypto.randomUUID();

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1234,7 +1234,7 @@ export class SyncEngine {
 	private idMapReconcileQueued = false;
 
 	/** note_ids the SERVER is known to already have a note row for — learned
-	 *  either from a `/sync/changes` pull (applySyncChange) or confirmed by a
+	 *  either from a seq-replay catch-up (`applySyncChange`) or confirmed by a
 	 *  successful REST push response. The backend's CRDT channel now requires
 	 *  the note to pre-exist (note_in_vault?) and silently drops a crdt_msg for
 	 *  an unknown note_id — it can no longer bootstrap a note row from a bare


### PR DESCRIPTION
## Summary
- The client is fully migrated off REST cursor-pull to socket seq-replay catch-up, but docs/comments still described `GET /sync/changes`, `syncCursor`, and `src/cursor.ts` as live — none of them exist in code anymore.
- `X-Device-Id` comments described it as a server-persisted "sync watermark per device" — corrected to its actual current purpose: delete-broadcast echo suppression (#970).
- Found while validating backend PR engram-app/Engram#1582 (drops the now-dead `vault_device_cursors` table these comments were describing).

Docs touched: `docs/internals.md`, `CLAUDE.md`, `DEV.md`, `src/main.ts` comments. No behavior change.

## Test plan
- [x] `bun run build` — clean (tsc + esbuild)
- [x] `bun test` — 3106 tests, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZU8U3d3gxBK8wi2qR6jfc