### PR TITLE
chore(deps): force patched colord and js-yaml transitives

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,8 +42,9 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.9",
+    "colord": "^2.9.4",
     "fast-uri": "^3.1.7",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "minimatch": "^10.0.1",
     "picomatch": "^2.3.2",
     "postcss": "^8.5.23",
@@ -294,7 +295,7 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
-    "colord": ["colord@2.9.3", "", {}, "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw=="],
+    "colord": ["colord@2.10.0", "", {}, "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw=="],
 
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
@@ -568,7 +569,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+    "js-yaml": ["js-yaml@4.3.2", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 

--- a/package.json
+++ b/package.json
@@ -64,8 +64,9 @@
     "brace-expansion": "^5.0.9",
     "minimatch": "^10.0.1",
     "picomatch": "^2.3.2",
-    "js-yaml": "^4.3.1",
+    "js-yaml": "^4.3.2",
     "fast-uri": "^3.1.7",
-    "postcss": "^8.5.23"
+    "postcss": "^8.5.23",
+    "colord": "^2.9.4"
   }
 }


### PR DESCRIPTION
`bun audit` was red on `main`, not just on feature branches. Two transitive deps under `stylelint`:

- `colord <2.9.4` (moderate)
- `js-yaml >=4.0.0 <4.3.2` (high)

The existing `js-yaml` override pinned `^4.3.1`, itself inside the vulnerable range.

Forced via `overrides` rather than direct dependencies: neither is imported by our source, and adding them to `dependencies` would ship them in the plugin's own tree.

`bun audit` now reports **No vulnerabilities found**. `stylelint`, `tsc` and the production build all still pass.

Unblocks the audit gate on #512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZU8U3d3gxBK8wi2qR6jfc