### PR TITLE
feat(sync): report plugin version, and surface the backend's version floor

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -206,16 +206,31 @@ export class EngramApi {
 	 *  original error unchanged. Nothing branches on a 426 programmatically;
 	 *  the user-visible half is the notice, which latches to once per session.
 	 *
-	 *  Returning true short-circuits the generic warn below. That is not tidiness:
-	 *  `/api/logs` is itself on the vault-scoped pipeline, so a below-floor client
-	 *  gets 426 on its own log push too. Logging every refusal would refill the
-	 *  200-entry remote-log ring with nothing but its own refusals and evict the
-	 *  diagnostics you actually wanted off a blocked install. The latched warn
-	 *  inside `notifyUpgradeRequired` is the one record we keep. */
-	private noteIfUpgradeRequired(e: unknown, status: number | undefined): boolean {
+	 *  Returning true short-circuits the generic per-request warn, so the ONE
+	 *  record kept names the route. Two reasons that matters:
+	 *
+	 *  - 426 is a generic HTTP status. A proxy in front of a self-hosted backend
+	 *    can emit a bare one for reasons unrelated to this feature, and the user
+	 *    then gets "this plugin is too old" that updating cannot fix. Without
+	 *    the route there is nothing to diagnose it from.
+	 *  - `/api/logs` is itself on the vault-scoped pipeline, so a below-floor
+	 *    client 426s on its own log push. Warning per-request would have the
+	 *    remote-log ring re-buffering nothing but its own refusals.
+	 *
+	 *  The route is folded into the latched warn rather than dropped, because
+	 *  the latch already bounds it to one line per session. */
+	private noteIfUpgradeRequired(
+		e: unknown,
+		status: number | undefined,
+		method: string,
+		path: string,
+	): boolean {
 		if (status !== 426) return false;
 		const body = errorBody(e);
-		notifyUpgradeRequired(typeof body.min_version === "string" ? body.min_version : null);
+		notifyUpgradeRequired(typeof body.min_version === "string" ? body.min_version : null, {
+			method,
+			route: beaconRoute(path),
+		});
 		return true;
 	}
 
@@ -237,7 +252,7 @@ export class EngramApi {
 			if (status === 402) {
 				throw parseLimitExceededError(e);
 			}
-			if (this.noteIfUpgradeRequired(e, status)) {
+			if (this.noteIfUpgradeRequired(e, status, method, path)) {
 				throw e;
 			}
 			// On 401, the cached access token may be stale (e.g. server-side TTL
@@ -263,7 +278,7 @@ export class EngramApi {
 					// that refreshes a token puts the version refusal on THIS
 					// path, not the primary one. Missing it here made the notice
 					// unreachable in the single most likely real-world shape.
-					if (this.noteIfUpgradeRequired(e2, retryStatus)) {
+					if (this.noteIfUpgradeRequired(e2, retryStatus, method, path)) {
 						throw e2;
 					}
 					rlog().warn(

--- a/src/api.ts
+++ b/src/api.ts
@@ -11,6 +11,7 @@ import { LimitExceededError } from "./limit-error";
 import { BeaconBuffer } from "./observability/beacon";
 import { newTraceContext } from "./observability/traceGen";
 import type { BillingUsage } from "./plan-usage";
+import { pluginVersion } from "./plugin-version";
 import { type RemoteLogEntry, rlog } from "./remote-log";
 import type {
 	AttachmentDetail,
@@ -282,6 +283,13 @@ export class EngramApi {
 		}
 		if (this.deviceId) {
 			headers["X-Device-Id"] = this.deviceId;
+		}
+		// Reported so the backend can refuse clients below its compatibility
+		// floor (426 plugin_upgrade_required). Omitted, never sent empty — see
+		// plugin-version.ts.
+		const version = pluginVersion();
+		if (version) {
+			headers["X-Plugin-Version"] = version;
 		}
 		if (body !== undefined) {
 			headers["Content-Type"] = "application/json";

--- a/src/api.ts
+++ b/src/api.ts
@@ -201,6 +201,24 @@ export class EngramApi {
 		this.lastToken = "";
 	}
 
+	/** Surface a `426` — this plugin is below the backend's minimum version —
+	 *  and report whether that is what happened, so the caller rethrows the
+	 *  original error unchanged. Nothing branches on a 426 programmatically;
+	 *  the user-visible half is the notice, which latches to once per session.
+	 *
+	 *  Returning true short-circuits the generic warn below. That is not tidiness:
+	 *  `/api/logs` is itself on the vault-scoped pipeline, so a below-floor client
+	 *  gets 426 on its own log push too. Logging every refusal would refill the
+	 *  200-entry remote-log ring with nothing but its own refusals and evict the
+	 *  diagnostics you actually wanted off a blocked install. The latched warn
+	 *  inside `notifyUpgradeRequired` is the one record we keep. */
+	private noteIfUpgradeRequired(e: unknown, status: number | undefined): boolean {
+		if (status !== 426) return false;
+		const body = errorBody(e);
+		notifyUpgradeRequired(typeof body.min_version === "string" ? body.min_version : null);
+		return true;
+	}
+
 	private async request(
 		method: string,
 		path: string,
@@ -219,16 +237,8 @@ export class EngramApi {
 			if (status === 402) {
 				throw parseLimitExceededError(e);
 			}
-			// 426 = this plugin is below the backend's minimum version. Terminal
-			// on every transport, so it is surfaced here rather than left to
-			// each caller's generic failure path. Rethrown unchanged: nothing
-			// branches on it programmatically, and the user-visible half is the
-			// notice (which latches itself to once per session).
-			if (status === 426) {
-				const body = errorBody(e);
-				notifyUpgradeRequired(
-					typeof body.min_version === "string" ? body.min_version : null,
-				);
+			if (this.noteIfUpgradeRequired(e, status)) {
+				throw e;
 			}
 			// On 401, the cached access token may be stale (e.g. server-side TTL
 			// shorter than the expires_in we trusted). Invalidate and retry once
@@ -246,6 +256,15 @@ export class EngramApi {
 					const retryStatus = statusOf(e2);
 					if (retryStatus === 402) {
 						throw parseLimitExceededError(e2);
+					}
+					// 426 must be handled here too, for the same reason 402 is.
+					// `Auth` runs BEFORE `RequirePluginVersion` server-side, so a
+					// stale cached token yields 401-then-426 — i.e. every launch
+					// that refreshes a token puts the version refusal on THIS
+					// path, not the primary one. Missing it here made the notice
+					// unreachable in the single most likely real-world shape.
+					if (this.noteIfUpgradeRequired(e2, retryStatus)) {
+						throw e2;
 					}
 					rlog().warn(
 						"api",

--- a/src/api.ts
+++ b/src/api.ts
@@ -24,6 +24,7 @@ import type {
 	VaultRegistrationResponse,
 	VersionConflictResponse,
 } from "./types";
+import { notifyUpgradeRequired } from "./upgrade-required";
 
 /** A request exceeded its deadline. requestUrl() cannot be aborted, so the
  *  underlying request is ABANDONED, not cancelled — a late server-side apply
@@ -217,6 +218,17 @@ export class EngramApi {
 			// so 402 always gets the rich error — see spec §4.6.
 			if (status === 402) {
 				throw parseLimitExceededError(e);
+			}
+			// 426 = this plugin is below the backend's minimum version. Terminal
+			// on every transport, so it is surfaced here rather than left to
+			// each caller's generic failure path. Rethrown unchanged: nothing
+			// branches on it programmatically, and the user-visible half is the
+			// notice (which latches itself to once per session).
+			if (status === 426) {
+				const body = errorBody(e);
+				notifyUpgradeRequired(
+					typeof body.min_version === "string" ? body.min_version : null,
+				);
 			}
 			// On 401, the cached access token may be stale (e.g. server-side TTL
 			// shorter than the expires_in we trusted). Invalidate and retry once
@@ -718,20 +730,29 @@ export function beaconRoute(path: string): string {
 		.slice(0, 64);
 }
 
-function parseLimitExceededError(e: unknown): LimitExceededError {
+/** The JSON body of an Obsidian `requestUrl` rejection. Arrives as `.json`
+ *  (parsed) or `.text` (raw) depending on platform, so try both; a malformed
+ *  or missing body yields `{}` rather than a decode crash, because every
+ *  caller here is already on an error path and must not fail twice. */
+function errorBody(e: unknown): Record<string, unknown> {
 	const err = e as { json?: unknown; text?: string };
-	let body: Record<string, unknown> = {};
 	if (err.json && typeof err.json === "object") {
-		body = err.json as Record<string, unknown>;
-	} else if (typeof err.text === "string") {
+		return err.json as Record<string, unknown>;
+	}
+	if (typeof err.text === "string") {
 		try {
 			const parsed: unknown = JSON.parse(err.text);
-			if (parsed && typeof parsed === "object") body = parsed as Record<string, unknown>;
+			if (parsed && typeof parsed === "object") return parsed as Record<string, unknown>;
 		} catch {
-			// Malformed text — fall through with empty body; "unknown" reason
-			// still routes to the generic toast.
+			// Malformed text — fall through to {}. For a 402 that still routes
+			// to the generic toast via the "unknown" reason.
 		}
 	}
+	return {};
+}
+
+function parseLimitExceededError(e: unknown): LimitExceededError {
+	const body = errorBody(e);
 	const pick = <T>(key: string): T | null => (body[key] !== undefined ? (body[key] as T) : null);
 	// Fall back to `error` when `reason` is absent. Not every 402 uses the
 	// LimitResponse shape: RequireApiWriteEnabled and EnforcePatCreation emit

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -928,10 +928,16 @@ export class NoteChannel {
 		});
 		if (this.deviceId) params.set("device_id", this.deviceId);
 		if (this.vaultId) params.set("vault_id", this.vaultId);
-		// The socket half of the compatibility floor, and the ONLY place the
-		// backend records the installed base's version distribution (one field
-		// per connect, not per request). ChannelGate refuses a join below the
-		// floor with reason `plugin_upgrade_required`.
+		// The socket half of the compatibility floor. ChannelGate refuses a join
+		// below the floor with reason `plugin_upgrade_required`.
+		//
+		// Also the version signal with the BEST COVERAGE — not the only one.
+		// `remote-log.ts` puts plugin_version on every client log entry and the
+		// backend persists it as an indexed column (`logs/client_log.ex`), which
+		// is far easier to query than a log line; but client logs only ship when
+		// the user has enabled diagnostics, so that source silently under-counts
+		// exactly the disengaged installs a floor decision most needs to see.
+		// One field per connect, not per request.
 		const version = pluginVersion();
 		if (version) params.set("plugin_version", version);
 		const url = `${wsBase}/socket/websocket?${params.toString()}`;
@@ -1300,6 +1306,15 @@ export class NoteChannel {
 				// the refusal on a backend or code path where sync: is rejected
 				// first — leaving the user with a silent, permanent failure.
 				// Latches to one notice per session inside notifyUpgradeRequired.
+				//
+				// Also ref-agnostic, unlike the crdt branch below which screens on
+				// `crdtJoinMsgRef` to separate a JOIN error from a per-message
+				// error reply. Safe only because `plugin_upgrade_required` comes
+				// from `ChannelGate.check/3`, which is called from `join/3` and
+				// nowhere else. If the server ever emits that reason on a
+				// per-message reply, this needs the same ref screen — otherwise
+				// one stray frame latches the notice and permanently suppresses
+				// the real one.
 				if (joinReason === "plugin_upgrade_required") {
 					notifyUpgradeRequired(
 						typeof joinResponse?.min_version === "string"

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2,6 +2,7 @@ import type { AuthProvider } from "./auth";
 import { expBackoff } from "./backoff";
 import { errMsg } from "./error-util";
 import { noteRef } from "./note-ref";
+import { pluginVersion } from "./plugin-version";
 import { rlog } from "./remote-log";
 
 /** How long to wait before reconnecting when no auth token is available
@@ -926,6 +927,12 @@ export class NoteChannel {
 		});
 		if (this.deviceId) params.set("device_id", this.deviceId);
 		if (this.vaultId) params.set("vault_id", this.vaultId);
+		// The socket half of the compatibility floor, and the ONLY place the
+		// backend records the installed base's version distribution (one field
+		// per connect, not per request). ChannelGate refuses a join below the
+		// floor with reason `plugin_upgrade_required`.
+		const version = pluginVersion();
+		if (version) params.set("plugin_version", version);
 		const url = `${wsBase}/socket/websocket?${params.toString()}`;
 
 		const openedAt = Date.now();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -4,6 +4,7 @@ import { errMsg } from "./error-util";
 import { noteRef } from "./note-ref";
 import { pluginVersion } from "./plugin-version";
 import { rlog } from "./remote-log";
+import { notifyUpgradeRequired } from "./upgrade-required";
 
 /** How long to wait before reconnecting when no auth token is available
  *  (e.g. plugin loaded before OAuth refresh hydrated, or user signed out).
@@ -1287,11 +1288,28 @@ export class NoteChannel {
 					"channel",
 					`Channel join error on ${topic}: ${JSON.stringify(payload)}`,
 				);
+				const joinResponse = (
+					payload as {
+						response?: { reason?: unknown; min?: unknown; min_version?: unknown };
+					}
+				).response;
+				const joinReason =
+					typeof joinResponse?.reason === "string" ? joinResponse.reason : undefined;
+				// Checked for EVERY topic, not just crdt:. The version floor refuses
+				// sync: and crdt: alike, and the crdt-only branch below would miss
+				// the refusal on a backend or code path where sync: is rejected
+				// first — leaving the user with a silent, permanent failure.
+				// Latches to one notice per session inside notifyUpgradeRequired.
+				if (joinReason === "plugin_upgrade_required") {
+					notifyUpgradeRequired(
+						typeof joinResponse?.min_version === "string"
+							? joinResponse.min_version
+							: null,
+					);
+				}
 				if (topic === this.crdtTopic) {
-					const response = (payload as { response?: { reason?: unknown; min?: unknown } })
-						.response;
-					const reason =
-						typeof response?.reason === "string" ? response.reason : undefined;
+					const response = joinResponse;
+					const reason = joinReason;
 					const min = typeof response?.min === "number" ? response.min : undefined;
 					if (ref === this.crdtJoinMsgRef) {
 						// Remember the rejection for THIS session so a subsequent whole-

--- a/src/main.ts
+++ b/src/main.ts
@@ -1383,9 +1383,13 @@ export default class EngramSyncPlugin extends Plugin {
 		setLogSink(null);
 		setActiveTracker(null);
 		// Same rule uninstallDebugApi states: a module-level closure over the
-		// instance being unloaded outlives it. A 426 landing between here and
-		// the next eval (the beacon flush above can produce one) would render a
-		// notice whose Update button calls into a dead `this.app`.
+		// instance being unloaded outlives it. The 426 that can land after this
+		// point comes from `destroyRemoteLog()` below — it awaits a final
+		// flush() -> pushLogs -> EngramApi.request, inside a voided promise, so
+		// it settles after this synchronous line. (NOT the beacon flush: that
+		// uses window.fetch and never reads .status, so it cannot reach
+		// notifyUpgradeRequired.) Without this, the notice's Update button
+		// would call into a dead `this.app`.
 		setUpgradeAction(null);
 		this.promiseTracker?.destroy();
 		this.promiseTracker = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1382,6 +1382,11 @@ export default class EngramSyncPlugin extends Plugin {
 		// down after this point would otherwise write into a destroyed devLog.
 		setLogSink(null);
 		setActiveTracker(null);
+		// Same rule uninstallDebugApi states: a module-level closure over the
+		// instance being unloaded outlives it. A 426 landing between here and
+		// the next eval (the beacon flush above can produce one) would render a
+		// notice whose Update button calls into a dead `this.app`.
+		setUpgradeAction(null);
 		this.promiseTracker?.destroy();
 		this.promiseTracker = null;
 		destroyDevLog();

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,7 @@ import {
 	type SyncStatus,
 } from "./types";
 import { checkForPluginUpdate } from "./update-check";
+import { setUpgradeAction } from "./upgrade-required";
 
 /** Generate a stable client ID for vault registration.
  *  Uses SHA-256 of the vault's absolute path (desktop) or name (mobile fallback). */
@@ -489,6 +490,10 @@ export default class EngramSyncPlugin extends Plugin {
 		// plugin_version on the socket URL. Set it late and the first requests
 		// of a launch go out unversioned.
 		setPluginVersion(this.manifest.version);
+		// Reuses the soft nudge's destination: a hard "too old to sync" refusal
+		// and a "newer version available" nudge want the same place, and that
+		// path is already feature-detected against Obsidian internals.
+		setUpgradeAction(() => this.openCommunityPluginsUpdate());
 		rlog().info("lifecycle", `onload start — v${this.manifest.version}`);
 		activeDocument.body.classList.add("engram-vault-sync-active");
 		await this.loadSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ import { LimitExceededError } from "./limit-error";
 import { notifyLimitExceeded } from "./limit-toast";
 import { parsePlanState } from "./plan-state";
 import { atomicWriteJson, resilientReadJson } from "./plugin-data-io";
+import { setPluginVersion } from "./plugin-version";
 import { destroyRemoteLog, initRemoteLog, rlog } from "./remote-log";
 import { SearchModal } from "./search-modal";
 import { SEARCH_VIEW_TYPE, SearchView } from "./search-view";
@@ -483,6 +484,11 @@ export default class EngramSyncPlugin extends Plugin {
 			setActiveTracker(this.promiseTracker);
 		}
 		devLog().log("lifecycle", "plugin loading");
+		// Ahead of every transport, because both read it lazily on the wire: the
+		// api client stamps X-Plugin-Version per request and the channel puts
+		// plugin_version on the socket URL. Set it late and the first requests
+		// of a launch go out unversioned.
+		setPluginVersion(this.manifest.version);
 		rlog().info("lifecycle", `onload start — v${this.manifest.version}`);
 		activeDocument.body.classList.add("engram-vault-sync-active");
 		await this.loadSettings();

--- a/src/plugin-version.ts
+++ b/src/plugin-version.ts
@@ -1,0 +1,29 @@
+/**
+ * The running plugin's version, reported to the backend on every REST call
+ * (`X-Plugin-Version`) and every socket connect (`plugin_version`).
+ *
+ * The backend refuses clients below a floor it ships as a constant — see
+ * `Engram.PluginVersion`. Reporting is what makes that floor enforceable AND
+ * what makes the installed-base distribution visible in the `ws connect` log,
+ * which is the only signal that says whether raising the floor is safe.
+ *
+ * A module singleton rather than a constructor parameter because the version
+ * is fixed for the process and needed in two unrelated transports; threading
+ * it would mean a sixth positional argument on `NoteChannel`'s constructor
+ * AND on `updateConfig`. Set once from `manifest.version` in `onload`.
+ *
+ * Unset reads as "" and is OMITTED from the wire, not sent as an empty value.
+ * The backend allows anything it cannot parse, so an empty string would work
+ * too — but omission keeps "never reported" and "reported garbage" distinct in
+ * the logs, and those need different responses.
+ */
+let version = "";
+
+export function setPluginVersion(v: string): void {
+	version = v;
+}
+
+/** "" until `setPluginVersion` runs. Callers must omit the field when empty. */
+export function pluginVersion(): string {
+	return version;
+}

--- a/src/plugin-version.ts
+++ b/src/plugin-version.ts
@@ -3,18 +3,32 @@
  * that goes through `EngramApi` (`X-Plugin-Version`) and every socket connect
  * (`plugin_version`).
  *
- * Five network paths bypass `EngramApi` and therefore report nothing, all
- * correctly: token refresh (`main.ts`), the two device-flow calls
- * (`device-flow-modal.ts`), `EngramApi.probeHealth` (static, no instance), and
- * the beacon's raw `window.fetch` (`observability/beacon.ts`). The auth ones
- * MUST stay exempt — a client refused for being too old still has to be able
- * to link and refresh a token, or the only way out of the block is a
- * reinstall.
+ * Several network paths do NOT carry it, all correctly:
+ *
+ *   - token refresh (`main.ts`) and the two device-flow calls
+ *     (`device-flow-modal.ts`) — these MUST stay exempt, or a client refused
+ *     for being too old cannot link or refresh a token and the only way out of
+ *     the block is a reinstall;
+ *   - `device-flow-socket.ts`, which opens `/socket/device/websocket` with no
+ *     `plugin_version` param, for the same reason;
+ *   - `EngramApi.probeHealth` (static, no instance) and `EngramApi.health()`
+ *     (an instance method that calls `requestUrl` directly rather than through
+ *     `sendRequest`) — `/health` is public and ungated;
+ *   - the beacon's raw `window.fetch` (`observability/beacon.ts`);
+ *   - `update-check.ts`, which fetches the published manifest from GitHub.
+ *
+ * The list is worth keeping accurate: an earlier version said "every REST
+ * call" and then "five paths", and both were wrong. Grep `requestUrl(`,
+ * `fetch(` and `new WebSocket` before trusting it.
  *
  * The backend refuses clients below a floor it ships as a constant — see
  * `Engram.PluginVersion`. Reporting is what makes that floor enforceable AND
- * what makes the installed-base distribution visible in the `ws connect` log,
- * which is the only signal that says whether raising the floor is safe.
+ * what makes the installed-base distribution visible in the `ws connect` log.
+ * That log is the version signal with the best COVERAGE, not the only one:
+ * `remote-log.ts` sends the same value on every client log entry and the
+ * backend stores it as an indexed column, but only when the user has enabled
+ * diagnostics — so it under-counts exactly the disengaged installs a floor
+ * decision most needs to see.
  *
  * A module singleton rather than a constructor parameter because the version
  * is fixed for the process and needed in two unrelated transports; threading

--- a/src/plugin-version.ts
+++ b/src/plugin-version.ts
@@ -1,6 +1,15 @@
 /**
  * The running plugin's version, reported to the backend on every REST call
- * (`X-Plugin-Version`) and every socket connect (`plugin_version`).
+ * that goes through `EngramApi` (`X-Plugin-Version`) and every socket connect
+ * (`plugin_version`).
+ *
+ * Five network paths bypass `EngramApi` and therefore report nothing, all
+ * correctly: token refresh (`main.ts`), the two device-flow calls
+ * (`device-flow-modal.ts`), `EngramApi.probeHealth` (static, no instance), and
+ * the beacon's raw `window.fetch` (`observability/beacon.ts`). The auth ones
+ * MUST stay exempt — a client refused for being too old still has to be able
+ * to link and refresh a token, or the only way out of the block is a
+ * reinstall.
  *
  * The backend refuses clients below a floor it ships as a constant — see
  * `Engram.PluginVersion`. Reporting is what makes that floor enforceable AND

--- a/src/upgrade-required.ts
+++ b/src/upgrade-required.ts
@@ -1,0 +1,91 @@
+/**
+ * upgrade-required.ts — the client half of the backend's minimum-plugin-version
+ * floor.
+ *
+ * The server refuses a plugin older than its floor: HTTP `426` on REST, and a
+ * `plugin_upgrade_required` reason on a channel join. Both are terminal —
+ * retrying cannot clear them and every transport is refused at once — so the
+ * user has to be told, or they watch sync fail forever with no explanation.
+ *
+ * ## Why the server's `update_url` is ignored
+ *
+ * The 426 body carries one, and this module deliberately does not read it.
+ * `api.ts`'s `sanitizeUpgradeUrl` already refuses any non-http(s) URL from a
+ * 402 body precisely because a malicious self-host backend must not be able to
+ * launch arbitrary protocol handlers — and the natural update target here IS a
+ * non-http scheme (`obsidian://`). Rather than carve an exception into that
+ * rule, the action is supplied locally by `main.ts` via `setUpgradeAction`.
+ * The server field stays useful to other clients; this one never trusts it.
+ *
+ * ## Once per session
+ *
+ * Every refused request and every reconnect would otherwise toast. The latch
+ * clears only on plugin reload, which is also when a freshly-installed version
+ * would take effect.
+ *
+ * ponytail: does NOT stop sync. The server already refuses everything, so a
+ * local kill switch would only duplicate that at the cost of a second piece of
+ * state to get wrong. Add one if the reconnect traffic ever shows up as load.
+ */
+import { Notice } from "obsidian";
+import { rlog } from "./remote-log";
+
+const NOTICE_MS = 15_000;
+
+let notified = false;
+let openUpdateUi: (() => void) | null = null;
+
+/**
+ * Supply the "take me there" action. `main.ts` passes its
+ * `openCommunityPluginsUpdate`, which opens Obsidian's Community plugins tab
+ * and refreshes its update check — the same path the soft update nudge uses,
+ * already feature-detected against Obsidian internals.
+ *
+ * Unset (tests, or a load order that never got here) degrades to a Notice with
+ * no link, never a throw.
+ */
+export function setUpgradeAction(fn: (() => void) | null): void {
+	openUpdateUi = fn;
+}
+
+/** Tell the user their plugin is too old. First call wins; the rest are no-ops. */
+export function notifyUpgradeRequired(minVersion: string | null): void {
+	if (notified) return;
+	notified = true;
+
+	rlog().warn(
+		"lifecycle",
+		`server requires plugin >= ${minVersion ?? "unknown"} — sync refused until updated`,
+	);
+
+	const needs = minVersion ? ` (needs ${minVersion} or newer)` : "";
+	const notice = new Notice(
+		`Engram: this plugin is too old to sync${needs}. Update it to continue.`,
+		NOTICE_MS,
+	);
+
+	// No action wired = no button. A button that does nothing is worse than
+	// prose telling the user to go update.
+	const action = openUpdateUi;
+	if (!action) return;
+	const noticeEl = (notice as unknown as { noticeEl?: HTMLElement }).noticeEl;
+	if (!noticeEl) return;
+	// "Update", never "Upgrade" — the 402 toast next door uses "Upgrade" for
+	// paying more money, and these two must not read as the same action.
+	const btn = noticeEl.createEl("button", {
+		text: "Update",
+		cls: "engram-limit-upgrade-btn",
+	});
+	btn.addEventListener("click", () => action());
+}
+
+/** True once the server has refused us for being too old. */
+export function isUpgradeRequired(): boolean {
+	return notified;
+}
+
+/** Test seam. The latch is otherwise per-process by design. */
+export function resetUpgradeRequired(): void {
+	notified = false;
+	openUpdateUi = null;
+}

--- a/src/upgrade-required.ts
+++ b/src/upgrade-required.ts
@@ -26,6 +26,15 @@
  * ponytail: does NOT stop sync. The server already refuses everything, so a
  * local kill switch would only duplicate that at the cost of a second piece of
  * state to get wrong. Add one if the reconnect traffic ever shows up as load.
+ *
+ * What that actually looks like on the wire, since "does not stop sync" sounds
+ * busier than it is: Phoenix does not close a socket on a join error, so a
+ * refused client keeps ONE open socket. `sync:` and `crdt:` are refused,
+ * `user:` still joins (no version gate on `check_not_deleted/1`), and the 30s
+ * heartbeat keeps the connection alive — so `onclose` never fires and the
+ * `crdtJoinFailedReason` backoff in `channel.ts` is never reached. The client
+ * idles with `connected === false` rather than retry-storming. Nothing watches
+ * that flag today.
  */
 import { Notice } from "obsidian";
 import { rlog } from "./remote-log";

--- a/src/upgrade-required.ts
+++ b/src/upgrade-required.ts
@@ -57,14 +57,28 @@ export function setUpgradeAction(fn: (() => void) | null): void {
 	openUpdateUi = fn;
 }
 
+/** Where the refusal came from. Folded into the single latched log line so a
+ *  false positive is diagnosable — 426 is a generic HTTP status and a proxy in
+ *  front of a self-hosted backend can emit a bare one, leaving the user with
+ *  "this plugin is too old" that updating cannot fix. Omitted for a socket
+ *  refusal, which `channel.ts` logs separately with its own topic. */
+export interface UpgradeRefusalSource {
+	method: string;
+	route: string;
+}
+
 /** Tell the user their plugin is too old. First call wins; the rest are no-ops. */
-export function notifyUpgradeRequired(minVersion: string | null): void {
+export function notifyUpgradeRequired(
+	minVersion: string | null,
+	source?: UpgradeRefusalSource,
+): void {
 	if (notified) return;
 	notified = true;
 
+	const where = source ? ` on ${source.method} ${source.route}` : "";
 	rlog().warn(
 		"lifecycle",
-		`server requires plugin >= ${minVersion ?? "unknown"} — sync refused until updated`,
+		`server requires plugin >= ${minVersion ?? "unknown"}${where} — sync refused until updated`,
 	);
 
 	const needs = minVersion ? ` (needs ${minVersion} or newer)` : "";

--- a/tests/channel-plugin-version.test.ts
+++ b/tests/channel-plugin-version.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, expect, test } from "bun:test";
+import { afterEach, beforeAll, beforeEach, expect, test } from "bun:test";
 import { NoteChannel } from "../src/channel";
 import { setPluginVersion } from "../src/plugin-version";
 
@@ -25,10 +25,18 @@ beforeAll(() => {
 
 afterEach(() => setPluginVersion(""));
 
+// `lastUrl` is static and survives between tests, so the "omits" case would
+// otherwise read whatever the previous socket left behind and pass on stale
+// state.
+beforeEach(() => {
+	FakeWS.lastUrl = "";
+});
+
 // The socket param is the load-bearing half of the compatibility floor: sync
 // runs over channels, so a floor enforced only on REST would leave a blocked
-// client syncing. It is also the ONLY place the backend records which plugin
-// versions are actually in use.
+// client syncing. It is also the version signal with the best COVERAGE — the
+// client-log column carries the same value but only when the user has enabled
+// diagnostics.
 test("puts plugin_version on the socket URL", async () => {
 	setPluginVersion("1.28.0");
 	const ch = new NoteChannel("http://x", "key-123", "user-1", "vault-9", "dev-1");

--- a/tests/channel-plugin-version.test.ts
+++ b/tests/channel-plugin-version.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeAll, expect, test } from "bun:test";
+import { NoteChannel } from "../src/channel";
+import { setPluginVersion } from "../src/plugin-version";
+
+// Capture the URL passed to WebSocket without opening a real socket.
+class FakeWS {
+	static lastUrl = "";
+	static OPEN = 1;
+	onopen: (() => void) | null = null;
+	onclose: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	onmessage: (() => void) | null = null;
+	readyState = 0;
+	constructor(url: string) {
+		FakeWS.lastUrl = url;
+	}
+	close() {}
+	send() {}
+}
+
+beforeAll(() => {
+	// @ts-expect-error test shim
+	global.WebSocket = FakeWS;
+});
+
+afterEach(() => setPluginVersion(""));
+
+// The socket param is the load-bearing half of the compatibility floor: sync
+// runs over channels, so a floor enforced only on REST would leave a blocked
+// client syncing. It is also the ONLY place the backend records which plugin
+// versions are actually in use.
+test("puts plugin_version on the socket URL", async () => {
+	setPluginVersion("1.28.0");
+	const ch = new NoteChannel("http://x", "key-123", "user-1", "vault-9", "dev-1");
+
+	await ch.connect();
+
+	expect(FakeWS.lastUrl).toContain("plugin_version=1.28.0");
+});
+
+test("omits plugin_version when unset", async () => {
+	const ch = new NoteChannel("http://x", "key-123", "user-1", "vault-9", "dev-1");
+
+	await ch.connect();
+
+	expect(FakeWS.lastUrl).not.toContain("plugin_version");
+});

--- a/tests/plugin-version-wiring.test.ts
+++ b/tests/plugin-version-wiring.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Compliance test: the version floor's `onload` wiring.
+ *
+ * Everything else about this feature is unit-tested by calling
+ * `setPluginVersion` / `setUpgradeAction` directly. That leaves the one line
+ * production actually depends on covered by nothing: delete
+ * `setPluginVersion(this.manifest.version)` from `onload` and every other test
+ * stays green while the feature goes 100% inert — no header, no socket param,
+ * so no floor and no notice, on every install.
+ *
+ * Booting `onload` in a test would need most of Obsidian. Scanning the source
+ * is the cheap guard that still fails for the thing that actually breaks, and
+ * matches the existing compliance tests in this directory
+ * (`command-ids.test.ts`, `manifest-compliance.test.ts`).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const main = readFileSync(join(import.meta.dir, "..", "src", "main.ts"), "utf8");
+
+/** The body of `async onload()`, up to the next top-level method. */
+function onloadBody(source: string): string {
+	const start = source.indexOf("async onload(): Promise<void> {");
+	expect(start).toBeGreaterThan(-1);
+	const end = source.indexOf("\n\tonunload(): void {", start);
+	expect(end).toBeGreaterThan(start);
+	return source.slice(start, end);
+}
+
+describe("onload wiring", () => {
+	test("reports the manifest version, not a hardcoded string", () => {
+		expect(onloadBody(main)).toContain("setPluginVersion(this.manifest.version)");
+	});
+
+	test("wires the upgrade action so the notice has a working button", () => {
+		expect(onloadBody(main)).toContain("setUpgradeAction(");
+	});
+
+	// Both transports read the version lazily, so a late set means the first
+	// requests of a launch go out unversioned and are silently exempt from the
+	// floor. It must precede anything that can reach the network.
+	test("sets the version before the api client is constructed", () => {
+		const body = onloadBody(main);
+		const set = body.indexOf("setPluginVersion(");
+		const api = body.indexOf("new EngramApi(");
+
+		expect(set).toBeGreaterThan(-1);
+		expect(api).toBeGreaterThan(-1);
+		expect(set).toBeLessThan(api);
+	});
+
+	// Module-level closure over the instance being unloaded — the same rule
+	// uninstallDebugApi states for the debug global.
+	test("releases the upgrade action on unload", () => {
+		expect(main).toContain("setUpgradeAction(null)");
+	});
+});

--- a/tests/plugin-version-wiring.test.ts
+++ b/tests/plugin-version-wiring.test.ts
@@ -20,22 +20,59 @@ import { join } from "node:path";
 
 const main = readFileSync(join(import.meta.dir, "..", "src", "main.ts"), "utf8");
 
-/** The body of `async onload()`, up to the next top-level method. */
+/** The body of `async onload()`, up to the NEXT top-level member.
+ *
+ *  Not `onunload` — that is 858 lines and three methods further on
+ *  (`handleSyncError`, `healingVault`, `healDeadVault` all sit between), so
+ *  slicing to it made "appears in onload" mean "appears anywhere in a
+ *  three-method window". Moving the call into `healDeadVault` — reached only
+ *  on a dead-vault error — kept the naive version green.
+ *
+ *  The boundary is therefore the first top-level member AFTER the opening: a
+ *  line at exactly one tab of indent that declares something. If that regex
+ *  stops matching, the slice runs long and the tests get WEAKER silently, so
+ *  the length is asserted too. */
 function onloadBody(source: string): string {
 	const start = source.indexOf("async onload(): Promise<void> {");
 	expect(start).toBeGreaterThan(-1);
-	const end = source.indexOf("\n\tonunload(): void {", start);
-	expect(end).toBeGreaterThan(start);
-	return source.slice(start, end);
+	const rest = source.slice(start + 1);
+	const next = rest.search(/\n\t(?:private |readonly |async |@)?\w+[<(:]/);
+	expect(next).toBeGreaterThan(-1);
+	const body = rest.slice(0, next);
+	// onload really is ~772 lines and ends at `private handleSyncError`. The
+	// naive boundary (`onunload`) ran ~858 lines further, swallowing
+	// handleSyncError, healingVault and healDeadVault — so a call relocated
+	// into healDeadVault, reached only on a dead-vault error, still "appeared
+	// in onload". Naming the two methods that must NOT be in scope fails
+	// loudly if the boundary drifts, which a line count alone would not.
+	// Their DECLARATIONS, not their names — `onload` legitimately calls both.
+	expect(body).not.toContain("private handleSyncError(");
+	expect(body).not.toContain("private async healDeadVault(");
+	return body;
+}
+
+/** A call must be LIVE: at method-body indent, not commented out, not nested
+ *  inside a conditional. `toContain` matched `// setPluginVersion(...)` and
+ *  `if (DEV_MODE) setPluginVersion(...)` — both of which leave the feature
+ *  completely inert on a production install while all four tests pass. */
+function callsAtTopLevel(body: string, call: string): boolean {
+	return body.split("\n").some((l) => l === `\t\t${call}`);
 }
 
 describe("onload wiring", () => {
 	test("reports the manifest version, not a hardcoded string", () => {
-		expect(onloadBody(main)).toContain("setPluginVersion(this.manifest.version)");
+		expect(callsAtTopLevel(onloadBody(main), "setPluginVersion(this.manifest.version);")).toBe(
+			true,
+		);
 	});
 
 	test("wires the upgrade action so the notice has a working button", () => {
-		expect(onloadBody(main)).toContain("setUpgradeAction(");
+		expect(
+			callsAtTopLevel(
+				onloadBody(main),
+				"setUpgradeAction(() => this.openCommunityPluginsUpdate());",
+			),
+		).toBe(true);
 	});
 
 	// Both transports read the version lazily, so a late set means the first

--- a/tests/plugin-version.test.ts
+++ b/tests/plugin-version.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The backend refuses clients below a compatibility floor (426
+ * `plugin_upgrade_required` on REST, the same reason on a channel join) and
+ * reads the installed-base version distribution off these two fields.
+ *
+ * If either stops being sent the floor silently stops applying to us and the
+ * distribution goes blank. Both failures are invisible in normal use, which
+ * is the whole reason they are pinned here.
+ */
+import { afterEach, beforeEach, describe, expect, type Mock, test } from "bun:test";
+import { requestUrl } from "obsidian";
+import { EngramApi } from "../src/api";
+import { pluginVersion, setPluginVersion } from "../src/plugin-version";
+
+const mockRequestUrl = requestUrl as unknown as Mock<() => Promise<any>>;
+
+const okResponse = { status: 200, json: { notes: [], attachments: [] } } as any;
+
+describe("X-Plugin-Version", () => {
+	let api: EngramApi;
+
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+		api = new EngramApi("https://api.example.com", "test-key");
+	});
+
+	// Module singleton: leaking a version into the next file's tests would make
+	// the "omits when unset" case pass or fail on ordering.
+	afterEach(() => setPluginVersion(""));
+
+	test("stamps the version set at onload", async () => {
+		setPluginVersion("1.28.0");
+		mockRequestUrl.mockResolvedValueOnce(okResponse);
+
+		await api.getManifest();
+
+		expect(mockRequestUrl.mock.calls[0][0].headers["X-Plugin-Version"]).toBe("1.28.0");
+	});
+
+	// Omitted, not sent empty. The backend allows both, but "never reported"
+	// and "reported junk" want different operator responses.
+	test("omits the header when the version was never set", async () => {
+		mockRequestUrl.mockResolvedValueOnce(okResponse);
+
+		await api.getManifest();
+
+		expect(mockRequestUrl.mock.calls[0][0].headers["X-Plugin-Version"]).toBeUndefined();
+	});
+
+	test("is read per request, so a late set still reaches the wire", async () => {
+		mockRequestUrl.mockResolvedValueOnce(okResponse);
+		await api.getManifest();
+		expect(mockRequestUrl.mock.calls[0][0].headers["X-Plugin-Version"]).toBeUndefined();
+
+		setPluginVersion("1.29.0");
+		mockRequestUrl.mockResolvedValueOnce(okResponse);
+		await api.getManifest();
+
+		expect(mockRequestUrl.mock.calls[1][0].headers["X-Plugin-Version"]).toBe("1.29.0");
+	});
+});
+
+describe("setPluginVersion", () => {
+	afterEach(() => setPluginVersion(""));
+
+	test("round-trips", () => {
+		expect(pluginVersion()).toBe("");
+		setPluginVersion("9.9.9");
+		expect(pluginVersion()).toBe("9.9.9");
+	});
+});

--- a/tests/upgrade-required.test.ts
+++ b/tests/upgrade-required.test.ts
@@ -94,7 +94,10 @@ describe("REST 426", () => {
 
 		const api = new EngramApi("https://api.example.com", "key");
 
-		await expect(api.getManifest()).rejects.toBeDefined();
+		// Shape asserted, not just "it threw": the contract is that a 426 is
+		// rethrown UNCHANGED. `toBeDefined()` passed even when the error was
+		// replaced wholesale.
+		await expect(api.getManifest()).rejects.toMatchObject({ status: 426 });
 		expect(__noticeCapture.notices).toHaveLength(1);
 		expect(__noticeCapture.notices[0].message).toContain("1.29.0");
 	});
@@ -107,7 +110,10 @@ describe("REST 426", () => {
 
 		const api = new EngramApi("https://api.example.com", "key");
 
-		await expect(api.getManifest()).rejects.toBeDefined();
+		// Shape asserted, not just "it threw": the contract is that a 426 is
+		// rethrown UNCHANGED. `toBeDefined()` passed even when the error was
+		// replaced wholesale.
+		await expect(api.getManifest()).rejects.toMatchObject({ status: 426 });
 		expect(__noticeCapture.notices[0].message).toContain("1.31.0");
 	});
 
@@ -116,8 +122,37 @@ describe("REST 426", () => {
 
 		const api = new EngramApi("https://api.example.com", "key");
 
-		await expect(api.getManifest()).rejects.toBeDefined();
+		// Shape asserted, not just "it threw": the contract is that a 426 is
+		// rethrown UNCHANGED. `toBeDefined()` passed even when the error was
+		// replaced wholesale.
+		await expect(api.getManifest()).rejects.toMatchObject({ status: 426 });
 		expect(__noticeCapture.notices).toHaveLength(1);
+	});
+
+	// The shape a real launch produces. Server-side `Auth` runs BEFORE
+	// `RequirePluginVersion`, so a stale cached token yields 401-then-426 —
+	// the 426 lands on the single-shot retry path, not the primary one.
+	// That path handled 402 and not 426, so the notice never fired at all.
+	test("a 426 arriving on the 401 retry still notifies", async () => {
+		const api = new EngramApi("https://api.example.com", "key");
+		api.setAuthProvider({
+			getToken: async () => "token",
+			getVaultId: () => null,
+			isAuthenticated: () => true,
+			signOut: () => {},
+			invalidateAccessToken: () => {},
+		} as any);
+
+		mockRequestUrl.mockRejectedValueOnce({ status: 401, text: "unauthorized" });
+		mockRequestUrl.mockRejectedValueOnce({
+			status: 426,
+			json: { min_version: "1.29.0" },
+		});
+
+		await expect(api.getManifest()).rejects.toMatchObject({ status: 426 });
+
+		expect(__noticeCapture.notices).toHaveLength(1);
+		expect(__noticeCapture.notices[0].message).toContain("1.29.0");
 	});
 
 	test("other statuses do not trip it", async () => {
@@ -125,7 +160,7 @@ describe("REST 426", () => {
 
 		const api = new EngramApi("https://api.example.com", "key");
 
-		await expect(api.getManifest()).rejects.toBeDefined();
+		await expect(api.getManifest()).rejects.toMatchObject({ status: 500 });
 		expect(__noticeCapture.notices).toHaveLength(0);
 		expect(isUpgradeRequired()).toBe(false);
 	});

--- a/tests/upgrade-required.test.ts
+++ b/tests/upgrade-required.test.ts
@@ -1,0 +1,193 @@
+/**
+ * The client half of the backend's minimum-plugin-version floor.
+ *
+ * Every case here guards a SILENT failure: if the 426 branch or the join-reason
+ * branch stops firing, the user gets sync that fails forever with no
+ * explanation, and nothing in the logs looks different from an outage.
+ */
+import { afterEach, beforeEach, describe, expect, type Mock, mock, test } from "bun:test";
+import { requestUrl } from "obsidian";
+import { EngramApi } from "../src/api";
+import { NoteChannel } from "../src/channel";
+import {
+	isUpgradeRequired,
+	notifyUpgradeRequired,
+	resetUpgradeRequired,
+	setUpgradeAction,
+} from "../src/upgrade-required";
+import { __noticeCapture } from "./__mocks__/obsidian";
+
+const mockRequestUrl = requestUrl as unknown as Mock<() => Promise<any>>;
+
+beforeEach(() => {
+	__noticeCapture.notices.length = 0;
+	mockRequestUrl.mockReset();
+	resetUpgradeRequired();
+});
+
+afterEach(() => resetUpgradeRequired());
+
+describe("notifyUpgradeRequired", () => {
+	test("names the minimum version so the user can tell if they already updated", () => {
+		notifyUpgradeRequired("1.29.0");
+
+		expect(__noticeCapture.notices).toHaveLength(1);
+		const n = __noticeCapture.notices[0];
+		expect(n.message).toMatch(/too old/i);
+		expect(n.message).toContain("1.29.0");
+		expect(n.duration).toBeGreaterThanOrEqual(10_000);
+	});
+
+	test("still says something useful when the body carried no version", () => {
+		notifyUpgradeRequired(null);
+
+		expect(__noticeCapture.notices[0].message).toMatch(/too old/i);
+	});
+
+	// Every refused request and every reconnect would otherwise toast.
+	test("latches to one notice per session", () => {
+		notifyUpgradeRequired("1.29.0");
+		notifyUpgradeRequired("1.29.0");
+		notifyUpgradeRequired("1.30.0");
+
+		expect(__noticeCapture.notices).toHaveLength(1);
+		expect(isUpgradeRequired()).toBe(true);
+	});
+
+	test("the button is labelled Update, not Upgrade", () => {
+		// The 402 toast next door says "Upgrade" and means "pay more". A user
+		// who reads this one as a sales prompt will dismiss it and stay broken.
+		setUpgradeAction(() => {});
+		notifyUpgradeRequired("1.29.0");
+
+		expect(__noticeCapture.notices[0].buttons).toHaveLength(1);
+		expect(__noticeCapture.notices[0].buttons[0].text).toBe("Update");
+	});
+
+	test("the button runs the injected action", () => {
+		const action = mock(() => {});
+		setUpgradeAction(action);
+		notifyUpgradeRequired("1.29.0");
+
+		__noticeCapture.notices[0].buttons[0].click();
+
+		expect(action).toHaveBeenCalledTimes(1);
+	});
+
+	test("renders no button when no action was wired", () => {
+		notifyUpgradeRequired("1.29.0");
+
+		expect(__noticeCapture.notices[0].buttons).toHaveLength(0);
+	});
+});
+
+describe("REST 426", () => {
+	test("a refused request notifies and still rejects", async () => {
+		mockRequestUrl.mockRejectedValueOnce({
+			status: 426,
+			json: {
+				error: "plugin_upgrade_required",
+				min_version: "1.29.0",
+				your_version: "1.10.0",
+			},
+		});
+
+		const api = new EngramApi("https://api.example.com", "key");
+
+		await expect(api.getManifest()).rejects.toBeDefined();
+		expect(__noticeCapture.notices).toHaveLength(1);
+		expect(__noticeCapture.notices[0].message).toContain("1.29.0");
+	});
+
+	test("reads a body that arrived as raw text", async () => {
+		mockRequestUrl.mockRejectedValueOnce({
+			status: 426,
+			text: JSON.stringify({ min_version: "1.31.0" }),
+		});
+
+		const api = new EngramApi("https://api.example.com", "key");
+
+		await expect(api.getManifest()).rejects.toBeDefined();
+		expect(__noticeCapture.notices[0].message).toContain("1.31.0");
+	});
+
+	test("a malformed body still notifies rather than crashing the error path", async () => {
+		mockRequestUrl.mockRejectedValueOnce({ status: 426, text: "<html>nope" });
+
+		const api = new EngramApi("https://api.example.com", "key");
+
+		await expect(api.getManifest()).rejects.toBeDefined();
+		expect(__noticeCapture.notices).toHaveLength(1);
+	});
+
+	test("other statuses do not trip it", async () => {
+		mockRequestUrl.mockRejectedValueOnce({ status: 500, text: "boom" });
+
+		const api = new EngramApi("https://api.example.com", "key");
+
+		await expect(api.getManifest()).rejects.toBeDefined();
+		expect(__noticeCapture.notices).toHaveLength(0);
+		expect(isUpgradeRequired()).toBe(false);
+	});
+});
+
+describe("channel join refusal", () => {
+	class FakeWS {
+		static last: FakeWS | null = null;
+		static OPEN = 1;
+		onopen: (() => void) | null = null;
+		onclose: (() => void) | null = null;
+		onerror: (() => void) | null = null;
+		onmessage: ((e: { data: string }) => void) | null = null;
+		readyState = 0;
+		constructor(_url: string) {
+			FakeWS.last = this;
+		}
+		close() {}
+		send() {}
+	}
+
+	const joinError = (topic: string, reason: string, minVersion?: string) =>
+		JSON.stringify([
+			null,
+			"1",
+			topic,
+			"phx_reply",
+			{
+				status: "error",
+				response: { reason, ...(minVersion ? { min_version: minVersion } : {}) },
+			},
+		]);
+
+	beforeEach(() => {
+		// @ts-expect-error test shim
+		global.WebSocket = FakeWS;
+		FakeWS.last = null;
+	});
+
+	// Checked for EVERY topic. The floor refuses sync: and crdt: alike, and the
+	// crdt-only path would miss a sync: refusal entirely.
+	test("a sync: topic refusal notifies", async () => {
+		const ch = new NoteChannel("http://x", "key", "user-1", "vault-9", "dev-1");
+		await ch.connect();
+
+		FakeWS.last?.onmessage?.({
+			data: joinError("sync:user-1:vault-9", "plugin_upgrade_required", "1.29.0"),
+		});
+
+		expect(__noticeCapture.notices).toHaveLength(1);
+		expect(__noticeCapture.notices[0].message).toContain("1.29.0");
+	});
+
+	test("an unrelated join reason does not trip it", async () => {
+		const ch = new NoteChannel("http://x", "key", "user-1", "vault-9", "dev-1");
+		await ch.connect();
+
+		FakeWS.last?.onmessage?.({
+			data: joinError("sync:user-1:vault-9", "onboarding_required"),
+		});
+
+		expect(__noticeCapture.notices).toHaveLength(0);
+		expect(isUpgradeRequired()).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

- Send `X-Plugin-Version` on every REST call and `plugin_version` on the socket connect URL, both from `manifest.version` at `onload`. This is what makes the backend's minimum-version floor enforceable, and the socket param is the only place the backend records which versions are actually in use.
- Handle the refusal: one Notice per session — *"this plugin is too old to sync (needs X or newer)"* — with an **Update** button that opens Obsidian's Community plugins tab. Fired from the `426` branch in `api.ts` and from the join-error branch in `channel.ts`.
- Backend side: engram-app/Engram#1588. Independent — that PR allows an absent header, so neither branch needs the other, and the floor ships set to the current version so nothing is refused today.

### Notes for review

- **The join-reason check runs for every topic, not just `crdt:`.** The floor refuses `sync:` and `crdt:` alike; a crdt-only check would miss a `sync:` refusal, which is exactly the case that leaves the user with a silent permanent failure.
- **The button says "Update", not "Upgrade".** The 402 toast next door says "Upgrade" and means "pay more money". A user who reads a version block as a sales prompt dismisses it and stays broken.
- **The server's `update_url` is deliberately ignored.** `sanitizeUpgradeUrl` already refuses non-http(s) URLs from a 402 body so a malicious self-host backend cannot launch arbitrary protocol handlers — and the right target here is `obsidian://`. Rather than carve an exception into that rule, the action is injected locally by `main.ts` via `setUpgradeAction`, reusing the soft nudge's existing feature-detected path.
- **Sync is not stopped locally.** The server already refuses everything; a local kill switch would duplicate that at the cost of another piece of state to get wrong.
- `plugin-version.ts` is a module singleton rather than a constructor argument: the version is fixed for the process and needed in two unrelated transports, so threading it would mean a sixth positional argument on `NoteChannel`'s constructor *and* on `updateConfig`.
- `errorBody()` extracted from `parseLimitExceededError`, now shared by the 402 and 426 paths.

## Test plan

- [x] `tests/plugin-version.test.ts` — header is stamped, **omitted** (not empty) when unset, and read per request
- [x] `tests/channel-plugin-version.test.ts` — `plugin_version` lands on the socket URL, omitted when unset
- [x] `tests/upgrade-required.test.ts` — notice fires from both seams, latches to once per session, survives a malformed body, and does **not** fire on other statuses or other join reasons
- [x] `bun test` — 3123 pass, 1 skip, 0 fail
- [x] `bun run build` (tsc + esbuild) and `biome check src/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZU8U3d3gxBK8wi2qR6jfc